### PR TITLE
Use OS Default SecureRandom.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,6 @@ If you need the absolute latest, before it propagates to maven central, you can 
 
 If you are using the 1.x version of java-nats and don't want to upgrade to 2.0.0 please use ranges in your POM file, java-nats-streaming 1.x is using [1.1, 1.9.9) for this.
 
-### Linux Platform Note
-
-NATS uses RNG to generate unique inbox names. A peculiarity of the JDK on Linux (see [JDK-6202721](https://bugs.openjdk.java.net/browse/JDK-6202721) and [JDK-6521844](https://bugs.openjdk.java.net/browse/JDK-6521844)) causes Java to use `/dev/random` even when `/dev/urandom` is called for. The net effect is that successive calls to `newInbox()`, either directly or through calling `request()` will become very slow, on the order of seconds, making many applications unusable if the issue is not addressed. A simple workaround would be to use the following jvm args.
-
-`-Djava.security.egd=file:/dev/./urandom`
-
 ## Basic Usage
 
 Sending and receiving with NATS is as simple as connecting to the nats-server and publishing or subscribing for messages. A number of examples are provided in this repo as described in [examples.md](src/examples/java/io/nats/examples/examples.md).

--- a/build.gradle
+++ b/build.gradle
@@ -113,9 +113,6 @@ jar {
 test {
     useJUnitPlatform()
     maxHeapSize = "2g"
-    if (org.gradle.internal.os.OperatingSystem.current().isLinux()) {
-        jvmArgs '-Djava.security.egd=file:/dev/./urandom'
-    }
     testLogging {
         exceptionFormat = 'full'
         events "started", "passed", "skipped", "failed"

--- a/src/main/java/io/nats/client/NKey.java
+++ b/src/main/java/io/nats/client/NKey.java
@@ -438,7 +438,7 @@ public class NKey {
     private static NKey createPair(Type type, SecureRandom random)
             throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         if (random == null) {
-            random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+            random = new SecureRandom();
         }
 
         byte[] seed = new byte[NKey.ed25519.getCurve().getField().getb() / 8];
@@ -466,7 +466,7 @@ public class NKey {
     /**
      * Create an Account NKey from the provided random number generator.
      * 
-     * If no random is provided, SecureRandom.getInstance("SHA1PRNG", "SUN") will be used to creat eone.
+     * If no random is provided, SecureRandom() will be used to create one.
      * 
      * The new NKey contains the private seed, which should be saved in a secure location.
      * 
@@ -484,7 +484,7 @@ public class NKey {
     /**
      * Create an Cluster NKey from the provided random number generator.
      * 
-     * If no random is provided, SecureRandom.getInstance("SHA1PRNG", "SUN") will be used to creat eone.
+     * If no random is provided, SecureRandom() will be used to create one.
      * 
      * The new NKey contains the private seed, which should be saved in a secure location.
      * 
@@ -502,7 +502,7 @@ public class NKey {
     /**
      * Create an Operator NKey from the provided random number generator.
      * 
-     * If no random is provided, SecureRandom.getInstance("SHA1PRNG", "SUN") will be used to creat eone.
+     * If no random is provided, SecureRandom() will be used to create one.
      * 
      * The new NKey contains the private seed, which should be saved in a secure location.
      * 
@@ -520,7 +520,7 @@ public class NKey {
     /**
      * Create a Server NKey from the provided random number generator.
      * 
-     * If no random is provided, SecureRandom.getInstance("SHA1PRNG", "SUN") will be used to creat eone.
+     * If no random is provided, SecureRandom() will be used to create one.
      * 
      * The new NKey contains the private seed, which should be saved in a secure location.
      * 
@@ -538,7 +538,7 @@ public class NKey {
     /**
      * Create a User NKey from the provided random number generator.
      * 
-     * If no random is provided, SecureRandom.getInstance("SHA1PRNG", "SUN") will be used to creat eone.
+     * If no random is provided, SecureRandom() will be used to create one.
      * 
      * The new NKey contains the private seed, which should be saved in a secure location.
      * 

--- a/src/main/java/io/nats/client/NUID.java
+++ b/src/main/java/io/nats/client/NUID.java
@@ -57,11 +57,7 @@ public final class NUID {
     private static final NUID globalNUID;
 
     static {
-        try {
-            srand = SecureRandom.getInstance("SHA1PRNG");
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("NUID requires SHA1PRNG Algorithm and it is not available.");
-        }
+        srand = new SecureRandom();
         prand = new Random(bytesToLong(srand.generateSeed(8))); // seed with 8 bytes (64 bits)
         globalNUID = new NUID();
     }
@@ -73,7 +69,7 @@ public final class NUID {
     /**
      * The default NUID constructor.
      * 
-     * Relies on the SHA1PRNG instance of SecureRandom.
+     * Relies on the OS Default instance of SecureRandom.
      * 
      * @throws IllegalStateException
      *                                   if the class cannot find the necessary

--- a/src/test/java/io/nats/client/NKeyTests.java
+++ b/src/test/java/io/nats/client/NKeyTests.java
@@ -82,7 +82,7 @@ public class NKeyTests {
     @Test
     public void testEncodeDecodeSeed() throws Exception {
         byte[] bytes = new byte[64];
-        SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+        SecureRandom random = new SecureRandom();
         random.nextBytes(bytes);
 
         char[] encoded = NKey.encodeSeed(NKey.Type.ACCOUNT, bytes);
@@ -95,7 +95,7 @@ public class NKeyTests {
     @Test
     public void testEncodeDecode() throws Exception {
         byte[] bytes = new byte[32];
-        SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+        SecureRandom random = new SecureRandom();
         random.nextBytes(bytes);
 
         char[] encoded = NKey.encode(NKey.Type.ACCOUNT, bytes);
@@ -119,7 +119,7 @@ public class NKeyTests {
     public void testDecodeWrongType() {
         assertThrows(IllegalArgumentException.class, () -> {
             byte[] bytes = new byte[32];
-            SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+            SecureRandom random = new SecureRandom();
             random.nextBytes(bytes);
 
             char[] encoded = NKey.encode(NKey.Type.ACCOUNT, bytes);
@@ -131,7 +131,7 @@ public class NKeyTests {
     public void testEncodeSeedSize() {
         assertThrows(IllegalArgumentException.class, () -> {
             byte[] bytes = new byte[48];
-            SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+            SecureRandom random = new SecureRandom();
             random.nextBytes(bytes);
 
             NKey.encodeSeed(NKey.Type.ACCOUNT, bytes);
@@ -148,7 +148,7 @@ public class NKeyTests {
         for (int i=0;i<10000;i++) {
             try {
                 byte[] bytes = new byte[32];
-                SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+                SecureRandom random = new SecureRandom();
                 random.nextBytes(bytes);
         
                 char[] encoded = NKey.encode(NKey.Type.ACCOUNT, bytes);


### PR DESCRIPTION
The bug causing `/dev/random` to be used on Linux is due to the `SHA1PRNG`(use of which is generally discouraged) instance of `SecureRandom` being used, use the OS default instance to fix this issue which should properly select `/dev/urandom` on Linux and have sane defaults on other systems.