### PR TITLE
Avoid retrying the last server on reconnect.

### DIFF
--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -341,7 +341,6 @@ public class ReconnectTests {
         }
     }
 
-
     @Test
     public void testNoRandomizeReconnectToSecondServer() throws Exception {
         NatsConnection nc = null;
@@ -615,7 +614,7 @@ public class ReconnectTests {
                                         server(ts.getURI()).
                                         secure().
                                         connectionListener(handler).
-                                        maxReconnects(10). // we get multiples for some, so need enough
+                                        maxReconnects(20). // we get multiples for some, so need enough
                                         reconnectWait(Duration.ofMillis(100)).
                                         connectionTimeout(Duration.ofSeconds(5)).
                                         noRandomize().


### PR DESCRIPTION
With the randomization algorithm there's a chance the client will immediately try the server it just lost connection with.  Move the last connected server to the end of the list when reconnecting.

Signed-off-by: Colin Sullivan <colin@synadia.com>