### PR TITLE
Allow to disable reconnectBuffer via zero size

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -179,7 +179,7 @@ class NatsConnectionWriter implements Runnable {
     }
 
     boolean canQueue(NatsMessage msg, long maxSize) {
-        return (maxSize <= 0 || (outgoing.sizeInBytes() + msg.getSizeInBytes()) < maxSize);
+        return (maxSize < 0 || (outgoing.sizeInBytes() + msg.getSizeInBytes()) < maxSize);
     }
 
     void queue(NatsMessage msg) {


### PR DESCRIPTION
`NatsConnectionWriter#canQueue` is not in line with docs.

I want to disable the reconnect buffer (used during a reconnect/disconnect) via `Options.Builder().reconnectBufferSize(0)`. According to the docs https://github.com/nats-io/nats.java/blob/master/src/main/java/io/nats/client/Options.java#L1004:
```
A value of zero will disable the reconnect buffer, a value less than zero means unlimited.
```

The reason for disabling it is that if NATS is down, the client will buffer up to 8MB by default and if the client goes down, the buffer with all the messages will vanish.

Now in `NatsConnectionWriter#canQueue`, a zero is treated like a negative number (infinite buffer):
```
    boolean canQueue(NatsMessage msg, long maxSize) {
        return (maxSize <= 0 || (outgoing.sizeInBytes() + msg.getSizeInBytes()) < maxSize);
    }
```

This PR allows to queue only, when buffer is a negative value or the message would exceed the buffer.