### PR TITLE
V2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Change Log
 
+## Version 2.5.1
+
+* [FIXED] - #239 - cleaned up extra code after SSL connect failure
+* [FIXED] - #240 - removed stack trace that was left from debugging
+* [FIXED] - #241 - changed method used to create an ssl socket to allow support for conscrypt/wildfly native libraries
+* [ADDED] - conscrypt flag to natsautobench to allow testing with native library, requires Jar in class path
+
 ## Version 2.5.0
 
 * [CHANGED] added back pressure to message queue on publish, this may effect behavior of multi-threaded publishers so moving minor version

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Previous versions are still available in the repo.
 
 ### SSL/TLS Performance
 
-Initial testing was focused on TLS support, not performance. After some performance tests we discovered that TLS performance is poor. After researching the problem and possible solutions we came to a few conclusions:
+After recent tests we realized that TLS performance is lower than we would like. After researching the problem and possible solutions we came to a few conclusions:
 
+* TLS performance for the native JDK has not be historically great
 * TLS performance is better in JDK12 than JDK8
 * A small fix to the library in 2.5.1 allows the use of https://github.com/google/conscrypt and https://github.com/wildfly/wildfly-openssl, conscrypt provides the best performance in our tests
 * TLS still comes at a price (1gb/s vs 4gb/s in some tests), but using the JNI libraries can result in a 10x boost in our testing

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Previous versions are still available in the repo.
 Initial testing was focused on TLS support, not performance. After some performance tests we discovered that TLS performance is poor. After researching the problem and possible solutions we came to a few conclusions:
 
 * TLS performance is better in JDK12 than JDK8
-* A small fix to the library allows the use of https://github.com/google/conscrypt and https://github.com/wildfly/wildfly-openssl, conscrypt provides the best performance in our tests
+* A small fix to the library in 2.5.1 allows the use of https://github.com/google/conscrypt and https://github.com/wildfly/wildfly-openssl, conscrypt provides the best performance in our tests
 * TLS still comes at a price (1gb/s vs 4gb/s in some tests), but using the JNI libraries can result in a 10x boost in our testing
 * If TLS performance is reasonable for your application we recommend using the j2se implementation for simplicity
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Version 2.5.0 adds some back pressure to publish calls to alleviate issues when 
 
 Previous versions are still available in the repo.
 
+### SSL/TLS Performance
+
+Initial testing was focused on TLS support, not performance. After some performance tests we discovered that TLS performance is poor. After researching the problem and possible solutions we came to a few conclusions:
+
+* TLS performance is better in JDK12 than JDK8
+* A small fix to the library allows the use of https://github.com/google/conscrypt and https://github.com/wildfly/wildfly-openssl, conscrypt provides the best performance in our tests
+* TLS still comes at a price (1gb/s vs 4gb/s in some tests), but using the JNI libraries can result in a 10x boost in our testing
+* If TLS performance is reasonable for your application we recommend using the j2se implementation for simplicity
+
+To use conscrypt or wildfly, you will need to add the appropriate jars to your class path and create an SSL context manually. This context can be passed to the Options used when creating a connection. The NATSAutoBench example provides a conscrypt flag which can be used to try out the library,  manually including the jar is required.
+
 ### UTF-8 Subjects
 
 The client protocol spec doesn't explicitly state the encoding on subjects. Some clients use ASCII and some use UTF-8 which matches ASCII for a-Z and 0-9. Until 2.1.2 the 2.0+ version of the Java client used ASCII for performance reasons. As of 2.1.2 you can choose to support UTF-8 subjects via the Options. Keep in mind that there is a small performance penalty for UTF-8 encoding and decoding in benchmarks, but depending on your application this cost may be negligible. Also, keep in mind that not all clients support UTF-8 and test accordingly.
@@ -40,9 +51,9 @@ The java-nats client is provided in a single jar file, with a single external de
 
 ### Downloading the Jar
 
-You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0.jar).
+You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1.jar).
 
-The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.0/jnats-2.5.0-examples.jar).
+The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1-examples.jar).
 
 To use NKeys, you will need the ed25519 library, which can be downloaded at [https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar](https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar).
 
