### PR TITLE
Run tests in github actions.

### DIFF
--- a/.github/workflows/jnats.yml
+++ b/.github/workflows/jnats.yml
@@ -1,0 +1,38 @@
+name: "Run Java Nats Client Tests"
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 1.8, 9, 10, 11, 12, 13, 14, 15, 16 ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+      - name: Install NATS
+        run: go get github.com/nats-io/nats-server/v2@master
+        env:
+          GO111MODULE: on
+      - name: Assemble
+        run: ./gradlew assemble --info
+        env:
+          TERM: dumb
+      - name: Check
+        run: ./gradlew check --info
+        env:
+          TERM: dumb

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Travis is becoming increasingly unusable for open source projects as they no longer offer credits for open source builds. In addition they seem to have been getting more unreliable in general.

<img width="938" alt="travis" src="https://user-images.githubusercontent.com/3298484/101611448-c4067f00-39c6-11eb-956a-4208c8f97edf.png">
