### PR TITLE
JetStream NEXT not working

### DIFF
--- a/src/test/java/io/nats/client/JetStreamTests.java
+++ b/src/test/java/io/nats/client/JetStreamTests.java
@@ -1,0 +1,32 @@
+package io.nats.client;
+
+import static org.junit.Assert.*;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+// Assumes ./nats-server -js is running:
+public class JetStreamTests {
+    @Test
+    public void testJSNext() throws Exception {
+        Options opts = new Options.Builder()
+            .oldRequestStyle()
+            .build();
+        try (Connection nats = Nats.connect(opts)) {
+            // Create a stream:
+            nats.request("$JS.API.STREAM.CREATE.STREAM1",
+                        "{\"name\":\"STREAM1\",\"subjects\":[\"STREAM1.*\"],\"retention\":\"workqueue\",\"max_consumers\":-1,\"max_msgs\":-1,\"max_bytes\":-1,\"max_age\":0,\"max_msg_size\":-1,\"storage\":\"file\",\"discard\":\"old\",\"num_replicas\":1}".getBytes(),
+                        Duration.ofSeconds(15));
+            // Create a consumer:
+            nats.request("$JS.API.CONSUMER.DURABLE.CREATE.STREAM1.CONSUMER1",
+                        "{\"stream_name\":\"STREAM1\",\"config\":{\"durable_name\":\"CONSUMER1\",\"deliver_policy\":\"all\",\"ack_policy\":\"explicit\",\"max_deliver\":-1,\"replay_policy\":\"instant\"}}".getBytes(),
+                        Duration.ofSeconds(15));
+            // Enqueue a message:
+            nats.request("STREAM1.CONSUMER1", "msg1".getBytes(), Duration.ofSeconds(15));
+            // Request from the stream, always times-out:
+            nats.request("$JS.API.CONSUMER.MSG.NEXT.STREAM1.CONSUMER1", new byte[0]).get(15L, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
...if using a pull client, this does not work in Java implementation of client.

To demonstrate this issue, run `nats-server -js` in another terminal. Then run this test code as such:

```bash
git clone git@github.com:brimworks/nats.java.git
git checkout jetstream-next
./gradlew test --tests JetStreamTests
```

GOT:

```
io.nats.client.JetStreamTests > testJSNext FAILED
    java.util.concurrent.TimeoutException
        at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1784)
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1928)
        at io.nats.client.JetStreamTests.testJSNext(JetStreamTests.java:29)
```

Expected no timeout.

After running the test, you can introspect the stream and consumer is as such:

```
$ nats str info STREAM1
Information for Stream STREAM1

Configuration:

             Subjects: STREAM1.*
     Acknowledgements: true
            Retention: File - WorkQueue
             Replicas: 1
       Discard Policy: Old
     Duplicate Window: 2m0s
     Maximum Messages: unlimited
        Maximum Bytes: unlimited
          Maximum Age: 0s
 Maximum Message Size: unlimited
    Maximum Consumers: unlimited

State:

            Messages: 2
               Bytes: 102 B
            FirstSeq: 1 @ 2020-07-24T12:25:33 UTC
             LastSeq: 2 @ 2020-07-24T12:31:06 UTC
    Active Consumers: 1

$ nats con info STREAM1 CONSUMER1
Information for Consumer STREAM1 > CONSUMER1

Configuration:

        Durable Name: CONSUMER1
           Pull Mode: true
         Deliver All: true
          Ack Policy: Explicit
            Ack Wait: 30s
       Replay Policy: Instant

State:

  Last Delivered Message: Consumer sequence: 2 Stream sequence: 1
    Acknowledgment floor: Consumer sequence: 0 Stream sequence: 0
        Pending Messages: 1
    Redelivered Messages: 1

```