@@ -52,7 +63,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:jnats:2.5.0'
+    implementation 'io.nats:jnats:2.5.1'
 }
 ```
 
@@ -78,7 +89,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>jnats</artifactId>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ plugins {
 // Be sure to update Nats.java with the latest version, the change log and the package-info.java
 def versionMajor = 2
 def versionMinor = 5
-def versionPatch = 0
+def versionPatch = 1
 def versionModifier = ""
-def jarVersion = "2.5.0"
+def jarVersion = "2.5.1"
 def branch = System.getenv("TRAVIS_BRANCH");
 
 def getVersionName = { ->

--- a/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
+++ b/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
@@ -13,9 +13,13 @@
 
 package io.nats.examples.autobench;
 
+import java.security.Provider;
+import java.security.Security;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.net.ssl.SSLContext;
 
 import io.nats.client.Options;
 
@@ -36,6 +40,7 @@ public class NatsAutoBench {
     public static void main(String args[]) {
         String server = Options.DEFAULT_URL;
         boolean utf8 = false;
+        boolean conscrypt = false;
         int baseMsgs = 100_000;
         int latencyMsgs = 5_000;
         long maxSize = 8*1024;
@@ -44,10 +49,12 @@ public class NatsAutoBench {
             for (String s : args) {
                 if (s.equals("utf8")) {
                     utf8 = true;
-                }else if (s.equals("med")) {
+                } else if (s.equals("conscrypt")) {
+                    conscrypt = true;
+                } else if (s.equals("med")) {
                     baseMsgs = 50_000;
                     latencyMsgs = 2_500;
-                }  else if (s.equals("small")) {
+                } else if (s.equals("small")) {
                     baseMsgs = 5_000;
                     latencyMsgs = 250;
                     maxSize = 1024;
@@ -79,6 +86,15 @@ public class NatsAutoBench {
             if (utf8) {
                 System.out.printf("Enabling UTF-8 subjects\n");
                 builder.supportUTF8Subjects();
+            }
+            
+            if (conscrypt) {
+                Provider provider = (Provider) Class.forName("org.conscrypt.OpenSSLProvider").newInstance();
+                Security.insertProviderAt(provider, 1);
+            }
+
+            if (server.startsWith("tls")) {
+                System.out.println("Security Provider - "+ SSLContext.getDefault().getProvider().getInfo());
             }
                     
             Options connectOptions = builder.build();                   

--- a/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
+++ b/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
@@ -88,6 +88,15 @@ public class NatsAutoBench {
                 builder.supportUTF8Subjects();
             }
             
+            /**
+             * The conscrypt flag is provided for testing with the conscrypt jar. Using it through reflection is
+             * deprecated but allows the library to ship without a dependency. Using conscrypt should only require the
+             * jar plus the flag. For example, to run after building locally and using the test cert files:
+             * java -cp ./build/libs/jnats-2.5.1-SNAPSHOT-examples.jar:./build/libs/jnats-2.5.1-SNAPSHOT-fat.jar:<path to conscrypt.jar> \
+             * -Djavax.net.ssl.keyStore=src/test/resources/keystore.jks -Djavax.net.ssl.keyStorePassword=password \
+             * -Djavax.net.ssl.trustStore=src/test/resources/cacerts -Djavax.net.ssl.trustStorePassword=password \
+             * io.nats.examples.autobench.NatsAutoBench tls://localhost:4443 med conscrypt
+             */
             if (conscrypt) {
                 Provider provider = (Provider) Class.forName("org.conscrypt.OpenSSLProvider").newInstance();
                 Security.insertProviderAt(provider, 1);

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -72,7 +72,7 @@ public class Nats {
     /**
      * Current version of the library - {@value #CLIENT_VERSION}
      */
-    public static final String CLIENT_VERSION = "2.5.0";
+    public static final String CLIENT_VERSION = "2.5.1";
 
     /**
      * Current language of the library - {@value #CLIENT_LANGUAGE}

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1010,7 +1010,6 @@ class NatsConnection implements Connection {
             
             queueInternalOutgoing(msg);
         } catch (Exception exp) {
-            exp.printStackTrace();
             throw new IOException("Error sending connect string", exp);
         }
     }

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -90,6 +90,7 @@ public class SocketDataPort implements DataPort {
             waitForHandshake.get(timeout.toNanos(), TimeUnit.NANOSECONDS);
         } catch (Exception ex) {
             this.connection.handleCommunicationIssue(ex);
+            return;
         }
 
         in = sslSocket.getInputStream();

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -75,7 +75,7 @@ public class SocketDataPort implements DataPort {
         SSLSocketFactory factory = context.getSocketFactory();
         Duration timeout = options.getConnectionTimeout();
 
-        this.sslSocket = (SSLSocket) factory.createSocket(socket, null, true);
+        this.sslSocket = (SSLSocket) factory.createSocket(socket, this.host, this.port, true);
         this.sslSocket.setUseClientMode(true);
 
         final CompletableFuture<Void> waitForHandshake = new CompletableFuture<>();


### PR DESCRIPTION
* [FIXED] - #239 - cleaned up extra code after SSL connect failure
* [FIXED] - #240 - removed stack trace that was left from debugging
* [FIXED] - #241 - changed method used to create an ssl socket to allow support for conscrypt/wildfly native libraries
* [ADDED] - conscrypt flag to natsautobench to allow testing with native library, requires Jar in class path