### PR TITLE
2.5.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Thumbs.db
 ################
 *~
 *.swp
+.sts4-cache/*
 
 # Gradle Files #
 ################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Change Log
 
+## Version 2.5.2
+
+* [FIXED] - #244 - fixed an issue with parsing ipv6 addresses in the info JSON
+
 ## Version 2.5.1
 
 * [FIXED] - #239 - cleaned up extra code after SSL connect failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 
 ## Version 2.5.2
 
-* [FIXED] - #244 - fixed an issue with parsing ipv6 addresses in the info JSON
+* [FIXED] - #244 - fixed an issue with parsing ipv6 addresses in the info JSON, added unit test for parser
+* [FIXED] - #245 - fixed a timing bug in nats bench, now subscribers start timing at the first receive
+* [FIXED/CHANGED] - #246 - fixed a confusing output from nats bench in CSV mode, now the test count and the total count are printed
+* [ADDED] - spring cache to git ignore file
+* [ADDED] - support for running nats bench with conscrypt
 
 ## Version 2.5.1
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ The java-nats client is provided in a single jar file, with a single external de
 
 ### Downloading the Jar
 
-You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1.jar).
+You can download the latest jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.2/jnats-2.5.2.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.2/jnats-2.5.2.jar).
 
-The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.1/jnats-2.5.1-examples.jar).
+The examples are available at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.2/jnats-2.5.2-examples.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.5.2/jnats-2.5.2-examples.jar).
 
 To use NKeys, you will need the ed25519 library, which can be downloaded at [https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar](https://repo1.maven.org/maven2/net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar).
 
@@ -64,7 +64,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:jnats:2.5.1'
+    implementation 'io.nats:jnats:2.5.2'
 }
 ```
 
@@ -90,7 +90,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>jnats</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ plugins {
 // Be sure to update Nats.java with the latest version, the change log and the package-info.java
 def versionMajor = 2
 def versionMinor = 5
-def versionPatch = 1
+def versionPatch = 2
 def versionModifier = ""
-def jarVersion = "2.5.1"
+def jarVersion = "2.5.2"
 def branch = System.getenv("TRAVIS_BRANCH");
 
 def getVersionName = { ->

--- a/src/examples/java/io/nats/examples/benchmark/Benchmark.java
+++ b/src/examples/java/io/nats/examples/benchmark/Benchmark.java
@@ -132,7 +132,7 @@ public class Benchmark extends Sample {
     public final String csv() {
         StringBuilder sb = new StringBuilder();
         String header =
-                "#RunID, ClientID, MsgCount, MsgBytes, MsgsPerSec, BytesPerSec, DurationSecs";
+                "#RunID, ClientID, Test Msgs, MsgsPerSec, BytesPerSec, Total Msgs, Total Bytes, DurationSecs";
 
         sb.append(String.format("%s stats: %s\n", name, this));
         sb.append(header); sb.append("\n");
@@ -145,8 +145,10 @@ public class Benchmark extends Sample {
         StringBuilder sb = new StringBuilder();
         int j = 0;
         for (Sample stat : grp.getSamples()) {
-            String line = String.format("%s,%s%d,%d,%d,%d,%f,%f", runId, prefix, j++, stat.msgCnt,
-                    stat.msgBytes, stat.rate(), stat.throughput(),
+            String line = String.format("%s,%s%d,%d,%d,%.2f,%d,%d,%.4f", runId,
+                    prefix, j++,
+                    stat.getJobMsgCnt(), stat.rate(), stat.throughput(),
+                    stat.msgCnt, stat.msgBytes, 
                     (double) stat.duration() / 1000000000.0);
                     sb.append(line); sb.append("\n");
         }

--- a/src/examples/java/io/nats/examples/benchmark/NatsBench.java
+++ b/src/examples/java/io/nats/examples/benchmark/NatsBench.java
@@ -21,6 +21,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,11 +38,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import javax.net.ssl.SSLContext;
+
 /**
- * A utility class for measuring NATS performance, similar to the version in go and node.
- * The various tradeoffs to make this code act/work like the other versions, including the
- * previous java version, make it a bit &quot;crufty&quot; for an example. See autobench for
- * an example with minimal boilerplate.
+ * A utility class for measuring NATS performance, similar to the version in go
+ * and node. The various tradeoffs to make this code act/work like the other
+ * versions, including the previous java version, make it a bit
+ * &quot;crufty&quot; for an example. See autobench for an example with minimal
+ * boilerplate.
  */
 public class NatsBench {
     final BlockingQueue<Throwable> errorQueue = new LinkedBlockingQueue<Throwable>();
@@ -57,6 +62,7 @@ public class NatsBench {
     private final AtomicLong received = new AtomicLong();
     private boolean csv = false;
     private boolean stats = false;
+    private boolean conscrypt = false;
 
     private Thread shutdownHook;
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
@@ -64,16 +70,16 @@ public class NatsBench {
     private boolean secure = false;
     private Benchmark bench;
 
-    static final String usageString =
-            "\nUsage: java NatsBench [-s server] [-tls] [-np num] [-ns num] [-n num] [-ms size] "
-                    + "[-csv file] <subject>\n\nOptions:\n"
-                    + "    -s   <urls>                    The nats server URLs (comma-separated), use tls:// or opentls:// to require tls\n"
-                    + "    -np                             Number of concurrent publishers (1)\n"
-                    + "    -ns                             Number of concurrent subscribers (0)\n"
-                    + "    -n                              Number of messages to publish (100,000)\n"
-                    + "    -ms                             Size of the message (128)\n"
-                    + "    -csv                            Print results to stdout as csv (false)\n"
-                    + "    -stats                          Track and print out internal statistics (false)\n";
+    static final String usageString = "\nUsage: java NatsBench [-s server] [-tls] [-np num] [-ns num] [-n num] [-ms size] "
+            + "[-csv file] <subject>\n\nOptions:\n"
+            + "    -s  <urls>                     The nats server URLs (comma-separated), use tls:// or opentls:// to require tls\n"
+            + "    -np <int>                       Number of concurrent publishers (1)\n"
+            + "    -ns <int>                       Number of concurrent subscribers (0)\n"
+            + "    -n  <int>                       Number of messages to publish (100,000)\n"
+            + "    -ms <int>                       Size of the message (128)\n"
+            + "    -csv                            Print results to stdout as csv (false)\n"
+            + "    -tls                            Set the secure flag on the SSL context to true (false)\n"
+            + "    -stats                          Track and print out internal statistics (false)\n";
 
     public NatsBench(String[] args) throws Exception {
         if (args == null || args.length < 1) {
@@ -85,18 +91,12 @@ public class NatsBench {
 
     public NatsBench(Properties properties) throws NoSuchAlgorithmException {
         urls = properties.getProperty("bench.nats.servers", urls);
-        secure = Boolean.parseBoolean(
-                properties.getProperty("bench.nats.secure", Boolean.toString(secure)));
-        numMsgs = Integer.parseInt(
-                properties.getProperty("bench.nats.msg.count", Integer.toString(numMsgs)));
-        size = Integer
-                .parseInt(properties.getProperty("bench.nats.msg.size", Integer.toString(numSubs)));
-        numPubs = Integer
-                .parseInt(properties.getProperty("bench.nats.pubs", Integer.toString(numPubs)));
-        numSubs = Integer
-                .parseInt(properties.getProperty("bench.nats.subs", Integer.toString(numSubs)));
-        csv = Boolean.parseBoolean(
-            properties.getProperty("bench.nats.csv", Boolean.toString(csv)));
+        secure = Boolean.parseBoolean(properties.getProperty("bench.nats.secure", Boolean.toString(secure)));
+        numMsgs = Integer.parseInt(properties.getProperty("bench.nats.msg.count", Integer.toString(numMsgs)));
+        size = Integer.parseInt(properties.getProperty("bench.nats.msg.size", Integer.toString(numSubs)));
+        numPubs = Integer.parseInt(properties.getProperty("bench.nats.pubs", Integer.toString(numPubs)));
+        numSubs = Integer.parseInt(properties.getProperty("bench.nats.subs", Integer.toString(numSubs)));
+        csv = Boolean.parseBoolean(properties.getProperty("bench.nats.csv", Boolean.toString(csv)));
         subject = properties.getProperty("bench.nats.subject", NUID.nextGlobal());
     }
 
@@ -106,7 +106,7 @@ public class NatsBench {
         builder.noReconnect();
         builder.connectionName("NatsBench");
         builder.servers(servers);
-        builder.errorListener(new ErrorListener(){
+        builder.errorListener(new ErrorListener() {
             @Override
             public void errorOccurred(Connection conn, String error) {
                 System.out.printf("An error occurred %s\n", error);
@@ -126,6 +126,30 @@ public class NatsBench {
 
         if (stats) {
             builder.turnOnAdvancedStats();
+        }
+
+        /**
+         * The conscrypt flag is provided for testing with the conscrypt jar. Using it
+         * through reflection is deprecated but allows the library to ship without a
+         * dependency. Using conscrypt should only require the jar plus the flag. For
+         * example, to run after building locally and using the test cert files: java
+         * -cp
+         * ./build/libs/jnats-2.5.1-SNAPSHOT-examples.jar:./build/libs/jnats-2.5.1-SNAPSHOT-fat.jar:<path
+         * to conscrypt.jar> \ -Djavax.net.ssl.keyStore=src/test/resources/keystore.jks
+         * -Djavax.net.ssl.keyStorePassword=password \
+         * -Djavax.net.ssl.trustStore=src/test/resources/cacerts
+         * -Djavax.net.ssl.trustStorePassword=password \
+         * io.nats.examples.autobench.NatsAutoBench tls://localhost:4443 med conscrypt
+         */
+        if (conscrypt) {
+            try {
+                Provider provider = null;
+                provider = (Provider) Class.forName("org.conscrypt.OpenSSLProvider").newInstance();
+                Security.insertProviderAt(provider, 1);
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.exit(-1);
+            }
         }
 
         if (secure) {
@@ -394,7 +418,6 @@ public class NatsBench {
             String arg = it.next();
             switch (arg) {
                 case "-s":
-                case "--server":
                     if (!it.hasNext()) {
                         usage();
                     }
@@ -403,9 +426,6 @@ public class NatsBench {
                     it.remove();
                     continue;
                 case "-tls":
-                    if (!it.hasNext()) {
-                        usage();
-                    }
                     it.remove();
                     secure = true;
                     continue;
@@ -443,18 +463,16 @@ public class NatsBench {
                     it.remove();
                     continue;
                 case "-csv":
-                    if (it.hasNext()) {
-                        usage();
-                    }
                     it.remove();
                     csv = true;
                     continue;
                 case "-stats":
-                    if (it.hasNext()) {
-                        usage();
-                    }
                     it.remove();
                     stats = true;
+                    continue;
+                case "-conscrypt":
+                    it.remove();
+                    conscrypt = true;
                     continue;
                 default:
                     System.err.printf("Unexpected token: '%s'\n", arg);

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -72,7 +72,7 @@ public class Nats {
     /**
      * Current version of the library - {@value #CLIENT_VERSION}
      */
-    public static final String CLIENT_VERSION = "2.5.1";
+    public static final String CLIENT_VERSION = "2.5.2";
 
     /**
      * Current language of the library - {@value #CLIENT_LANGUAGE}

--- a/src/main/java/io/nats/client/impl/NatsServerInfo.java
+++ b/src/main/java/io/nats/client/impl/NatsServerInfo.java
@@ -102,7 +102,7 @@ class NatsServerInfo {
     private static final String grabString = "\\s*\"(.+?)\"";
     private static final String grabBoolean = "\\s*(true|false)";
     private static final String grabNumber = "\\s*(\\d+)";
-    private static final String grabArray = "\\s*\\[(.+?)\\]";
+    private static final String grabStringArray = "\\s*\\[(\".+?\")\\]";
     private static final String grabObject = "\\{(.+?)\\}";
 
     void parseInfo(String jsonString) {
@@ -116,7 +116,7 @@ class NatsServerInfo {
         Pattern portRE = Pattern.compile("\""+PORT+"\":" + grabNumber, Pattern.CASE_INSENSITIVE);
         Pattern maxRE = Pattern.compile("\""+MAX_PAYLOAD+"\":" + grabNumber, Pattern.CASE_INSENSITIVE);
         Pattern protoRE = Pattern.compile("\""+PROTOCOL_VERSION+"\":" + grabNumber, Pattern.CASE_INSENSITIVE);
-        Pattern connectRE = Pattern.compile("\""+CONNECT_URLS+"\":" + grabArray, Pattern.CASE_INSENSITIVE);
+        Pattern connectRE = Pattern.compile("\""+CONNECT_URLS+"\":" + grabStringArray, Pattern.CASE_INSENSITIVE);
         Pattern infoObject = Pattern.compile(grabObject, Pattern.CASE_INSENSITIVE);
 
         Matcher m = infoObject.matcher(jsonString);

--- a/src/test/java/io/nats/client/impl/NatsServerInfoTests.java
+++ b/src/test/java/io/nats/client/impl/NatsServerInfoTests.java
@@ -73,12 +73,12 @@ public class NatsServerInfoTests {
     public void testIPV6InBrackets() {
         String json = "{" +
                         "\"server_id\":\"myserver\"" + "," +
-                        "\"connect_urls\":[\"one:4222\", \"[a:b:c]:4222\"]" + "," +
+                        "\"connect_urls\":[\"one:4222\", \"[a:b:c]:4222\", \"[d:e:f]:4223\"]" + "," +
                         "\"max_payload\":100000000000" +
                        "}";
         NatsServerInfo info = new NatsServerInfo(json);
         assertEquals(info.getServerId(), "myserver");
-        String[] urls = {"one:4222", "[a:b:c]:4222"};
+        String[] urls = {"one:4222", "[a:b:c]:4222", "[d:e:f]:4223"};
         assertTrue(Arrays.equals(info.getConnectURLs(), urls));
     }
     

--- a/src/test/java/io/nats/client/impl/NatsServerInfoTests.java
+++ b/src/test/java/io/nats/client/impl/NatsServerInfoTests.java
@@ -68,6 +68,19 @@ public class NatsServerInfoTests {
         String[] urls = {"one"};
         assertTrue(Arrays.equals(info.getConnectURLs(), urls));
     }
+
+    @Test
+    public void testIPV6InBrackets() {
+        String json = "{" +
+                        "\"server_id\":\"myserver\"" + "," +
+                        "\"connect_urls\":[\"one:4222\", \"[a:b:c]:4222\"]" + "," +
+                        "\"max_payload\":100000000000" +
+                       "}";
+        NatsServerInfo info = new NatsServerInfo(json);
+        assertEquals(info.getServerId(), "myserver");
+        String[] urls = {"one:4222", "[a:b:c]:4222"};
+        assertTrue(Arrays.equals(info.getConnectURLs(), urls));
+    }
     
     @Test(expected=IllegalArgumentException.class)
     public void testThrowsOnNonJson() {


### PR DESCRIPTION

* [FIXED] - #244 - fixed a critical issue with parsing ipv6 addresses in the info JSON, added unit test for parser
* [FIXED] - #245 - fixed a timing bug in nats bench, now subscribers start timing at the first receive
* [FIXED/CHANGED] - #246 - fixed a confusing output from nats bench in CSV mode, now the test count and the total count are printed
* [ADDED] - spring cache to git ignore file
* [ADDED] - support for running nats bench with conscrypt