### PR TITLE
[FIX] Reconnect wait was not being honored

### DIFF
--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -20,9 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -20,8 +20,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import io.nats.client.ConnectionListener.Events;
@@ -487,4 +490,52 @@ public class ConnectTests {
             assertTrue(e.getMessage().contains("testserver.alsonotnats:4223"));
         }
     }
+
+    private class TestReconnecWaitHandler implements ConnectionListener {
+        int disconnectCount = 0;
+
+        public synchronized int getDisconnectCount() {
+            return disconnectCount;
+        }
+
+        private synchronized void incrementDisconnectedCount() {
+            disconnectCount++;
+        }
+
+        @Override
+        public void connectionEvent(Connection conn, Events type) {
+            if (type == Events.DISCONNECTED) {
+                // disconnect is called after every failed reconnect attempt.
+                incrementDisconnectedCount();
+            }
+        }
+    }
+
+    @Test
+    public void TestReconnectWait() throws IOException, InterruptedException {
+        TestReconnecWaitHandler trwh = new TestReconnecWaitHandler();
+
+        int port = NatsTestServer.nextPort();
+        Options options = new Options.Builder().
+                                server("nats://localhost:"+port).
+                                maxReconnects(-1).
+                                connectionTimeout(Duration.ofSeconds(1)).
+                                reconnectWait(Duration.ofMillis(250)).
+                                connectionListener(trwh).
+                                build();
+
+        NatsTestServer ts = new NatsTestServer(port, false);
+        Connection c = Nats.connect(options);
+        ts.close();
+
+        try {
+            Thread.sleep(250);
+        } catch (Exception exp) {
+        }
+
+        Assert.assertTrue("disconnectCount", trwh.getDisconnectCount() < 3);
+        
+        c.close();
+    }     
+
 }

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -29,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 import io.nats.client.Connection;
+import io.nats.client.ConnectionListener;
 import io.nats.client.Dispatcher;
 import io.nats.client.Message;
 import io.nats.client.Nats;
@@ -44,7 +46,7 @@ public class ReconnectTests {
 
     static void flushAndWait(Connection nc, TestHandler handler) {
         try {
-            nc.flush(Duration.ofSeconds(1));
+            nc.flush(Duration.ofSeconds(2));
         } catch (Exception exp) {
         }
 
@@ -722,5 +724,53 @@ public class ReconnectTests {
             }
         }
     }
+
+   
+    private class TestReconnecWaitHandler implements ConnectionListener {
+        int disconnectCount = 0;
+
+        public synchronized int getDisconnectCount() {
+            return disconnectCount;
+        }
+
+        private synchronized void incrementDisconnectedCount() {
+            disconnectCount++;
+        }
+
+        @Override
+        public void connectionEvent(Connection conn, Events type) {
+            if (type == Events.DISCONNECTED) {
+                // disconnect is called after every failed reconnect attempt.
+                incrementDisconnectedCount();
+            }
+        }
+    } 
+    
+    @Test
+    public void testReconnectWait() throws IOException, InterruptedException {
+        TestReconnecWaitHandler trwh = new TestReconnecWaitHandler();
+
+        int port = NatsTestServer.nextPort();
+        Options options = new Options.Builder().
+                                server("nats://localhost:"+port).
+                                maxReconnects(-1).
+                                connectionTimeout(Duration.ofSeconds(1)).
+                                reconnectWait(Duration.ofMillis(250)).
+                                connectionListener(trwh).
+                                build();
+
+        NatsTestServer ts = new NatsTestServer(port, false);
+        Connection c = Nats.connect(options);
+        ts.close();
+
+        try {
+            Thread.sleep(250);
+        } catch (Exception exp) {
+        }
+
+        assertTrue("disconnectCount", trwh.getDisconnectCount() < 3);
+        
+        c.close();
+    }  
 
 }


### PR DESCRIPTION
The reconnect wait option was not being honored.  Adjust the reconnect logic to honor it.

Partially resolves #329.
Resolves #290.