### PR TITLE
[FIXED] Make jwtFile optional in Nats.credentials(String jwtFile, nkeyFile)

### DIFF
--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -221,6 +221,8 @@ public class Nats {
     /**
      * Create an authhandler from a jwt file and an nkey file. The handler will read the files each time it needs to respond to a request
      * and clear the memory after. This has a small price, but will only be encountered during connect or reconnect.
+     *
+     * <p>The {@code jwtFile} parameter can be set to {@code null} for challenge only authentication.
      * 
      * @param jwtFile a file containing a user JWT, may or may not contain separators
      * @param nkeyFile a file containing a user nkey that matches the JWT, may or may not contain separators

--- a/src/main/java/io/nats/client/impl/FileAuthHandler.java
+++ b/src/main/java/io/nats/client/impl/FileAuthHandler.java
@@ -195,6 +195,12 @@ class FileAuthHandler implements AuthHandler {
                 fileToUse = this.credsFile;
             }
 
+            // If no file is provided, assume this is challenge only authentication
+            // and simply return null here.
+            if (fileToUse == null) {
+                return null;
+            }
+
             byte[] data = Files.readAllBytes(Paths.get(fileToUse));
             ByteBuffer bb = ByteBuffer.wrap(data);
             CharBuffer chars = StandardCharsets.UTF_8.decode(bb);

--- a/src/test/java/io/nats/client/impl/FileAuthHandlerTests.java
+++ b/src/test/java/io/nats/client/impl/FileAuthHandlerTests.java
@@ -53,6 +53,18 @@ public class FileAuthHandlerTests {
     }
 
     @Test
+    public void testSeparateNKeyWrappedFile() throws Exception {
+        AuthHandler auth = Nats.credentials(null, "src/test/resources/jwt_nkey/test_wrapped.nk");
+        NKey key = NKey.fromSeed(SEED.toCharArray());
+        byte[] test = "hello world again".getBytes(StandardCharsets.UTF_8);
+
+        char[] pubKey = auth.getID();
+        assertArrayEquals(key.getPublicKey(), pubKey);
+        assertArrayEquals(key.sign(test), auth.sign(test));
+        assertArrayEquals(null, auth.getJWT());
+    }
+
+    @Test
     public void testSeparateBareFiles() throws Exception {
         AuthHandler auth = Nats.credentials("src/test/resources/jwt_nkey/test.jwt", "src/test/resources/jwt_nkey/test.nk");
         NKey key = NKey.fromSeed(SEED.toCharArray());


### PR DESCRIPTION
If one only wants to provide an NKey file but no JWT, Nats.credentials() would not be suitable because the getJWT() would throw an exception if no JWT file was specified.

Resolves #282

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>