### PR TITLE
Refactored MessagesQueue to use LinkedBlockingQueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Change Log
 
+## Version 2.5.0
+
+* [CHANGED] added back pressure to message queue on publish, this may effect behavior of multi-threaded publishers so moving minor version
+
 ## Version 2.4.5 & 2.4.6
 
 * Clean up for rename to nats.java

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ A [Java](http://java.com) client for the [NATS messaging system](https://nats.io
 
 ## A Note on Versions
 
-The NATS server renamed itself from gnatsd to nats-server around 2.4.6. This and other files try to use the new names, but some underlying code may change over several versions. If you are building yourself, please keep an eye out for issues and report them.
-
-This is version 2.1 of the java-nats library. This version is a ground up rewrite of the original library. Part of the goal of this re-write was to address the excessive use of threads, we created a Dispatcher construct to allow applications to control thread creation more intentionally. This version also removes all non-JDK runtime dependencies.
+This is version 2.x of the java-nats library. This version is a ground up rewrite of the original library. Part of the goal of this re-write was to address the excessive use of threads, we created a Dispatcher construct to allow applications to control thread creation more intentionally. This version also removes all non-JDK runtime dependencies.
 
 The API is [simple to use](#listening-for-incoming-messages) and highly [performant](#Benchmarking).
 
 Version 2+ uses a simplified versioning scheme. Any issues will be fixed in the incremental version number. As a major release, the major version has been updated to 2 to allow clients to limit there use of this new API. With the addition of drain() we updated to 2.1, NKey support moved us to 2.2.
+
+The NATS server renamed itself from gnatsd to nats-server around 2.4.4. This and other files try to use the new names, but some underlying code may change over several versions. If you are building yourself, please keep an eye out for issues and report them.
+
+Version 2.5.0 adds some back pressure to publish calls to alleviate issues when there is a slow network. This may alter performance characteristics of publishing apps, although the total performance is equivalent.
 
 Previous versions are still available in the repo.
 
@@ -38,9 +40,9 @@ The java-nats client is provided in a single jar file, with a single external de
 
 ### Downloading the Jar
 
-You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.6/jnats-2.4.6.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.6/jnats-2.4.6.jar).
+You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0.jar).
 
-The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.6/jnats-2.4.6-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.4.6/jnats-2.4.6-examples.jar).
+The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0-examples.jar).
 
 To use NKeys, you will need the ed25519 library, which can be downloaded at [https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar](https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar).
 
