### PR TITLE
Add support for subscriptions with their own message handlers for Dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The Java NATS library provides two mechanisms to listen for messages, three if y
     String response = new String(msg.getData(), StandardCharsets.UTF_8);
     ```
 
-2. A Dispatcher that will call application code in a background thread. Dispatchers can manage multiple subjects with a single thread and single callback.
+2. A Dispatcher that will call application code in a background thread. Dispatchers can manage multiple subjects with a single thread and shared callback.
 
     ```java
     Dispatcher d = nc.createDispatcher((msg) -> {
@@ -203,6 +203,18 @@ The Java NATS library provides two mechanisms to listen for messages, three if y
     });
 
     d.subscribe("subject");
+    ```
+
+    A dispatcher can also accept individual callbacks for any given subscription.
+
+    ```java
+    Dispatcher d = nc.createDispatcher((msg) -> {});
+
+    Subscription s = d.subscribe("some.subject", (msg) -> {
+        String response = new String(msg.getData(), StandardCharsets.UTF_8);
+        System.out.println("Message received (up to 100 times): " + response);
+    });
+    d.unsubscribe(s, 100);
     ```
 
 ## Advanced Usage

--- a/src/main/java/io/nats/client/Dispatcher.java
+++ b/src/main/java/io/nats/client/Dispatcher.java
@@ -64,7 +64,41 @@ public interface Dispatcher extends Consumer {
      */
     public Dispatcher subscribe(String subject, String queue);
 
+    /**
+     * Create a subscription to the specified subject under the control of this
+     * dispatcher. Since a MessageHandler is also required, the Dispatcher will
+     * not prevent duplicate subscriptions from being made.
+     *
+     * <p>
+     * Every call creates a new subscription, unlike the
+     * {@link Dispatcher#subscribe(String)} method that does not take a
+     * MessageHandler.
+     *
+     *
+     * @param subject The subject to subscribe to.
+     * @param handler The target for the messages
+     * @return The Subscription, so subscriptions may be later unsubscribed manually.
+     * @throws IllegalStateException if the dispatcher was previously closed
+     */
     public Subscription subscribe(String subject, MessageHandler handler);
+
+    /**
+     * Create a subscription to the specified subject under the control of this
+     * dispatcher. Since a MessageHandler is also required, the Dispatcher will
+     * not prevent duplicate subscriptions from being made.
+     *
+     * <p>
+     * Every call creates a new subscription, unlike the
+     * {@link Dispatcher#subscribe(String, String)} method that does not take a
+     * MessageHandler.
+     *
+     *
+     * @param subject The subject to subscribe to.
+     * @param queue The queue group to join.
+     * @param handler The target for the messages
+     * @return The Subscription, so subscriptions may be later unsubscribed manually.
+     * @throws IllegalStateException if the dispatcher was previously closed
+     */
     public Subscription subscribe(String subject, String queue, MessageHandler handler);
 
     /**
@@ -78,6 +112,18 @@ public interface Dispatcher extends Consumer {
      */
     public Dispatcher unsubscribe(String subject);
 
+    /**
+     * Unsubscribe from the specified Subscription.
+     *
+     * <p>Stops messages to the subscription locally and notifies the server.
+     * This method is to be used to unsubscribe from subscriptions created by
+     * the Dispatcher using {@link Dispatcher#subscribe(String, MessageHandler)}.
+     *
+     * @param subscription The Subscription to unsubscribe from.
+     * @return The Dispatcher, so calls can be chained.
+     * @throws IllegalStateException if the dispatcher was previously closed
+     * @throws IllegalStateException if the Subscription is not managed by this dispatcher
+     */
     public Dispatcher unsubscribe(Subscription subscription);
 
     /**
@@ -103,5 +149,24 @@ public interface Dispatcher extends Consumer {
      */
     public Dispatcher unsubscribe(String subject, int after);
 
+    /**
+     * Unsubscribe from the specified subject, the queue is implicit, after the
+     * specified number of messages.
+     *
+     * <p>If the subscription has already received <code>after</code> messages, it will not receive
+     * more. The provided limit is a lifetime total for the subscription, with the caveat
+     * that if the subscription already received more than <code>after</code> when unsubscribe is called
+     * the client will not travel back in time to stop them.
+     *
+     * <p>Stops messages to the subscription locally and notifies the server.
+     * This method is to be used to unsubscribe from subscriptions created by
+     * the Dispatcher using {@link Dispatcher#subscribe(String, MessageHandler)}.
+     *
+     * @param subscription The Subscription to unsubscribe from.
+     * @param after The number of messages to accept before unsubscribing
+     * @return The Dispatcher, so calls can be chained.
+     * @throws IllegalStateException if the dispatcher was previously closed
+     * @throws IllegalStateException if the Subscription is not managed by this dispatcher
+     */
     public Dispatcher unsubscribe(Subscription subscription, int after);
 }

--- a/src/main/java/io/nats/client/Dispatcher.java
+++ b/src/main/java/io/nats/client/Dispatcher.java
@@ -14,7 +14,7 @@
 package io.nats.client;
 
 /**
- * This library uses the concept of a Dispatcher to organize message callbacks in a way that the 
+ * This library uses the concept of a Dispatcher to organize message callbacks in a way that the
  * application can control. Each dispatcher has a single {@link MessageHandler MessageHandler} that
  * will be notified of incoming messages. The dispatcher also has 0 or more subscriptions associated with it.
  * This means that a group of subscriptions, or subjects, can be combined into a single callback thread. But,
@@ -24,11 +24,11 @@ package io.nats.client;
  * any one message it will delay deliver of subsequent messages. Use separate dispatchers to handle the scenario of
  * a set of messages that require a lot of work and a set of fast moving messages, or create other threads as necessary.
  * The Dispatcher will only use one.
- * 
+ *
  * <p>Dispatchers are created from the connection using {@link Connection#createDispatcher(MessageHandler) createDispatcher()}
  * and can be closed using {@link Connection#closeDispatcher(Dispatcher) closeDispatcher()}. Closing a dispatcher will
  * clean up the thread it is using for message deliver.
- * 
+ *
  * <p><em>See the documentation on {@link Consumer Consumer} for configuring behavior in a slow consumer situation.</em>
  */
 public interface Dispatcher extends Consumer {
@@ -36,12 +36,12 @@ public interface Dispatcher extends Consumer {
     /**
      * Create a subscription to the specified subject under the control of this
      * dispatcher.
-     * 
+     *
      * <p>
      * This call is a no-op if the dispatcher already has a subscription to the
      * specified subject.
-     * 
-     * 
+     *
+     *
      * @param subject The subject to subscribe to.
      * @return The Dispatcher, so calls can be chained.
      * @throws IllegalStateException if the dispatcher was previously closed
@@ -51,12 +51,12 @@ public interface Dispatcher extends Consumer {
     /**
      * Create a subscription to the specified subject and queue under the control of
      * this dispatcher.
-     * 
+     *
      * <p>
      * This call is a no-op if the dispatcher already has a subscription to the
      * specified subject (regardless of the queue name).
-     * 
-     * 
+     *
+     *
      * @param subject The subject to subscribe to.
      * @param queue The queue group to join.
      * @return The Dispatcher, so calls can be chained.
@@ -64,37 +64,44 @@ public interface Dispatcher extends Consumer {
      */
     public Dispatcher subscribe(String subject, String queue);
 
+    public Subscription subscribe(String subject, MessageHandler handler);
+    public Subscription subscribe(String subject, String queue, MessageHandler handler);
+
     /**
      * Unsubscribe from the specified subject, the queue is implicit.
-     * 
+     *
      * <p>Stops messages to the subscription locally and notifies the server.
-     * 
+     *
      * @param subject The subject to unsubscribe from.
      * @return The Dispatcher, so calls can be chained.
      * @throws IllegalStateException if the dispatcher was previously closed
      */
     public Dispatcher unsubscribe(String subject);
 
+    public Dispatcher unsubscribe(Subscription subscription);
+
     /**
      * Unsubscribe from the specified subject, the queue is implicit, after the
      * specified number of messages.
-     * 
+     *
      * <p>If the subscription has already received <code>after</code> messages, it will not receive
      * more. The provided limit is a lifetime total for the subscription, with the caveat
      * that if the subscription already received more than <code>after</code> when unsubscribe is called
      * the client will not travel back in time to stop them.
-     * 
+     *
      * <p>For example, to get a single asynchronous message, you might do:
      * <blockquote><pre>
      * nc = Nats.connect()
      * d = nc.createDispatcher(myHandler);
      * d.subscribe("hello").unsubscribe("hello", 1);
      * </pre></blockquote>
-     * 
+     *
      * @param subject The subject to unsubscribe from.
      * @param after The number of messages to accept before unsubscribing
      * @return The Dispatcher, so calls can be chained.
      * @throws IllegalStateException if the dispatcher was previously closed
      */
     public Dispatcher unsubscribe(String subject, int after);
+
+    public Dispatcher unsubscribe(Subscription subscription, int after);
 }

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -296,6 +296,14 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     }
 
     public Dispatcher unsubscribe(Subscription subscription, int after) {
+        if (!this.running.get()) {
+            throw new IllegalStateException("Dispatcher is closed");
+        }
+
+        if (isDraining()) { // No op while draining
+            return this;
+        }
+
         if (subscription.getDispatcher() != this) {
             throw new IllegalStateException("Subscription is not managed by this Dispatcher");
         }

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -290,10 +290,6 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
             throw new IllegalStateException("Subscription is not managed by this Dispatcher");
         }
 
-        if (this.subscriptionsUsingDefaultHandler.get(subscription.getSubject()) != null) {
-            throw new IllegalStateException("Subscription uses default handler and cannot call unsubscribe");
-        }
-
         // We can probably optimize this path by adding getSID() to the Subscription interface.
         if (!(subscription instanceof NatsSubscription)) {
             throw new IllegalArgumentException("This Subscription implementation is not known by Dispatcher");

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.nats.client.Subscription;
 import io.nats.client.Dispatcher;
 import io.nats.client.MessageHandler;
 
@@ -32,7 +33,16 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
 
     private String id;
 
+    // We will use the subject as the key for subscriptions that use the
+    // default handler.
     private Map<String, NatsSubscription> subscriptions;
+    // We will use the SID as the key. Sicne these subscriptions provide
+    // their own handlers, we allow duplicates. There is a subtle but very
+    // important difference here.
+    private Map<String, NatsSubscription> subscriptionsWithHandlers;
+    // We use the SID as the key here.
+    private Map<String, MessageHandler> subscriptionHandlers;
+
     private Duration waitForMessage;
 
 
@@ -41,6 +51,8 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         this.handler = handler;
         this.incoming = new MessageQueue(true);
         this.subscriptions = new ConcurrentHashMap<>();
+        this.subscriptionsWithHandlers = new ConcurrentHashMap<>();
+        this.subscriptionHandlers = new ConcurrentHashMap<>();
         this.running = new AtomicBoolean(false);
         this.waitForMessage = Duration.ofMinutes(5); // This can be long since we aren't doing anything
     }
@@ -58,7 +70,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     public void run() {
         try {
             while (this.running.get()) {
-                
+
                 NatsMessage msg = this.incoming.pop(this.waitForMessage);
 
                 if (msg == null) {
@@ -76,8 +88,14 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
                     sub.incrementDeliveredCount();
                     this.incrementDeliveredCount();
 
+                    MessageHandler currentHandler = this.handler;
+                    MessageHandler customHandler = this.subscriptionHandlers.get(sub.getSID());
+                    if (customHandler != null) {
+                        currentHandler = customHandler;
+                    }
+
                     try {
-                        handler.onMessage(msg);
+                        currentHandler.onMessage(msg);
                     } catch (Exception exp) {
                         this.connection.processException(exp);
                     }
@@ -120,8 +138,13 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
             this.subscriptions.forEach((subj, sub) -> {
                 this.connection.unsubscribe(sub, -1);
             });
+            this.subscriptionsWithHandlers.forEach((sid, sub) -> {
+                this.connection.unsubscribe(sub, -1);
+            });
         } else {
             this.subscriptions.clear();
+            this.subscriptionsWithHandlers.clear();
+            this.subscriptionHandlers.clear();
         }
     }
 
@@ -141,11 +164,18 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         this.subscriptions.forEach((id, sub)->{
             this.connection.sendSubscriptionMessage(sub.getSID(), sub.getSubject(), sub.getQueueName(), true);
         });
+        this.subscriptionsWithHandlers.forEach((sid, sub)->{
+            this.connection.sendSubscriptionMessage(sub.getSID(), sub.getSubject(), sub.getQueueName(), true);
+        });
     }
 
     // Called by the connection when the subscription is removed
     void remove(NatsSubscription sub) {
         subscriptions.remove(sub.getSubject());
+
+        // TODO: Can we optimize this somehow?
+        subscriptionsWithHandlers.remove(sub.getSID());
+        subscriptionHandlers.remove(sub.getSID());
     }
 
     public Dispatcher subscribe(String subject) {
@@ -153,7 +183,19 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
             throw new IllegalArgumentException("Subject is required in subscribe");
         }
 
-        return this.subscribeImpl(subject, null);
+        this.subscribeImpl(subject, null, null);
+        return this;
+    }
+
+    public Subscription subscribe(String subject, MessageHandler handler) {
+        if (subject == null || subject.length() == 0) {
+            throw new IllegalArgumentException("Subject is required in subscribe");
+        }
+
+        if (handler == null) {
+            throw new IllegalArgumentException("MessageHandler is required in subscribe");
+        }
+        return this.subscribeImpl(subject, null, handler);
     }
 
     public Dispatcher subscribe(String subject, String queueName) {
@@ -164,40 +206,68 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         if (queueName == null || queueName.length() == 0) {
             throw new IllegalArgumentException("QueueName is required in subscribe");
         }
-        return this.subscribeImpl(subject, queueName);
+        this.subscribeImpl(subject, queueName, null);
+        return this;
     }
 
+    public Subscription subscribe(String subject, String queueName,  MessageHandler handler) {
+        if (subject == null || subject.length() == 0) {
+            throw new IllegalArgumentException("Subject is required in subscribe");
+        }
+
+        if (queueName == null || queueName.length() == 0) {
+            throw new IllegalArgumentException("QueueName is required in subscribe");
+        }
+
+        if (handler == null) {
+            throw new IllegalArgumentException("MessageHandler is required in subscribe");
+        }
+        return this.subscribeImpl(subject, queueName, handler);
+    }
 
     // Assumes the subj/queuename checks are done, does check for closed status
-    Dispatcher subscribeImpl(String subject, String queueName) {
+    Subscription subscribeImpl(String subject, String queueName, MessageHandler handler) {
         if (!this.running.get()) {
             throw new IllegalStateException("Dispatcher is closed");
         }
-        
+
         if (this.isDraining()) {
             throw new IllegalStateException("Dispatcher is draining");
         }
 
-        NatsSubscription sub = subscriptions.get(subject);
+        // If the handler is null, then we use the default handler, which will not allow
+        // duplicate subscriptions to exist.
+        if (handler == null) {
+            NatsSubscription sub = subscriptions.get(subject);
 
-        if (sub == null) {
-            sub = connection.createSubscription(subject, queueName, this);
-            NatsSubscription actual = subscriptions.putIfAbsent(subject, sub);
-            if (actual != null) {
-                this.connection.unsubscribe(sub, -1); // Could happen on very bad timing
+            if (sub == null) {
+                sub = connection.createSubscription(subject, queueName, this);
+                NatsSubscription actual = subscriptions.putIfAbsent(subject, sub);
+                if (actual != null) {
+                    this.connection.unsubscribe(sub, -1); // Could happen on very bad timing
+                }
             }
-        }
 
-        return this;
+            return sub;
+        } else {
+            NatsSubscription sub = connection.createSubscription(subject, queueName, this);
+            subscriptionsWithHandlers.put(sub.getSID(), sub);
+            subscriptionHandlers.put(sub.getSID(), handler);
+            return sub;
+        }
     }
 
     public Dispatcher unsubscribe(String subject) {
         return this.unsubscribe(subject, -1);
     }
 
+    public Dispatcher unsubscribe(Subscription subscription) {
+        return this.unsubscribe(subscription, -1);
+    }
+
     public Dispatcher unsubscribe(String subject, int after) {
         if (!this.running.get()) {
-            throw new IllegalStateException("Dispatcfher is closed");
+            throw new IllegalStateException("Dispatcher is closed");
         }
 
         if (isDraining()) { // No op while draining
@@ -207,8 +277,32 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         if (subject == null || subject.length() == 0) {
             throw new IllegalArgumentException("Subject is required in unsubscribe");
         }
-        
+
         NatsSubscription sub = subscriptions.get(subject);
+
+        if (sub != null) {
+            this.connection.unsubscribe(sub, after); // Connection will tell us when to remove from the map
+        }
+
+        return this;
+    }
+
+    public Dispatcher unsubscribe(Subscription subscription, int after) {
+        if (subscription.getDispatcher() != this) {
+            throw new IllegalStateException("Subscription is not managed by this Dispatcher");
+        }
+
+        if (this.subscriptions.get(subscription.getSubject()) != null) {
+            throw new IllegalStateException("Subscription uses default handler and cannot call unsubscribe");
+        }
+
+        // We can probably optimize this path by adding getSID() to the Subscription interface.
+        if (!(subscription instanceof NatsSubscription)) {
+            throw new IllegalArgumentException("This Subscription implementation is not known by Dispatcher");
+        }
+        NatsSubscription ns = ((NatsSubscription) subscription);
+        // Grab the NatsSubscription to verify we weren't given a different manager's subscription.
+        NatsSubscription sub = this.subscriptionsWithHandlers.get(ns.getSID());
 
         if (sub != null) {
             this.connection.unsubscribe(sub, after); // Connection will tell us when to remove from the map
@@ -219,6 +313,9 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
 
     void sendUnsubForDrain() {
         this.subscriptions.forEach((id, sub)->{
+            this.connection.sendUnsub(sub, -1);
+        });
+        this.subscriptionsWithHandlers.forEach((sid, sub)->{
             this.connection.sendUnsub(sub, -1);
         });
     }

--- a/src/test/java/io/nats/client/impl/DispatcherTests.java
+++ b/src/test/java/io/nats/client/impl/DispatcherTests.java
@@ -561,16 +561,6 @@ public class DispatcherTests {
         }
     }
 
-    // @Test(expected=IllegalArgumentException.class)
-    // public void testThrowOnNullQueue() throws IOException, InterruptedException, TimeoutException {
-    //     try (NatsTestServer ts = new NatsTestServer(false);
-    //                 Connection nc = Nats.connect(ts.getURI())) {
-    //         Dispatcher d = nc.createDispatcher((msg) -> {});
-    //         d.subscribe("subject", null);
-    //         assertFalse(true);
-    //     }
-    // }
-
     @Test(expected=IllegalArgumentException.class)
     public void testThrowOnEmptyQueue() throws IOException, InterruptedException, TimeoutException {
         try (NatsTestServer ts = new NatsTestServer(false);
@@ -666,16 +656,6 @@ public class DispatcherTests {
             assertFalse(true);
         }
     }
-
-    // @Test(expected=IllegalArgumentException.class)
-    // public void testThrowOnNullSubjectInUnsub() throws IOException, InterruptedException, TimeoutException {
-    //     try (NatsTestServer ts = new NatsTestServer(false);
-    //                 Connection nc = Nats.connect(ts.getURI())) {
-    //         Dispatcher d = nc.createDispatcher((msg) -> {});
-    //         d.unsubscribe(null);
-    //         assertFalse(true);
-    //     }
-    // }
 
     @Test
     public void testDoubleSubscribe() throws IOException, InterruptedException, ExecutionException, TimeoutException {

--- a/src/test/java/io/nats/client/impl/DrainTests.java
+++ b/src/test/java/io/nats/client/impl/DrainTests.java
@@ -90,6 +90,7 @@ public class DrainTests {
                 }
             });
             d.subscribe("draintest");
+            d.subscribe("draintest", (msg) -> { count.incrementAndGet(); });
             subCon.flush(Duration.ofSeconds(1)); // Get the sub to the server
 
             pubCon.publish("draintest", null);
@@ -102,7 +103,7 @@ public class DrainTests {
             CompletableFuture<Boolean> tracker = d.drain(Duration.ofSeconds(4));
 
             assertTrue(tracker.get(5, TimeUnit.SECONDS)); // wait for the drain to complete
-            assertEquals(count.get(), 2); // Should get both
+            assertEquals(count.get(), 4); // Should get both, two times.
             assertFalse(d.isActive());
             assertEquals(((NatsConnection) subCon).getConsumerCount(), 0);
         }


### PR DESCRIPTION
This is a solution that satisfies what I was looking to get out of https://github.com/nats-io/nats.java/issues/197.

This adds a few new methods to the Dispatcher interface:

```java
public Subscription subscribe(String subject, MessageHandler handler);
public Subscription subscribe(String subject, String queue, MessageHandler handler);

