### PR TITLE
Fix before_install formatting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
 before_install:
 - |
   if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then
-    openssl aes-256-cbc -K $encrypted_f7c3aa8bac4f_key -iv $encrypted_f7c3aa8bac4f_iv
+    openssl aes-256-cbc -K $encrypted_f7c3aa8bac4f_key -iv $encrypted_f7c3aa8bac4f_iv \
       -in .travis/nats.travis.gpg.enc -out .travis/nats.travis.gpg -d
   fi
 install:


### PR DESCRIPTION
Seems I botched the syntax in #346 when making `before_install` conditional on `"${TRAVIS_SECURE_ENV_VARS}" == "true"` so that pull requests from repos without the secure env vars stopped failing, this should hopefully be correct, this doesn't get run on forks or pull requests so it's a bit tricky for me to fully test.