### PR TITLE
Discard messages when outgoing queue is full

### DIFF
--- a/src/main/java/io/nats/client/ErrorListener.java
+++ b/src/main/java/io/nats/client/ErrorListener.java
@@ -14,7 +14,7 @@
 package io.nats.client;
 
 /**
- * This library groups problems into three categories:
+ * This library groups problems into four categories:
  * <dl>
  * <dt>Errors</dt>
  * <dd>The server sent an error message using the {@code -err} protocol operation.</dd>
@@ -22,6 +22,8 @@ package io.nats.client;
  * <dd>A Java exception occurred, and was handled by the library.</dd>
  * <dt>Slow Consumers</dt>
  * <dd>One of the connections consumers, Subscription or Dispatcher, is slow, and starting to drop messages.</dd>
+ * <dt>Fast Producers</dt>
+ * <dd>One of the connections producers is too fast, and is discarding messages</dd>
  * </dl>
  * <p>All of these problems are reported to the application code using the ErrorListener. The 
  * listener is configured in the {@link Options Options} at creation time.
@@ -65,4 +67,12 @@ public interface ErrorListener {
      * @param consumer The consumer that is being marked slow
      */
     public void slowConsumerDetected(Connection conn, Consumer consumer);
+
+    /**
+     * Called by the connection when a message is discarded.
+     *
+     * @param conn The connection that discarded the message
+     * @param msg The message that is discarded
+     */
+    default void messageDiscarded(Connection conn, Message msg) {}
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1318,7 +1318,12 @@ class NatsConnection implements Connection {
         if (msg.getControlLineLength() > this.options.getMaxControlLine()) {
             throw new IllegalArgumentException("Control line is too long");
         }
-        this.writer.queue(msg);
+        if (!this.writer.queue(msg)) {
+            ErrorListener errorListener = this.options.getErrorListener();
+            if (errorListener != null) {
+                errorListener.messageDiscarded(this, msg);
+            }
+        }
     }
 
     void queueInternalOutgoing(NatsMessage msg) {

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -51,10 +51,13 @@ class NatsConnectionWriter implements Runnable {
         this.stopped = new CompletableFuture<>();
         ((CompletableFuture<Boolean>)this.stopped).complete(Boolean.TRUE); // we are stopped on creation
 
-        int bufSize = connection.getOptions().getBufferSize();
+        Options options = connection.getOptions();
+        int bufSize = options.getBufferSize();
         this.sendBuffer = new byte[bufSize];
         
-        outgoing = new MessageQueue(true, Options.MAX_MESSAGES_IN_OUTGOING_QUEUE);
+        outgoing = new MessageQueue(true,
+            options.getMaxMessagesInOutgoingQueue(),
+            options.isDiscardMessagesWhenOutgoingQueueFull());
 
         // The reconnect buffer contains internal messages, and we will keep it unlimited in size
         reconnectOutgoing = new MessageQueue(true, 0);
@@ -184,8 +187,8 @@ class NatsConnectionWriter implements Runnable {
         return (maxSize <= 0 || (outgoing.sizeInBytes() + msg.getSizeInBytes()) < maxSize);
     }
 
-    void queue(NatsMessage msg) {
-        this.outgoing.push(msg);
+    boolean queue(NatsMessage msg) {
+        return this.outgoing.push(msg);
     }
 
     void queueInternalMessage(NatsMessage msg) {

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -195,7 +195,7 @@ class NatsConnectionWriter implements Runnable {
         if (this.reconnectMode.get()) {
             this.reconnectOutgoing.push(msg);
         } else {
-            this.outgoing.push(msg);
+            this.outgoing.push(msg, true);
         }
     }
 }

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -58,6 +58,8 @@ public class OptionsTests {
         assertEquals("default oldstyle", false, o.isOldRequestStyle());
         assertEquals("default noEcho", false, o.isNoEcho());
         assertEquals("default UTF8 Support", false, o.supportUTF8Subjects());
+        assertEquals("default discard messages when outgoing queue full", Options.DEFAULT_DISCARD_MESSAGES_WHEN_OUTGOING_QUEUE_FULL,
+                o.isDiscardMessagesWhenOutgoingQueueFull());
 
         assertNull("default username", o.getUsernameChars());
         assertNull("default password", o.getPasswordChars());
@@ -69,6 +71,8 @@ public class OptionsTests {
         assertEquals("default max reconnect", Options.DEFAULT_MAX_RECONNECT, o.getMaxReconnect());
         assertEquals("default ping max", Options.DEFAULT_MAX_PINGS_OUT, o.getMaxPingsOut());
         assertEquals("default reconnect buffer size", Options.DEFAULT_RECONNECT_BUF_SIZE, o.getReconnectBufferSize());
+        assertEquals("default max messages in outgoing queue", Options.DEFAULT_MAX_MESSAGES_IN_OUTGOING_QUEUE,
+                o.getMaxMessagesInOutgoingQueue());
 
         assertEquals("default reconnect wait", Options.DEFAULT_RECONNECT_WAIT, o.getReconnectWait());
         assertEquals("default connection timeout", Options.DEFAULT_CONNECTION_TIMEOUT, o.getConnectionTimeout());
@@ -82,7 +86,9 @@ public class OptionsTests {
 
     @Test
     public void testChainedBooleanOptions() throws NoSuchAlgorithmException {
-        Options o = new Options.Builder().verbose().pedantic().noRandomize().supportUTF8Subjects().noEcho().oldRequestStyle().build();
+        Options o = new Options.Builder().verbose().pedantic().noRandomize().supportUTF8Subjects().noEcho().oldRequestStyle()
+                .discardMessagesWhenOutgoingQueueFull()
+                .build();
         assertNull("default username", o.getUsernameChars());
         assertEquals("chained verbose", true, o.isVerbose());
         assertEquals("chained pedantic", true, o.isPedantic());
@@ -90,6 +96,7 @@ public class OptionsTests {
         assertEquals("chained oldstyle", true, o.isOldRequestStyle());
         assertEquals("chained noecho", true, o.isNoEcho());
         assertEquals("chained utf8", true, o.supportUTF8Subjects());
+        assertEquals("chained discard messages when outgoing queue full", true, o.isDiscardMessagesWhenOutgoingQueueFull());
     }
 
     @Test
@@ -119,11 +126,16 @@ public class OptionsTests {
 
     @Test
     public void testChainedIntOptions() {
-        Options o = new Options.Builder().maxReconnects(100).maxPingsOut(200).reconnectBufferSize(300).build();
+        Options o = new Options.Builder().maxReconnects(100).maxPingsOut(200).reconnectBufferSize(300)
+                .maxControlLine(400)
+                .maxMessagesInOutgoingQueue(500)
+                .build();
         assertEquals("default verbose", false, o.isVerbose()); // One from a different type
         assertEquals("chained max reconnect", 100, o.getMaxReconnect());
         assertEquals("chained ping max", 200, o.getMaxPingsOut());
         assertEquals("chained reconnect buffer size", 300, o.getReconnectBufferSize());
+        assertEquals("chained max control line", 400, o.getMaxControlLine());
+        assertEquals("chained max messages in outgoing queue", 500, o.getMaxMessagesInOutgoingQueue());
     }
 
     @Test
@@ -165,6 +177,7 @@ public class OptionsTests {
         props.setProperty(Options.PROP_OPENTLS, "true");
         props.setProperty(Options.PROP_NO_ECHO, "true");
         props.setProperty(Options.PROP_UTF8_SUBJECTS, "true");
+        props.setProperty(Options.PROP_DISCARD_MESSAGES_WHEN_OUTGOING_QUEUE_FULL, "true");
 
         Options o = new Options.Builder(props).build();
         assertNull("default username chars", o.getUsernameChars());
@@ -174,6 +187,7 @@ public class OptionsTests {
         assertEquals("property oldstyle", true, o.isOldRequestStyle());
         assertEquals("property noecho", true, o.isNoEcho());
         assertEquals("property utf8", true, o.supportUTF8Subjects());
+        assertEquals("property discard messages when outgoing queue full", true, o.isDiscardMessagesWhenOutgoingQueueFull());
         assertNotNull("property opentls", o.getSslContext());
     }
 
@@ -210,6 +224,7 @@ public class OptionsTests {
         props.setProperty(Options.PROP_MAX_PINGS, "200");
         props.setProperty(Options.PROP_RECONNECT_BUF_SIZE, "300");
         props.setProperty(Options.PROP_MAX_CONTROL_LINE, "400");
+        props.setProperty(Options.PROP_MAX_MESSAGES_IN_OUTGOING_QUEUE, "500");
 
         Options o = new Options.Builder(props).build();
         assertEquals("default verbose", false, o.isVerbose()); // One from a different type
@@ -217,6 +232,7 @@ public class OptionsTests {
         assertEquals("property ping max", 200, o.getMaxPingsOut());
         assertEquals("property reconnect buffer size", 300, o.getReconnectBufferSize());
         assertEquals("property max control line", 400, o.getMaxControlLine());
+        assertEquals("property max messages in outgoing queue", 500, o.getMaxMessagesInOutgoingQueue());
     }
 
     @Test
@@ -227,6 +243,7 @@ public class OptionsTests {
         props.setProperty(Options.PROP_PING_INTERVAL, "-1");
         props.setProperty(Options.PROP_CLEANUP_INTERVAL, "-1");
         props.setProperty(Options.PROP_MAX_CONTROL_LINE, "-1");
+        props.setProperty(Options.PROP_MAX_MESSAGES_IN_OUTGOING_QUEUE, "-1");
 
         Options o = new Options.Builder(props).build();
         assertEquals("default max control line", Options.DEFAULT_MAX_CONTROL_LINE, o.getMaxControlLine());
@@ -235,6 +252,8 @@ public class OptionsTests {
         assertEquals("default ping interval", Options.DEFAULT_PING_INTERVAL, o.getPingInterval());
         assertEquals("default cleanup interval", Options.DEFAULT_REQUEST_CLEANUP_INTERVAL,
                 o.getRequestCleanupInterval());
+        assertEquals("default max messages in outgoing queue", Options.DEFAULT_MAX_MESSAGES_IN_OUTGOING_QUEUE,
+                o.getMaxMessagesInOutgoingQueue());
     }
 
     @Test

--- a/src/test/java/io/nats/client/TestHandler.java
+++ b/src/test/java/io/nats/client/TestHandler.java
@@ -39,6 +39,7 @@ public class TestHandler implements ErrorListener, ConnectionListener {
 
     private Connection connection;
     private ArrayList<Consumer> slowConsumers = new ArrayList<>();
+    private ArrayList<Message> discardedMessages = new ArrayList<>();
 
     private boolean printExceptions = true;
 
@@ -92,6 +93,18 @@ public class TestHandler implements ErrorListener, ConnectionListener {
         }
     }
 
+    public void messageDiscarded(Connection conn, Message msg) {
+        this.connection = conn;
+        this.count.incrementAndGet();
+
+        lock.lock();
+        try {
+            this.discardedMessages.add(msg);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     public void connectionEvent(Connection conn, Events type) {
         this.connection = conn;
         this.count.incrementAndGet();
@@ -138,6 +151,10 @@ public class TestHandler implements ErrorListener, ConnectionListener {
 
     public List<Consumer> getSlowConsumers() {
         return this.slowConsumers;
+    }
+
+    public List<Message> getDiscardedMessages() {
+        return this.discardedMessages;
     }
 
     public int getCount() {

--- a/src/test/java/io/nats/client/impl/MessageQueueTests.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueTests.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.CharBuffer;
@@ -537,5 +538,34 @@ public class MessageQueueTests {
         MessageQueue q = new MessageQueue(true);
         q.filter((msg) -> {return true;});
         assertFalse(true);
+    }
+
+    @Test
+    public void testExceptionWhenQueueIsFull() {
+        MessageQueue q  = new MessageQueue(true, 2);
+        NatsMessage msg1 = new NatsMessage(CharBuffer.wrap("one"));
+        NatsMessage msg2 = new NatsMessage(CharBuffer.wrap("two"));
+        NatsMessage msg3 = new NatsMessage(CharBuffer.wrap("three"));
+
+        assertTrue(q.push(msg1));
+        assertTrue(q.push(msg2));
+        try {
+            q.push(msg3);
+            fail("Expected " + IllegalStateException.class.getSimpleName());
+        } catch (IllegalStateException e) {
+            assertEquals("Output queue is full 2", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testDiscardMessageWhenQueueFull() {
+        MessageQueue q  = new MessageQueue(true, 2, true);
+        NatsMessage msg1 = new NatsMessage(CharBuffer.wrap("one"));
+        NatsMessage msg2 = new NatsMessage(CharBuffer.wrap("two"));
+        NatsMessage msg3 = new NatsMessage(CharBuffer.wrap("three"));
+
+        assertTrue(q.push(msg1));
+        assertTrue(q.push(msg2));
+        assertFalse(q.push(msg3));
     }
 }


### PR DESCRIPTION
Fast producers may fully fill the outgoing message queue. Once this
happens, a producer will block until there is space for new messages.

This change adds the option to set the maximum number of messages in the
outgoing queue. This option can be set with property
`io.nats.client.outgoingqueue.maxmessages`, default `5000`.

Moreover, this change adds the option to discard
messages when the outgoing queue is full. This option can be set with
property `io.nats.client.outgoingqueue.discardwhenfull`, default `false`.
Clients can be notified of such event by implementing the
`messageDiscarded` callback in the `ErrorListener` interface.

Example usage:
```java
ErrorListener handler = new ErrorListener() {
    public void messageDiscarded(Connection conn, Message msg) {
        ...
    }
}

Options options = new Options.Builder().
	maxMessagesInOutgoingQueue(10_000).
	discardMessagesWhenOutgoingQueueFull().
	errorListener(handler)
	build();

Connection nc = Nats.connect(options);
```