public Dispatcher unsubscribe(Subscription subscription);
public Dispatcher unsubscribe(Subscription subscription, int after);
```

Calling `Dispatcher#subscribe` with a message handler does not treat duplicate subscriptions as a no-op. It will instead allow duplicate subscriptions to be created and managed by the caller. With this support, the Dispatcher can be used in a similar manner to v1 of this library. Behavior does not change for existing Dispatcher methods.

Example:
```java
Dispatcher d = nc.createDispatcher((msg) -> {});

// Subscribe to different topics using our own message handlers to allow duplicate
// subscriptions to be created.

Subscription s1 =
    d.subscribe("subject", (msg) -> { printMsg(msg, "processed by first subscription"); });
d.subscribe("subject", (msg) -> { printMsg(msg, "processed by second subscription"); });
d.subscribe("done", (msg) -> { print("all done!"); });

// Publish messages.

nc.publish("subject", "1");
nc.publish("subject", "2");
nc.publish("done", "done");

// Output:
// Msg: 1, processed by first subscription
// Msg: 1, processed by second subscription
// Msg: 2, processed by first subscription
// Msg: 2, processed by second subscription
// Msg: done, all done!

// Now we will unsubscribe from the first "subject" subscription.

d.unsubscribe(s1);

// Publish messages.

nc.publish("subject", "1");
nc.publish("subject", "2");
nc.publish("done", "done");

// Output:
// Msg: 1, processed by second subscription
// Msg: 2, processed by second subscription
// Msg: done, all done!
```

I'm sure this branch could use a few more tests and a bit more polish, but feel free to start reviewing! Thanks.

cc @sasbury 