### PR TITLE
Nats.connect v2 credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,14 @@ There are four different ways to connect using the Java library:
     Connection nc = Nats.connect();
     ```
 
-2. Connect to a server using a URL:
+2. Connect to one or more servers using a URL:
 
     ```java
+    //single URL
     Connection nc = Nats.connect("nats://myhost:4222");
+
+    //comma-separated list of URLs
+    Connection nc = Nats.connect("nats://myhost:4222,nats://myhost:4223");
     ```
 
 3. Connect to one or more servers with a custom configuration:
@@ -147,11 +151,18 @@ There are four different ways to connect using the Java library:
 4. Connect asynchronously, this requires a callback to tell the application when the client is connected:
 
     ```java
-     Options options = new Options.Builder().server(Options.DEFAULT_URL).connectionListener(handler).build();
-     Nats.connectAsynchronously(options, true);
+    Options options = new Options.Builder().server(Options.DEFAULT_URL).connectionListener(handler).build();
+    Nats.connectAsynchronously(options, true);
     ```
 
     This feature is experimental, please let us know if you like it.
+
+5. Connect with authentication handler:
+
+    ```java
+    AuthHandler authHandler = Nats.credentials(System.getenv("NATS_CREDS")
+    Connection nc = Nats.connect("nats://myhost:4222", authHandler);
+    ```
 
 ### Publishing
 

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -132,6 +132,28 @@ public class Nats {
     }
 
     /**
+     * Connect to the specified URL with the specified username, password and default options.
+     *
+     * <p>This is a synchronous call, and the connection should be ready for use on return
+     * there are network timing issues that could result in a successful connect call but
+     * the connection is invalid soon after return, where soon is in the network/thread world.
+     *
+     * <p>If the connection fails, an IOException is thrown
+     *
+     * <p>See {@link Nats#connect(Options) connect(Options)} for more information on exceptions.
+     *
+     * @param url the url of the server, ie. nats://localhost:4222
+     * @param handler the authentication handler implementation
+     * @return the connection
+     * @throws IOException if a networking issue occurs
+     * @throws InterruptedException if the current thread is interrupted
+     */
+    public static Connection connect(String url, AuthHandler handler) throws IOException, InterruptedException {
+        Options options = new Options.Builder().server(url).authHandler(handler).build();
+        return createConnection(options, false);
+    }
+
+    /**
      * Options can be used to set the server URL, or multiple URLS, callback
      * handlers for various errors, and connection events.
      * 

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -142,7 +142,7 @@ public class Nats {
      *
      * <p>See {@link Nats#connect(Options) connect(Options)} for more information on exceptions.
      *
-     * @param url the url of the server, ie. nats://localhost:4222
+     * @param url comma separated list of the URLs of the server, ie. nats://localhost:4222,nats://localhost:4223
      * @param handler the authentication handler implementation
      * @return the connection
      * @throws IOException if a networking issue occurs

--- a/src/test/java/io/nats/client/AuthTests.java
+++ b/src/test/java/io/nats/client/AuthTests.java
@@ -465,6 +465,17 @@ public class AuthTests {
                 assertTrue("Closed Status", Connection.Status.CLOSED == nc.getStatus());
             }
         }
+
+        //test Nats.connect method
+        try (NatsTestServer ts = new NatsTestServer(configFile, false)) {
+            Connection nc = Nats.connect(ts.getURI(), Nats.staticCredentials(null, theKey.getSeed()));
+            try {
+                assertTrue("Connected Status", Connection.Status.CONNECTED == nc.getStatus());
+            } finally {
+                nc.close();
+                assertTrue("Closed Status", Connection.Status.CLOSED == nc.getStatus());
+            }
+        }
     }
 
     @Test
@@ -480,6 +491,17 @@ public class AuthTests {
             Options options = new Options.Builder().server(ts.getURI()).maxReconnects(0)
                     .authHandler(Nats.credentials("src/test/resources/jwt_nkey/user.creds")).build();
             Connection nc = Nats.connect(options);
+            try {
+                assertTrue("Connected Status", Connection.Status.CONNECTED == nc.getStatus());
+            } finally {
+                nc.close();
+                assertTrue("Closed Status", Connection.Status.CLOSED == nc.getStatus());
+            }
+        }
+
+        //test Nats.connect method
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/operator.conf", false)) {
+            Connection nc = Nats.connect(ts.getURI(), Nats.credentials("src/test/resources/jwt_nkey/user.creds"));
             try {
                 assertTrue("Connected Status", Connection.Status.CONNECTED == nc.getStatus());
             } finally {


### PR DESCRIPTION
Overloads the `Nats.connect` method by adding `AuthHandler` as an argument.

Addresses https://github.com/nats-io/nats.java/issues/321