@@ -50,7 +52,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:jnats:2.4.6'
+    implementation 'io.nats:jnats:2.5.0'
 }
 ```
 
@@ -76,7 +78,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>jnats</artifactId>
-    <version>2.4.6</version>
+    <version>2.5.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,10 +13,10 @@ plugins {
 // Update version here, repeated check-ins not into master will have snapshot on them
 // Be sure to update Nats.java with the latest version, the change log and the package-info.java
 def versionMajor = 2
-def versionMinor = 4
-def versionPatch = 6
+def versionMinor = 5
+def versionPatch = 0
 def versionModifier = ""
-def jarVersion = "2.4.6"
+def jarVersion = "2.5.0"
 def branch = System.getenv("TRAVIS_BRANCH");
 
 def getVersionName = { ->

--- a/src/examples/java/io/nats/examples/RawTCPLatencyTest.java
+++ b/src/examples/java/io/nats/examples/RawTCPLatencyTest.java
@@ -44,22 +44,23 @@ public class RawTCPLatencyTest {
     }
 
     private static void runServer() throws IOException {
-        ServerSocket serverSocket = new ServerSocket(port);
-        while (true) {
-            Socket socket = serverSocket.accept();
-            System.out.println("Connected");
-            socket.setTcpNoDelay(true);
-            socket.setReceiveBufferSize(2 * 1024 * 1024);
-            socket.setSendBufferSize(2 * 1024 * 1024);
-            in = socket.getInputStream();
-            out = socket.getOutputStream();
-            try {
-                while (true) {
-                    int rq = in.read();
-                    out.write(rq);
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            while (true) {
+                Socket socket = serverSocket.accept();
+                System.out.println("Connected");
+                socket.setTcpNoDelay(true);
+                socket.setReceiveBufferSize(2 * 1024 * 1024);
+                socket.setSendBufferSize(2 * 1024 * 1024);
+                in = socket.getInputStream();
+                out = socket.getOutputStream();
+                try {
+                    while (true) {
+                        int rq = in.read();
+                        out.write(rq);
+                    }
+                } catch (IOException e) {
+                    System.out.println("Disconnected");
                 }
-            } catch (IOException e) {
-                System.out.println("Disconnected");
             }
         }
     }

--- a/src/examples/java/io/nats/examples/autobench/ThrottledBenchmark.java
+++ b/src/examples/java/io/nats/examples/autobench/ThrottledBenchmark.java
@@ -70,7 +70,7 @@ public abstract class ThrottledBenchmark extends AutoBenchmark {
 
     /**
      * Throttled benchmarks use an optional target send rate. This is to make sure the subscribers are not overrun,
-     * become slow consumers. The addition of this code was motivated by the assymetry in the java library between
+     * become slow consumers. The addition of this code was motivated by the asymetry in the java library between
      * publishers and subscribers, especially if UTF-8 subjects are enabled.
      * @param nc the connection
      * @throws InterruptedException

--- a/src/examples/java/io/nats/examples/autobench/ThrottledBenchmark.java
+++ b/src/examples/java/io/nats/examples/autobench/ThrottledBenchmark.java
@@ -68,6 +68,13 @@ public abstract class ThrottledBenchmark extends AutoBenchmark {
 
     }
 
+    /**
+     * Throttled benchmarks use an optional target send rate. This is to make sure the subscribers are not overrun,
+     * become slow consumers. The addition of this code was motivated by the assymetry in the java library between
+     * publishers and subscribers, especially if UTF-8 subjects are enabled.
+     * @param nc the connection
+     * @throws InterruptedException
+     */
 	void adjustAndSleep(Connection nc) throws InterruptedException {
 
         long count = sent.incrementAndGet();

--- a/src/examples/java/io/nats/examples/benchmark/NatsBench.java
+++ b/src/examples/java/io/nats/examples/benchmark/NatsBench.java
@@ -211,7 +211,7 @@ public class NatsBench {
 
         private AtomicLong start;
 
-        PubWorker(Future<Boolean> starter, Phaser finisher, int numMsgs, int size, boolean secure, long targetPubRate) {
+        PubWorker(Future<Boolean> starter, Phaser finisher, int numMsgs, int size, boolean secure) {
             super(starter, finisher, numMsgs, size, secure);
             this.start = new AtomicLong();
         }
@@ -323,9 +323,9 @@ public class NatsBench {
                 }
                 
                 if (subCount == 0) {
-                    new Thread(new PubWorker(starter, finisher, perPubMsgs, this.size, secure, 0), "Pub-"+i).start();
+                    new Thread(new PubWorker(starter, finisher, perPubMsgs, this.size, secure), "Pub-"+i).start();
                 } else {
-                    new Thread(new PubWorker(starter, finisher, perPubMsgs, this.size, secure, 2_000_000), "Pub-"+i).start();
+                    new Thread(new PubWorker(starter, finisher, perPubMsgs, this.size, secure), "Pub-"+i).start();
                 }
                 
                 remaining -= perPubMsgs;

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -72,7 +72,7 @@ public class Nats {
     /**
      * Current version of the library - {@value #CLIENT_VERSION}
      */
-    public static final String CLIENT_VERSION = "2.4.6";
+    public static final String CLIENT_VERSION = "2.5.0";
 
     /**
      * Current language of the library - {@value #CLIENT_LANGUAGE}

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -177,6 +177,29 @@ public class Options {
      */
     public static final String DEFAULT_INBOX_PREFIX = "_INBOX.";
 
+    /**
+     * This value is used internally to limit the number of messages sent in a single network I/O.
+     * The value returned by {@link #getBufferSize() getBufferSize()} is used first, but if the buffer
+     * size is large and the message sizes are small, this limit comes into play.
+     * 
+     * The choice of 1000 is arbitrary and based on testing across several operating systems. Use buffer
+     * size for tuning.
+     */
+    public static final int MAX_MESSAGES_IN_NETWORK_BUFFER = 1000;
+
+    /**
+     * This value is used internally to limit the number of messages allowed in the outgoing queue. When
+     * this limit is reached, publish requests will be blocked until the queue can clear.
+     * 
+     * Because this value is in messages, the memory size associated with this value depends on the actual
+     * size of messages. If 0 byte messages are used, then MAX_MESSAGES_IN_OUTGOING_QUEUE will take up the minimal
+     * space. If 1024 byte messages are used then approximately 5Mb is used for the queue (plus overhead for subjects, etc..)
+     * 
+     * We are using messages, not bytes, to allow a simplification in the underlying library, and use LinkedBlockingQueue as
+     * the core element in the queue.
+     */
+    public static final int MAX_MESSAGES_IN_OUTGOING_QUEUE = 5000;
+
     static final String PFX = "io.nats.client.";
 
     /**

--- a/src/main/java/io/nats/client/impl/MessageQueue.java
+++ b/src/main/java/io/nats/client/impl/MessageQueue.java
@@ -35,14 +35,16 @@ class MessageQueue {
     private final LinkedBlockingQueue<NatsMessage> queue;
     private final Lock filterLock;
 
-    // Poison pill is a graphic, but common term for an item that breaks loops or forces some other action
+    // Poison pill is a graphic, but common term for an item that breaks loops or stop something.
     // In this class the poisonPill is used to break out of timed waits on the blocking queue.
+    // A simple == is used to check if any message in the queue is this message.
     private final NatsMessage poisonPill;
 
     /**
-     * If publishHighwaterMark is set to 0 the underlying queue can grow forever. This is used by readers
-     * to prevent the read thread from blocking. If set to a number, the publish command will block, which provides
-     * backpressure on a publisher if the writer is slow to push things onto the network.
+     * If publishHighwaterMark is set to 0 the underlying queue can grow forever (or until the max size of a linked blocking queue that is).
+     * A value of 0 is used by readers to prevent the read thread from blocking.
+     * If set to a number of messages, the publish command will block, which provides
+     * backpressure on a publisher if the writer is slow to push things onto the network. Publishers use the value of Options.MAX_MESSAGES_IN_OUTGOING_QUEUE.
      * @param singleReaderMode allows the use of "accumulate"
      * @param publishHighwaterMark sets a limit on the size of the underlying queue
      */

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -53,9 +53,16 @@ class NatsConnectionWriter implements Runnable {
         int bufSize = connection.getOptions().getBufferSize();
         this.sendBuffer = new byte[bufSize];
 
-        // Limit the messages that we can push on the queue to 5x the number we would send in a single batch
+        // The value of 1000 is arbitrary, based on performance testing, a send buffer is also configured above and
+        // that size is used first, only if many small messages are being sent on a big buffer will this value
+        // come into play.
         this.maxAccumulate = 1000;
+        
+        // We limit the messages that we can push before blocking to 5x the number we would send in a single batch
+        // Again this is arbitrary, based on testing
         outgoing = new MessageQueue(true, (int) (5 * maxAccumulate));
+
+        // The reconnect buffer contains internal messages, and we will keep it unlimited in size
         reconnectOutgoing = new MessageQueue(true, 0);
     }
 

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -39,6 +39,7 @@ class NatsConnectionWriter implements Runnable {
 
     private MessageQueue outgoing;
     private MessageQueue reconnectOutgoing;
+    private final long maxAccumulate;
 
     NatsConnectionWriter(NatsConnection connection) {
         this.connection = connection;
@@ -49,10 +50,13 @@ class NatsConnectionWriter implements Runnable {
         this.stopped = new CompletableFuture<>();
         ((CompletableFuture<Boolean>)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
 
-        this.sendBuffer = new byte[connection.getOptions().getBufferSize()];
+        int bufSize = connection.getOptions().getBufferSize();
+        this.sendBuffer = new byte[bufSize];
 
-        outgoing = new MessageQueue(true);
-        reconnectOutgoing = new MessageQueue(true);
+        // Limit the messages that we can push on the queue to 5x the number we would send in a single batch
+        this.maxAccumulate = 1000;
+        outgoing = new MessageQueue(true, (int) (5 * maxAccumulate));
+        reconnectOutgoing = new MessageQueue(true, 0);
     }
 
     // Should only be called if the current thread has exited.
@@ -97,7 +101,6 @@ class NatsConnectionWriter implements Runnable {
     public void run() {
         Duration waitForMessage = Duration.ofMinutes(2); // This can be long since no one is sending
         Duration reconnectWait = Duration.ofMillis(1); // This should be short, since we are trying to get the reconnect through
-        long maxMessages = 1000;
 
         try {
             DataPort dataPort = this.dataPortFuture.get(); // Will wait for the future to complete
@@ -108,9 +111,9 @@ class NatsConnectionWriter implements Runnable {
                 NatsMessage msg = null;
                 
                 if (this.reconnectMode.get()) {
-                    msg = this.reconnectOutgoing.accumulate(this.sendBuffer.length, maxMessages, reconnectWait);
+                    msg = this.reconnectOutgoing.accumulate(this.sendBuffer.length, this.maxAccumulate, reconnectWait);
                 } else {
-                    msg = this.outgoing.accumulate(this.sendBuffer.length, maxMessages, waitForMessage);
+                    msg = this.outgoing.accumulate(this.sendBuffer.length, this.maxAccumulate, waitForMessage);
                 }
 
                 if (msg == null) { // Make sure we are still running

--- a/src/test/java/io/nats/client/SubscriberTests.java
+++ b/src/test/java/io/nats/client/SubscriberTests.java
@@ -109,6 +109,7 @@ public class SubscriberTests {
             Message msg = sub.nextMessage(Duration.ZERO);//Duration.ofMillis(1000));
 
             assertTrue(sub.isActive());
+            assertNotNull(msg);
             assertEquals("subject", msg.getSubject());
             assertEquals(sub, msg.getSubscription());
             assertNull(msg.getReplyTo());

--- a/src/test/java/io/nats/client/impl/DrainTests.java
+++ b/src/test/java/io/nats/client/impl/DrainTests.java
@@ -625,7 +625,7 @@ public class DrainTests {
                 assertNotNull(msg);
             }
 
-            assertTrue(tracker.get(1, TimeUnit.SECONDS));
+            assertTrue(tracker.get(5, TimeUnit.SECONDS));
             assertFalse(sub.isActive());
             assertEquals(((NatsConnection) subCon).getConsumerCount(), 0);
         }


### PR DESCRIPTION
message queue was using a lot of custom code to handle all the performance and locking requirements. Now it uses a LinkedBlockingQueue which is much simpler. The new implementation uses a poison pill to shutdown.

By switching to a blocking queue we get back pressure on publishers. This changes the performance characteristics from Autobench but mostly to smooth them out over all message sizes. Latency and request/reply performance are nominal.

Added error handler to NatsBench.
Fixed a minor warning in raw tcp test

Prepare for 2.5.0, updated all versions