### PR TITLE
Subject Remapping Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,9 @@ publishing {
         }
         
         tasks.publishMavenJavaPublicationToSonatypeRepository {
-            dependsOn project.tasks.signArchives
+            if (useSigning) {
+                dependsOn project.tasks.signArchives
+            }
         }
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1059,11 +1059,16 @@ class NatsConnection implements Connection {
         String responseToken = getResponseToken(responseInbox);
         CompletableFuture<Message> future = new CompletableFuture<>();
 
-        responses.put(responseToken, future);
+        if (!oldStyle) {
+            responses.put(responseToken, future);
+        }
         statistics.incrementOutstandingRequests();
 
         if (oldStyle) {
-            this.inboxDispatcher.get().subscribe(responseInbox).unsubscribe(responseInbox, 1);
+            NatsDispatcher dispatcher = this.inboxDispatcher.get();
+            NatsSubscription sub = dispatcher.subscribeReturningSubscription(responseInbox);
+            dispatcher.unsubscribe(responseInbox, 1);
+            responses.put(sub.getSID(), future);
         }
 
         this.publish(subject, responseInbox, body);
@@ -1073,16 +1078,23 @@ class NatsConnection implements Connection {
     }
 
     void deliverReply(Message msg) {
+        boolean oldStyle = options.isOldRequestStyle();
         String subject = msg.getSubject();
         String token = getResponseToken(subject);
         CompletableFuture<Message> f = null;
 
-        f = responses.remove(token);
+        if (oldStyle) {
+            f = responses.remove(msg.getSID());
+        } else {
+            f = responses.remove(token);
+        }
 
         if (f != null) {
             statistics.decrementOutstandingRequests();
             f.complete(msg);
             statistics.incrementRepliesReceived();
+        } else if (!oldStyle && !subject.startsWith(mainInbox)) {
+            System.out.println("ERROR: Subject remapping requires Options.oldRequestStyle() to be set on the Connection");
         }
     }
 

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -194,7 +194,13 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         this.subscribeImpl(subject, null, null);
         return this;
     }
+    NatsSubscription subscribeReturningSubscription(String subject) {
+        if (subject == null || subject.length() == 0) {
+            throw new IllegalArgumentException("Subject is required in subscribe");
+        }
 
+        return this.subscribeImpl(subject, null, null);
+    }
     public Subscription subscribe(String subject, MessageHandler handler) {
         if (subject == null || subject.length() == 0) {
             throw new IllegalArgumentException("Subject is required in subscribe");
@@ -234,7 +240,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     }
 
     // Assumes the subj/queuename checks are done, does check for closed status
-    Subscription subscribeImpl(String subject, String queueName, MessageHandler handler) {
+    NatsSubscription subscribeImpl(String subject, String queueName, MessageHandler handler) {
         if (!this.running.get()) {
             throw new IllegalStateException("Dispatcher is closed");
         }


### PR DESCRIPTION
Fixes: https://github.com/nats-io/nats.java/issues/326

Allow for JetStream subject remapping by tracking outstanding requests based on the SID (only works for "old style").

The `build.gradle` fix was useful when using Visual Studio Code which failed due to invalid `dependsOn` when `useSigning=false`.