### PR TITLE
fix test failing because of timeout that aren't testing timing

### DIFF
--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -13,20 +13,15 @@
 
 package io.nats.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.nats.client.ConnectionListener.Events;
+import io.nats.client.NatsServerProtocolMock.ExitAt;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Test;
-
-import io.nats.client.ConnectionListener.Events;
-import io.nats.client.NatsServerProtocolMock.ExitAt;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectTests {
     @Test
@@ -34,10 +29,10 @@ public class ConnectTests {
         try (NatsTestServer ts = new NatsTestServer(Options.DEFAULT_PORT, false)) {
             Connection nc = Nats.connect();
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -47,10 +42,10 @@ public class ConnectTests {
         try (NatsTestServer ts = new NatsTestServer(false)) {
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -61,10 +56,10 @@ public class ConnectTests {
             Options options = new Options.Builder().server(ts.getURI()).build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -74,10 +69,10 @@ public class ConnectTests {
         try (NatsServerProtocolMock ts = new NatsServerProtocolMock(ExitAt.NO_EXIT)) {
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -88,10 +83,10 @@ public class ConnectTests {
             ts.useTabs();
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -107,7 +102,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -125,7 +120,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -143,7 +138,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -161,7 +156,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -176,10 +171,10 @@ public class ConnectTests {
                 Options options = new Options.Builder().connectionTimeout(Duration.ofSeconds(5)).server(fake.getURI()).server(ts.getURI()).build();
                 Connection nc = Nats.connect(options);
                 try {
-                    assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                    assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 } finally {
                     nc.close();
-                    assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                    assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                 }
             }
         }
@@ -190,10 +185,10 @@ public class ConnectTests {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/simple.conf", false)) {
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -204,10 +199,10 @@ public class ConnectTests {
             try (NatsTestServer ts2 = new NatsTestServer(false)) {
                 Connection nc = Nats.connect(ts1.getURI() + "," + ts2.getURI());
                 try {
-                    assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                    assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 } finally {
                     nc.close();
-                    assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                    assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                 }
             }
         }
@@ -224,7 +219,7 @@ public class ConnectTests {
                 for (int i=0; i < 10; i++) {
                     Connection nc = Nats.connect(ts1.getURI() + "," + ts2.getURI());
                     try {
-                        assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                        assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                         if (nc.getConnectedUrl().equals(ts1.getURI())) {
                             one++;
@@ -233,7 +228,7 @@ public class ConnectTests {
                         }
                     } finally {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
 
@@ -256,7 +251,7 @@ public class ConnectTests {
                     Options options = new Options.Builder().noRandomize().servers(servers).build();
                     Connection nc = Nats.connect(options);
                     try {
-                        assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                        assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                         if (nc.getConnectedUrl().equals(ts1.getURI())) {
                             one++;
@@ -265,12 +260,12 @@ public class ConnectTests {
                         }
                     } finally {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
 
-                assertTrue(one == 10, "always got one");
-                assertTrue(two == 0, "never got two");
+                assertEquals(one, 10, "always got one");
+                assertEquals(two, 0, "never got two");
             }
         }
     }
@@ -287,7 +282,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -306,7 +301,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -326,7 +321,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -345,7 +340,7 @@ public class ConnectTests {
                 } finally {
                     if (nc != null) {
                         nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
                     }
                 }
             }
@@ -371,12 +366,10 @@ public class ConnectTests {
             try {
                 nc = handler.getConnection();
                 assertNotNull(nc);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
-                if (nc != null) {
-                    nc.close();
-                }
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                nc.close();
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -397,11 +390,7 @@ public class ConnectTests {
             Nats.connectAsynchronously(options, true);
 
             // No server at this point, let it fail and try to start over
-            try {
-                Thread.sleep(1000);
-            } catch (Exception exp) {
-
-            }
+            try { Thread.sleep(5000); } catch (Exception exp) { /* ignored */ }
 
             nc = handler.getConnection(); // will be disconnected, but should be there
             assertNotNull(nc);
@@ -409,12 +398,12 @@ public class ConnectTests {
             handler.prepForStatusChange(Events.RECONNECTED);
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
                 handler.waitForStatusChange(5, TimeUnit.SECONDS);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             }
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -459,7 +448,7 @@ public class ConnectTests {
                                             connectionTimeout(Duration.ofSeconds(2)). // 2 is also the default but explicit for test
                                             build();
                 Connection nc = Nats.connect(options);
-                assertFalse(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertNotSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             }
         });
     }
@@ -474,10 +463,10 @@ public class ConnectTests {
                                         build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -491,16 +480,16 @@ public class ConnectTests {
                                         build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
 
     @Test
-    public void testConnectExceptionHasURLS() throws IOException, InterruptedException {
+    public void testConnectExceptionHasURLS() {
         try {
             Nats.connect("nats://testserver.notnats:4222, nats://testserver.alsonotnats:4223");
         } catch (Exception e) {

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -32,7 +32,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -44,7 +44,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -57,7 +57,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -69,7 +69,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -82,7 +82,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -96,7 +96,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -111,7 +111,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -126,7 +126,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -141,7 +141,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -157,7 +157,7 @@ public class ConnectTests {
                 try {
                     assertConnected(nc);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         }
@@ -170,7 +170,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -183,7 +183,7 @@ public class ConnectTests {
                 try {
                     assertConnected(nc);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         }
@@ -208,7 +208,7 @@ public class ConnectTests {
                             two++;
                         }
                     } finally {
-                        closeConnectionAssertClosed(nc);
+                        closeThenAssertClosed(nc);
                     }
                 }
 
@@ -239,7 +239,7 @@ public class ConnectTests {
                             two++;
                         }
                     } finally {
-                        closeConnectionAssertClosed(nc);
+                        closeThenAssertClosed(nc);
                     }
                 }
 
@@ -259,7 +259,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -275,7 +275,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -292,7 +292,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -308,7 +308,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -335,7 +335,7 @@ public class ConnectTests {
                 assertNotNull(nc);
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -362,10 +362,10 @@ public class ConnectTests {
 
             handler.prepForStatusChange(Events.RECONNECTED);
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                allowTimeToConnectAssertOpen(nc, handler);
+                waitThenAssertConnected(nc, handler);
             }
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
     
@@ -426,7 +426,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -442,7 +442,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import static io.nats.client.impl.TestMacros.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectTests {
@@ -29,10 +30,9 @@ public class ConnectTests {
         try (NatsTestServer ts = new NatsTestServer(Options.DEFAULT_PORT, false)) {
             Connection nc = Nats.connect();
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -42,10 +42,9 @@ public class ConnectTests {
         try (NatsTestServer ts = new NatsTestServer(false)) {
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -56,10 +55,9 @@ public class ConnectTests {
             Options options = new Options.Builder().server(ts.getURI()).build();
             Connection nc = Nats.connect(options);
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -69,10 +67,9 @@ public class ConnectTests {
         try (NatsServerProtocolMock ts = new NatsServerProtocolMock(ExitAt.NO_EXIT)) {
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -83,10 +80,9 @@ public class ConnectTests {
             ts.useTabs();
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -100,10 +96,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -118,10 +111,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -136,10 +126,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -154,10 +141,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -171,10 +155,9 @@ public class ConnectTests {
                 Options options = new Options.Builder().connectionTimeout(Duration.ofSeconds(5)).server(fake.getURI()).server(ts.getURI()).build();
                 Connection nc = Nats.connect(options);
                 try {
-                    assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                    assertConnected(nc);
                 } finally {
-                    nc.close();
-                    assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                    closeConnection(nc);
                 }
             }
         }
@@ -185,10 +168,9 @@ public class ConnectTests {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/simple.conf", false)) {
             Connection nc = Nats.connect(ts.getURI());
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -199,10 +181,9 @@ public class ConnectTests {
             try (NatsTestServer ts2 = new NatsTestServer(false)) {
                 Connection nc = Nats.connect(ts1.getURI() + "," + ts2.getURI());
                 try {
-                    assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                    assertConnected(nc);
                 } finally {
-                    nc.close();
-                    assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                    closeConnection(nc);
                 }
             }
         }
@@ -219,7 +200,7 @@ public class ConnectTests {
                 for (int i=0; i < 10; i++) {
                     Connection nc = Nats.connect(ts1.getURI() + "," + ts2.getURI());
                     try {
-                        assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                        assertConnected(nc);
 
                         if (nc.getConnectedUrl().equals(ts1.getURI())) {
                             one++;
@@ -227,8 +208,7 @@ public class ConnectTests {
                             two++;
                         }
                     } finally {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                        closeConnection(nc);
                     }
                 }
 
@@ -251,7 +231,7 @@ public class ConnectTests {
                     Options options = new Options.Builder().noRandomize().servers(servers).build();
                     Connection nc = Nats.connect(options);
                     try {
-                        assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                        assertConnected(nc);
 
                         if (nc.getConnectedUrl().equals(ts1.getURI())) {
                             one++;
@@ -259,8 +239,7 @@ public class ConnectTests {
                             two++;
                         }
                     } finally {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                        closeConnection(nc);
                     }
                 }
 
@@ -280,10 +259,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -299,10 +275,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -319,10 +292,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -338,10 +308,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -366,10 +333,9 @@ public class ConnectTests {
             try {
                 nc = handler.getConnection();
                 assertNotNull(nc);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -397,14 +363,10 @@ public class ConnectTests {
 
             handler.prepForStatusChange(Events.RECONNECTED);
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                handler.waitForStatusChange(5, TimeUnit.SECONDS);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                allowTimeToConnect(nc, handler);
             }
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
     
@@ -463,10 +425,9 @@ public class ConnectTests {
                                         build();
             Connection nc = Nats.connect(options);
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -480,10 +441,9 @@ public class ConnectTests {
                                         build();
             Connection nc = Nats.connect(options);
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -32,7 +32,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -44,7 +44,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -57,7 +57,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -69,7 +69,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -82,7 +82,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -96,7 +96,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -111,7 +111,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -126,7 +126,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -141,7 +141,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(opt);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -157,7 +157,7 @@ public class ConnectTests {
                 try {
                     assertConnected(nc);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         }
@@ -170,7 +170,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -183,7 +183,7 @@ public class ConnectTests {
                 try {
                     assertConnected(nc);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         }
@@ -208,7 +208,7 @@ public class ConnectTests {
                             two++;
                         }
                     } finally {
-                        closeConnection(nc);
+                        closeConnectionAssertClosed(nc);
                     }
                 }
 
@@ -239,7 +239,7 @@ public class ConnectTests {
                             two++;
                         }
                     } finally {
-                        closeConnection(nc);
+                        closeConnectionAssertClosed(nc);
                     }
                 }
 
@@ -259,7 +259,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -275,7 +275,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -292,7 +292,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -308,7 +308,7 @@ public class ConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -335,7 +335,7 @@ public class ConnectTests {
                 assertNotNull(nc);
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -355,18 +355,17 @@ public class ConnectTests {
         try {
             Nats.connectAsynchronously(options, true);
 
-            // No server at this point, let it fail and try to start over
-            try { Thread.sleep(5000); } catch (Exception exp) { /* ignored */ }
+            sleep(5000); // No server at this point, let it fail and try to start over
 
             nc = handler.getConnection(); // will be disconnected, but should be there
             assertNotNull(nc);
 
             handler.prepForStatusChange(Events.RECONNECTED);
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                allowTimeToConnect(nc, handler);
+                allowTimeToConnectAssertOpen(nc, handler);
             }
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
     
@@ -427,7 +426,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -443,7 +442,7 @@ public class ConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }

--- a/src/test/java/io/nats/client/impl/ConnectionListenerTests.java
+++ b/src/test/java/io/nats/client/impl/ConnectionListenerTests.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import static io.nats.client.impl.TestMacros.assertConnected;
-import static io.nats.client.impl.TestMacros.closeConnectionAssertClosed;
+import static io.nats.client.impl.TestMacros.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectionListenerTests {
@@ -104,7 +103,7 @@ public class ConnectionListenerTests {
             assertNull(nc.getConnectedUrl());
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                try { Thread.sleep(1000); } catch (InterruptedException e) { /* ignored */ }
+                sleep(1000);
                 assertConnected(nc);
                 assertEquals(1, handler.getEventCount(Events.RECONNECTED));
                 assertEquals(ts.getURI(), nc.getConnectedUrl());

--- a/src/test/java/io/nats/client/impl/ConnectionListenerTests.java
+++ b/src/test/java/io/nats/client/impl/ConnectionListenerTests.java
@@ -43,7 +43,7 @@ public class ConnectionListenerTests {
                 assertConnected(nc);
                 assertEquals(ts.getURI(), nc.getConnectedUrl());
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
                 assertNull(nc.getConnectedUrl());
             }
             assertEquals(1, handler.getEventCount(Events.CLOSED));
@@ -69,7 +69,7 @@ public class ConnectionListenerTests {
                     handler.waitForStatusChange(5, TimeUnit.SECONDS);
                     assertConnected(nc);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                     assertEquals(1, handler.getEventCount(Events.DISCOVERED_SERVERS));
                 }
             }
@@ -110,7 +110,7 @@ public class ConnectionListenerTests {
             }
         } finally {
             assertNotNull(nc);
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
             assertNull(nc.getConnectedUrl());
         }
     }
@@ -127,7 +127,7 @@ public class ConnectionListenerTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
             assertTrue(((NatsConnection)nc).getNatsStatistics().getExceptions() > 0);
         }

--- a/src/test/java/io/nats/client/impl/ConnectionListenerTests.java
+++ b/src/test/java/io/nats/client/impl/ConnectionListenerTests.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import static io.nats.client.impl.TestMacros.assertConnected;
+import static io.nats.client.impl.TestMacros.closeConnectionAssertClosed;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ConnectionListenerTests {
@@ -39,11 +41,10 @@ public class ConnectionListenerTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertEquals(ts.getURI(), nc.getConnectedUrl());
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnectionAssertClosed(nc);
                 assertNull(nc.getConnectedUrl());
             }
             assertEquals(1, handler.getEventCount(Events.CLOSED));
@@ -67,10 +68,9 @@ public class ConnectionListenerTests {
                 Connection nc = Nats.connect(options);
                 try {
                     handler.waitForStatusChange(5, TimeUnit.SECONDS);
-                    assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                    assertConnected(nc);
                 } finally {
-                    nc.close();
-                    assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                    closeConnectionAssertClosed(nc);
                     assertEquals(1, handler.getEventCount(Events.DISCOVERED_SERVERS));
                 }
             }
@@ -92,7 +92,7 @@ public class ConnectionListenerTests {
                         build();
                 port = ts.getPort();
                 nc = Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertEquals(ts.getURI(), nc.getConnectedUrl());
                 handler.prepForStatusChange(Events.DISCONNECTED);
             }
@@ -105,13 +105,13 @@ public class ConnectionListenerTests {
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
                 try { Thread.sleep(1000); } catch (InterruptedException e) { /* ignored */ }
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertEquals(1, handler.getEventCount(Events.RECONNECTED));
                 assertEquals(ts.getURI(), nc.getConnectedUrl());
             }
         } finally {
             assertNotNull(nc);
-            nc.close();
+            closeConnectionAssertClosed(nc);
             assertNull(nc.getConnectedUrl());
         }
     }
@@ -126,10 +126,9 @@ public class ConnectionListenerTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnectionAssertClosed(nc);
             }
             assertTrue(((NatsConnection)nc).getNatsStatistics().getExceptions() > 0);
         }

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -94,7 +94,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                allowTimeToConnectAssertOpen(nc, handler);
+                waitThenAssertConnected(nc, handler);
 
                 end = System.nanoTime();
 
@@ -114,7 +114,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -151,7 +151,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RECONNECTED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                allowTimeToConnectAssertOpen(nc, handler);
+                waitThenAssertConnected(nc, handler);
 
                 // Make sure dispatcher and subscription are still there
                 Future<Message> inc = nc.request("dispatchSubject", "test".getBytes(StandardCharsets.UTF_8));
@@ -167,7 +167,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -226,7 +226,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer(customArgs, port, false)) {
-                allowTimeToConnectAssertOpen(nc, handler);
+                waitThenAssertConnected(nc, handler);
 
                 end = System.nanoTime();
 
@@ -247,7 +247,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -305,7 +305,7 @@ public class ReconnectTests {
             assertConnected(nc);
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -334,7 +334,7 @@ public class ReconnectTests {
             assertConnected(nc);
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -365,7 +365,7 @@ public class ReconnectTests {
             assertConnected(nc);
             assertTrue(ts.getURI().endsWith(nc.getConnectedUrl()));
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -505,7 +505,7 @@ public class ReconnectTests {
                 // connect good then bad
                 handler.prepForStatusChange(Events.RESUBSCRIBED);
                 try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                    allowTimeToConnectAssertOpen(nc, handler);
+                    waitThenAssertConnected(nc, handler);
                     handler.prepForStatusChange(Events.DISCONNECTED);
                 }
 
@@ -519,7 +519,7 @@ public class ReconnectTests {
 
                 handler.prepForStatusChange(Events.RESUBSCRIBED);
                 try (NatsServerProtocolMock ts = new NatsServerProtocolMock(receiveMessageCustomizer, port, true)) {
-                    allowTimeToConnectAssertOpen(nc, handler);
+                    waitThenAssertConnected(nc, handler);
                     subRef.get().get();
                     handler.prepForStatusChange(Events.DISCONNECTED);
                     sendRef.get().complete(true);
@@ -530,7 +530,7 @@ public class ReconnectTests {
 
             assertEquals(2 * thrashCount, nc.getNatsStatistics().getReconnects(), "reconnect count");
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -598,7 +598,7 @@ public class ReconnectTests {
             URI uri = options.createURIForServer(nc.getConnectedUrl());
             assertEquals(ts2.getPort(), uri.getPort()); // full uri will have some ip address, just check port
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
             if (ts != null) {
                 ts.close();
             }
@@ -674,7 +674,7 @@ public class ReconnectTests {
                 // Should have thrown an exception if #203 isn't fixed
             }
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -13,11 +13,9 @@
 
 package io.nats.client.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.nats.client.*;
+import io.nats.client.ConnectionListener.Events;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
@@ -28,28 +26,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.Test;
-
-import io.nats.client.Connection;
-import io.nats.client.ConnectionListener;
-import io.nats.client.Dispatcher;
-import io.nats.client.Message;
-import io.nats.client.Nats;
-import io.nats.client.NatsServerProtocolMock;
-import io.nats.client.NatsTestServer;
-import io.nats.client.Options;
-import io.nats.client.Subscription;
-import io.nats.client.TestHandler;
-import io.nats.client.TestSSLUtils;
-import io.nats.client.ConnectionListener.Events;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReconnectTests {
 
     static void flushAndWait(Connection nc, TestHandler handler) {
         try {
             nc.flush(Duration.ofSeconds(2));
-        } catch (Exception exp) {
         }
+        catch (Exception exp) { /* ignored */ }
 
         handler.waitForStatusChange(15, TimeUnit.SECONDS);
     }
@@ -66,8 +51,8 @@ public class ReconnectTests {
         TestHandler handler = new TestHandler();
         int port = NatsTestServer.nextPort();
         Subscription sub;
-        long start = 0;
-        long end = 0;
+        long start;
+        long end;
 
         handler.setPrintExceptions(true);
 
@@ -81,14 +66,12 @@ public class ReconnectTests {
                                     build();
                                     port = ts.getPort();
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                 sub = nc.subscribe("subsubject");
                 
                 final NatsConnection nnc = nc;
-                Dispatcher d = nc.createDispatcher((msg) -> {
-                    nnc.publish(msg.getReplyTo(), msg.getData());
-                });
+                Dispatcher d = nc.createDispatcher((msg) -> nnc.publish(msg.getReplyTo(), msg.getData()) );
                 d.subscribe("dispatchSubject");
                 nc.flush(Duration.ofMillis(1000));
 
@@ -111,7 +94,7 @@ public class ReconnectTests {
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
                 handler.waitForStatusChange(5000, TimeUnit.MILLISECONDS);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                 end = System.nanoTime();
 
@@ -133,7 +116,7 @@ public class ReconnectTests {
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -155,7 +138,7 @@ public class ReconnectTests {
                                     build();
                                     port = ts.getPort();
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 handler.prepForStatusChange(Events.DISCONNECTED);
             }
 
@@ -165,16 +148,14 @@ public class ReconnectTests {
             sub = nc.subscribe("subsubject");
                 
             final NatsConnection nnc = nc;
-            Dispatcher d = nc.createDispatcher((msg) -> {
-                nnc.publish(msg.getReplyTo(), msg.getData());
-            });
+            Dispatcher d = nc.createDispatcher((msg) -> nnc.publish(msg.getReplyTo(), msg.getData()));
             d.subscribe("dispatchSubject");
 
             handler.prepForStatusChange(Events.RECONNECTED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                handler.waitForStatusChange(400, TimeUnit.MILLISECONDS);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                handler.waitForStatusChange(1500, TimeUnit.MILLISECONDS);
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                 // Make sure dispatcher and subscription are still there
                 Future<Message> inc = nc.request("dispatchSubject", "test".getBytes(StandardCharsets.UTF_8));
@@ -192,7 +173,7 @@ public class ReconnectTests {
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -203,8 +184,8 @@ public class ReconnectTests {
         TestHandler handler = new TestHandler();
         int port = NatsTestServer.nextPort();
         Subscription sub;
-        long start = 0;
-        long end = 0;
+        long start;
+        long end;
         String[] customArgs = {"--user","stephen","--pass","password"};
 
         handler.setPrintExceptions(true);
@@ -219,14 +200,12 @@ public class ReconnectTests {
                                     connectionListener(handler).
                                     build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                 sub = nc.subscribe("subsubject");
                 
                 final NatsConnection nnc = nc;
-                Dispatcher d = nc.createDispatcher((msg) -> {
-                    nnc.publish(msg.getReplyTo(), msg.getData());
-                });
+                Dispatcher d = nc.createDispatcher((msg) -> nnc.publish(msg.getReplyTo(), msg.getData()));
                 d.subscribe("dispatchSubject");
                 nc.flush(Duration.ofMillis(1000));
 
@@ -255,7 +234,7 @@ public class ReconnectTests {
 
             try (NatsTestServer ts = new NatsTestServer(customArgs, port, false)) {
                 handler.waitForStatusChange(5000, TimeUnit.MILLISECONDS);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                 end = System.nanoTime();
 
@@ -278,7 +257,7 @@ public class ReconnectTests {
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -298,16 +277,16 @@ public class ReconnectTests {
                                     reconnectWait(Duration.ofMillis(10)).
                                     build();
                 nc = Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 handler.prepForStatusChange(Events.CLOSED);
             }
 
             flushAndWait(nc, handler);
-            assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+            assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -327,19 +306,19 @@ public class ReconnectTests {
                                             maxReconnects(-1).
                                             build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 assertEquals(ts2.getURI(), nc.getConnectedUrl());
                 handler.prepForStatusChange(Events.RECONNECTED);
             }
 
             flushAndWait(nc, handler);
 
-            assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -359,19 +338,19 @@ public class ReconnectTests {
                                             noRandomize().
                                             build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 assertEquals(nc.getConnectedUrl(), ts2.getURI());
                 handler.prepForStatusChange(Events.RECONNECTED);
             }
 
             flushAndWait(nc, handler);
 
-            assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -393,19 +372,19 @@ public class ReconnectTests {
                                             reconnectWait(Duration.ofSeconds(1)).
                                             build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 assertEquals(nc.getConnectedUrl(), ts2.getURI());
                 handler.prepForStatusChange(Events.RECONNECTED);
             }
 
             flushAndWait(nc, handler);
 
-            assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             assertTrue(ts.getURI().endsWith(nc.getConnectedUrl()));
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -426,7 +405,7 @@ public class ReconnectTests {
                                             reconnectWait(Duration.ofSeconds(480)).
                                             build();
                     nc = Nats.connect(options);
-                    assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                    assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                     handler.prepForStatusChange(Events.DISCONNECTED);
                 }
 
@@ -437,7 +416,8 @@ public class ReconnectTests {
                     nc.publish("test", new byte[512]);// Should blow up by the 5th message
                 }
 
-                assertFalse(true);
+                fail();
+
             } finally {
                 if (nc != null) {
                     nc.close();
@@ -462,7 +442,7 @@ public class ReconnectTests {
                                         reconnectWait(Duration.ofSeconds(30)).
                                         build();
                 nc = Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 handler.prepForStatusChange(Events.DISCONNECTED);
             }
 
@@ -495,7 +475,7 @@ public class ReconnectTests {
         AtomicReference<CompletableFuture<Boolean>> sendRef = new AtomicReference<>(sendMsg);
 
         NatsServerProtocolMock.Customizer receiveMessageCustomizer = (ts, r,w) -> {
-            String subLine = "";
+            String subLine;
             
             System.out.println("*** Mock Server @" + ts.getPort() + " waiting for SUB ...");
             try {
@@ -574,7 +554,7 @@ public class ReconnectTests {
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -627,7 +607,7 @@ public class ReconnectTests {
             
             handler.prepForStatusChange(Events.DISCOVERED_SERVERS);
             nc = (NatsConnection) Nats.connect(options);
-            assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             assertEquals(nc.getConnectedUrl(), ts.getURI());
 
             flushAndWait(nc, handler); // make sure we get the new server via info
@@ -637,14 +617,15 @@ public class ReconnectTests {
             ts.close();
             flushAndWait(nc, handler);
 
-            assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+            sleep(2000);
+            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
             URI uri = options.createURIForServer(nc.getConnectedUrl());
             assertEquals(ts2.getPort(), uri.getPort()); // full uri will have some ip address, just check port
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
             if (ts != null) {
                 ts.close();
@@ -666,10 +647,10 @@ public class ReconnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -685,10 +666,10 @@ public class ReconnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             } finally {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
@@ -706,9 +687,9 @@ public class ReconnectTests {
                                     noReconnect().
                                     connectionListener(handler).
                                     build();
-                                    port = ts.getPort();
+
                 nc = (NatsConnection) Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
 
                 for (int i=0;i<100;i++) {
                     // stop and start in a loop without waiting for the future to complete
@@ -723,13 +704,12 @@ public class ReconnectTests {
         } finally {
             if (nc != null) {
                 nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
             }
         }
     }
 
-   
-    private class TestReconnecWaitHandler implements ConnectionListener {
+    private static class TestReconnecWaitHandler implements ConnectionListener {
         int disconnectCount = 0;
 
         public synchronized int getDisconnectCount() {
@@ -766,14 +746,15 @@ public class ReconnectTests {
         Connection c = Nats.connect(options);
         ts.close();
 
-        try {
-            Thread.sleep(250);
-        } catch (Exception exp) {
-        }
+        sleep(250);
 
         assertTrue(trwh.getDisconnectCount() < 3, "disconnectCount");
         
         c.close();
-    }  
+    }
+
+    private void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (Exception exp) { /* ignored */ }
+    }
 
 }

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.nats.client.impl.TestMacros.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ReconnectTests {
@@ -66,7 +67,7 @@ public class ReconnectTests {
                                     build();
                                     port = ts.getPort();
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
 
                 sub = nc.subscribe("subsubject");
                 
@@ -93,8 +94,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                handler.waitForStatusChange(5000, TimeUnit.MILLISECONDS);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                allowTimeToConnect(nc, handler);
 
                 end = System.nanoTime();
 
@@ -114,10 +114,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -138,7 +135,7 @@ public class ReconnectTests {
                                     build();
                                     port = ts.getPort();
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 handler.prepForStatusChange(Events.DISCONNECTED);
             }
 
@@ -154,8 +151,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RECONNECTED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                handler.waitForStatusChange(1500, TimeUnit.MILLISECONDS);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                allowTimeToConnect(nc, handler);
 
                 // Make sure dispatcher and subscription are still there
                 Future<Message> inc = nc.request("dispatchSubject", "test".getBytes(StandardCharsets.UTF_8));
@@ -171,10 +167,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -200,7 +193,7 @@ public class ReconnectTests {
                                     connectionListener(handler).
                                     build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
 
                 sub = nc.subscribe("subsubject");
                 
@@ -233,8 +226,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer(customArgs, port, false)) {
-                handler.waitForStatusChange(5000, TimeUnit.MILLISECONDS);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                allowTimeToConnect(nc, handler);
 
                 end = System.nanoTime();
 
@@ -255,10 +247,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -277,7 +266,7 @@ public class ReconnectTests {
                                     reconnectWait(Duration.ofMillis(10)).
                                     build();
                 nc = Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 handler.prepForStatusChange(Events.CLOSED);
             }
 
@@ -306,20 +295,17 @@ public class ReconnectTests {
                                             maxReconnects(-1).
                                             build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertEquals(ts2.getURI(), nc.getConnectedUrl());
                 handler.prepForStatusChange(Events.RECONNECTED);
             }
 
             flushAndWait(nc, handler);
 
-            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+            assertConnected(nc);
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -338,20 +324,17 @@ public class ReconnectTests {
                                             noRandomize().
                                             build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertEquals(nc.getConnectedUrl(), ts2.getURI());
                 handler.prepForStatusChange(Events.RECONNECTED);
             }
 
             flushAndWait(nc, handler);
 
-            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+            assertConnected(nc);
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -372,20 +355,17 @@ public class ReconnectTests {
                                             reconnectWait(Duration.ofSeconds(1)).
                                             build();
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertEquals(nc.getConnectedUrl(), ts2.getURI());
                 handler.prepForStatusChange(Events.RECONNECTED);
             }
 
             flushAndWait(nc, handler);
 
-            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+            assertConnected(nc);
             assertTrue(ts.getURI().endsWith(nc.getConnectedUrl()));
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -405,7 +385,7 @@ public class ReconnectTests {
                                             reconnectWait(Duration.ofSeconds(480)).
                                             build();
                     nc = Nats.connect(options);
-                    assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                    assertConnected(nc);
                     handler.prepForStatusChange(Events.DISCONNECTED);
                 }
 
@@ -442,7 +422,7 @@ public class ReconnectTests {
                                         reconnectWait(Duration.ofSeconds(30)).
                                         build();
                 nc = Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 handler.prepForStatusChange(Events.DISCONNECTED);
             }
 
@@ -525,8 +505,7 @@ public class ReconnectTests {
                 // connect good then bad
                 handler.prepForStatusChange(Events.RESUBSCRIBED);
                 try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                    handler.waitForStatusChange(10, TimeUnit.SECONDS);
-                    assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                    allowTimeToConnect(nc, handler);
                     handler.prepForStatusChange(Events.DISCONNECTED);
                 }
 
@@ -540,8 +519,7 @@ public class ReconnectTests {
 
                 handler.prepForStatusChange(Events.RESUBSCRIBED);
                 try (NatsServerProtocolMock ts = new NatsServerProtocolMock(receiveMessageCustomizer, port, true)) {
-                    handler.waitForStatusChange(10, TimeUnit.SECONDS);
-                    assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                    allowTimeToConnect(nc, handler);
                     subRef.get().get();
                     handler.prepForStatusChange(Events.DISCONNECTED);
                     sendRef.get().complete(true);
@@ -552,10 +530,7 @@ public class ReconnectTests {
 
             assertEquals(2 * thrashCount, nc.getNatsStatistics().getReconnects(), "reconnect count");
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -607,7 +582,7 @@ public class ReconnectTests {
             
             handler.prepForStatusChange(Events.DISCOVERED_SERVERS);
             nc = (NatsConnection) Nats.connect(options);
-            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+            assertConnected(nc);
             assertEquals(nc.getConnectedUrl(), ts.getURI());
 
             flushAndWait(nc, handler); // make sure we get the new server via info
@@ -618,15 +593,12 @@ public class ReconnectTests {
             flushAndWait(nc, handler);
 
             sleep(2000);
-            assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+            assertConnected(nc);
 
             URI uri = options.createURIForServer(nc.getConnectedUrl());
             assertEquals(ts2.getPort(), uri.getPort()); // full uri will have some ip address, just check port
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
             if (ts != null) {
                 ts.close();
             }
@@ -647,7 +619,7 @@ public class ReconnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
                 nc.close();
                 assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -666,7 +638,7 @@ public class ReconnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
                 nc.close();
                 assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -689,7 +661,7 @@ public class ReconnectTests {
                                     build();
 
                 nc = (NatsConnection) Nats.connect(options);
-                assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertConnected(nc);
 
                 for (int i=0;i<100;i++) {
                     // stop and start in a loop without waiting for the future to complete
@@ -702,10 +674,7 @@ public class ReconnectTests {
                 // Should have thrown an exception if #203 isn't fixed
             }
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -670,7 +670,7 @@ public class ReconnectTests {
                 }
 
                 nc.getWriter().stop();
-                Thread.sleep(1000);
+                sleep(1000);
                 // Should have thrown an exception if #203 isn't fixed
             }
         } finally {
@@ -716,14 +716,8 @@ public class ReconnectTests {
         ts.close();
 
         sleep(250);
-
         assertTrue(trwh.getDisconnectCount() < 3, "disconnectCount");
-        
+
         c.close();
     }
-
-    private void sleep(long ms) {
-        try { Thread.sleep(ms); } catch (Exception exp) { /* ignored */ }
-    }
-
 }

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -94,7 +94,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                allowTimeToConnect(nc, handler);
+                allowTimeToConnectAssertOpen(nc, handler);
 
                 end = System.nanoTime();
 
@@ -114,7 +114,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -151,7 +151,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RECONNECTED);
 
             try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                allowTimeToConnect(nc, handler);
+                allowTimeToConnectAssertOpen(nc, handler);
 
                 // Make sure dispatcher and subscription are still there
                 Future<Message> inc = nc.request("dispatchSubject", "test".getBytes(StandardCharsets.UTF_8));
@@ -167,7 +167,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -226,7 +226,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer(customArgs, port, false)) {
-                allowTimeToConnect(nc, handler);
+                allowTimeToConnectAssertOpen(nc, handler);
 
                 end = System.nanoTime();
 
@@ -247,7 +247,7 @@ public class ReconnectTests {
             assertEquals(1, nc.getNatsStatistics().getReconnects(), "reconnect count");
             assertTrue(nc.getNatsStatistics().getExceptions() > 0, "exception count");
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -305,7 +305,7 @@ public class ReconnectTests {
             assertConnected(nc);
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -334,7 +334,7 @@ public class ReconnectTests {
             assertConnected(nc);
             assertEquals(ts.getURI(), nc.getConnectedUrl());
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -365,7 +365,7 @@ public class ReconnectTests {
             assertConnected(nc);
             assertTrue(ts.getURI().endsWith(nc.getConnectedUrl()));
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -505,7 +505,7 @@ public class ReconnectTests {
                 // connect good then bad
                 handler.prepForStatusChange(Events.RESUBSCRIBED);
                 try (NatsTestServer ts = new NatsTestServer(port, false)) {
-                    allowTimeToConnect(nc, handler);
+                    allowTimeToConnectAssertOpen(nc, handler);
                     handler.prepForStatusChange(Events.DISCONNECTED);
                 }
 
@@ -519,7 +519,7 @@ public class ReconnectTests {
 
                 handler.prepForStatusChange(Events.RESUBSCRIBED);
                 try (NatsServerProtocolMock ts = new NatsServerProtocolMock(receiveMessageCustomizer, port, true)) {
-                    allowTimeToConnect(nc, handler);
+                    allowTimeToConnectAssertOpen(nc, handler);
                     subRef.get().get();
                     handler.prepForStatusChange(Events.DISCONNECTED);
                     sendRef.get().complete(true);
@@ -530,7 +530,7 @@ public class ReconnectTests {
 
             assertEquals(2 * thrashCount, nc.getNatsStatistics().getReconnects(), "reconnect count");
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -598,7 +598,7 @@ public class ReconnectTests {
             URI uri = options.createURIForServer(nc.getConnectedUrl());
             assertEquals(ts2.getPort(), uri.getPort()); // full uri will have some ip address, just check port
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
             if (ts != null) {
                 ts.close();
             }
@@ -674,7 +674,7 @@ public class ReconnectTests {
                 // Should have thrown an exception if #203 isn't fixed
             }
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -42,7 +42,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -61,7 +61,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -79,7 +79,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -96,7 +96,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -113,7 +113,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -130,7 +130,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -146,7 +146,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -177,7 +177,7 @@ public class TLSConnectTests {
                     assertEquals(16, msg.getData().length);
                 }
             } finally {
-                closeConnectionAssertClosed(nc);
+                closeThenAssertClosed(nc);
             }
         }
     }
@@ -211,10 +211,10 @@ public class TLSConnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", newPort, false)) {
-                allowTimeToConnectAssertOpen(nc, handler, 10000);
+                waitThenAssertConnected(nc, handler, 10000);
             }
         } finally {
-            closeConnectionAssertClosed(nc);
+            closeThenAssertClosed(nc);
         }
     }
 
@@ -233,7 +233,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -251,7 +251,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -271,7 +271,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });
@@ -291,7 +291,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnectionAssertClosed(nc);
+                    closeThenAssertClosed(nc);
                 }
             }
         });

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -42,7 +42,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -61,7 +61,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -79,7 +79,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -96,7 +96,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -113,7 +113,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -130,7 +130,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -146,7 +146,7 @@ public class TLSConnectTests {
             try {
                 assertConnected(nc);
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -177,7 +177,7 @@ public class TLSConnectTests {
                     assertEquals(16, msg.getData().length);
                 }
             } finally {
-                closeConnection(nc);
+                closeConnectionAssertClosed(nc);
             }
         }
     }
@@ -211,10 +211,10 @@ public class TLSConnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", newPort, false)) {
-                allowTimeToConnect(nc, handler, 10000);
+                allowTimeToConnectAssertOpen(nc, handler, 10000);
             }
         } finally {
-            closeConnection(nc);
+            closeConnectionAssertClosed(nc);
         }
     }
 
@@ -233,7 +233,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -251,7 +251,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -271,7 +271,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });
@@ -291,7 +291,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    closeConnection(nc);
+                    closeConnectionAssertClosed(nc);
                 }
             }
         });

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -13,30 +13,19 @@
 
 package io.nats.client.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.nats.client.*;
+import io.nats.client.ConnectionListener.Events;
+import io.nats.client.utils.CloseOnUpgradeAttempt;
+import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLContext;
-
-import org.junit.jupiter.api.Test;
-
-import io.nats.client.Connection;
-import io.nats.client.Dispatcher;
-import io.nats.client.Message;
-import io.nats.client.Nats;
-import io.nats.client.NatsTestServer;
-import io.nats.client.Options;
-import io.nats.client.TestHandler;
-import io.nats.client.TestSSLUtils;
-import io.nats.client.ConnectionListener.Events;
-import io.nats.client.utils.CloseOnUpgradeAttempt;
+import static io.nats.client.impl.TestMacros.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TLSConnectTests {
     @Test
@@ -51,10 +40,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -71,10 +59,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -90,10 +77,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -108,10 +94,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -126,10 +111,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -144,10 +128,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -161,10 +144,9 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -181,7 +163,7 @@ public class TLSConnectTests {
                                 build();
             Connection nc = Nats.connect(options);
             try {
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
 
                 Dispatcher d = nc.createDispatcher((msg) -> {
                     nc.publish(msg.getReplyTo(), new byte[16]);
@@ -195,8 +177,7 @@ public class TLSConnectTests {
                     assertEquals(16, msg.getData().length);
                 }
             } finally {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
+                closeConnection(nc);
             }
         }
     }
@@ -221,7 +202,7 @@ public class TLSConnectTests {
                                     reconnectWait(Duration.ofMillis(10)).
                                     build();
                 nc = Nats.connect(options);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                assertConnected(nc);
                 assertTrue(((NatsConnection)nc).getDataPort() instanceof SocketDataPort, "Correct data port class");
                 handler.prepForStatusChange(Events.DISCONNECTED);
             }
@@ -230,14 +211,10 @@ public class TLSConnectTests {
             handler.prepForStatusChange(Events.RESUBSCRIBED);
 
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", newPort, false)) {
-                handler.waitForStatusChange(10, TimeUnit.SECONDS);
-                assertTrue(Connection.Status.CONNECTED == nc.getStatus(), "Connected Status");
+                allowTimeToConnect(nc, handler, 10000);
             }
         } finally {
-            if (nc != null) {
-                nc.close();
-                assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
-            }
+            closeConnection(nc);
         }
     }
 
@@ -256,10 +233,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -277,10 +251,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -300,10 +271,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });
@@ -323,10 +291,7 @@ public class TLSConnectTests {
                 try {
                     nc = Nats.connect(options);
                 } finally {
-                    if (nc != null) {
-                        nc.close();
-                        assertTrue(Connection.Status.CLOSED == nc.getStatus(), "Closed Status");
-                    }
+                    closeConnection(nc);
                 }
             }
         });

--- a/src/test/java/io/nats/client/impl/TestMacros.java
+++ b/src/test/java/io/nats/client/impl/TestMacros.java
@@ -13,7 +13,6 @@ public final class TestMacros {
     // ----------------------------------------------------------------------------------------------------
     // assertions
     // ----------------------------------------------------------------------------------------------------
-
     public static void assertConnected(Connection conn) {
         assertSame(Connection.Status.CONNECTED, conn.getStatus(), "Connected Status");
     }
@@ -37,16 +36,16 @@ public final class TestMacros {
     // ----------------------------------------------------------------------------------------------------
     // macro utils
     // ----------------------------------------------------------------------------------------------------
-    public static void allowTimeToConnectAssertOpen(Connection conn, TestHandler handler) {
-        allowTimeToConnectAssertOpen(conn, handler, 5000);
+    public static void waitThenAssertConnected(Connection conn, TestHandler handler) {
+        waitThenAssertConnected(conn, handler, 5000);
     }
 
-    public static void allowTimeToConnectAssertOpen(Connection conn, TestHandler handler, long millis) {
+    public static void waitThenAssertConnected(Connection conn, TestHandler handler, long millis) {
         handler.waitForStatusChange(millis, TimeUnit.MILLISECONDS);
         assertConnected(conn);
     }
 
-    public static void closeConnectionAssertClosed(Connection conn) {
+    public static void closeThenAssertClosed(Connection conn) {
         if (conn != null) {
             try {
                 conn.close();

--- a/src/test/java/io/nats/client/impl/TestMacros.java
+++ b/src/test/java/io/nats/client/impl/TestMacros.java
@@ -6,6 +6,7 @@ import io.nats.client.TestHandler;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public final class TestMacros {
 
@@ -25,7 +26,12 @@ public final class TestMacros {
     // utils
     // ----------------------------------------------------------------------------------------------------
     public static void sleep(long ms) {
-        try { Thread.sleep(ms); } catch (InterruptedException e) { /* ignored */ }
+        try {
+            Thread.sleep(ms);
+        }
+        catch (InterruptedException e) {
+            fail(e); // will never happen, but if it does...
+        }
     }
 
     // ----------------------------------------------------------------------------------------------------
@@ -40,10 +46,14 @@ public final class TestMacros {
         assertConnected(conn);
     }
 
-    public static void closeConnectionAssertClosed(Connection conn) throws InterruptedException {
+    public static void closeConnectionAssertClosed(Connection conn) {
         if (conn != null) {
-            conn.close();
-            assertClosed(conn);
+            try {
+                conn.close();
+                assertClosed(conn);
+            } catch (InterruptedException e) {
+                fail(e); // will never happen, but if it does...
+            }
         }
     }
 }

--- a/src/test/java/io/nats/client/impl/TestMacros.java
+++ b/src/test/java/io/nats/client/impl/TestMacros.java
@@ -5,37 +5,45 @@ import io.nats.client.TestHandler;
 
 import java.util.concurrent.TimeUnit;
 
-import static java.lang.Thread.sleep;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public final class TestMacros {
 
-    public static void assertConnected(Connection nc) {
-        assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+    // ----------------------------------------------------------------------------------------------------
+    // assertions
+    // ----------------------------------------------------------------------------------------------------
+
+    public static void assertConnected(Connection conn) {
+        assertSame(Connection.Status.CONNECTED, conn.getStatus(), "Connected Status");
     }
 
-    public static void assertClosed(Connection nc) {
-        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+    public static void assertClosed(Connection conn) {
+        assertSame(Connection.Status.CLOSED, conn.getStatus(), "Closed Status");
     }
 
-    public static void allowTimeToConnect(Connection nc, TestHandler handler) {
-        allowTimeToConnect(nc, handler, 5000);
+    // ----------------------------------------------------------------------------------------------------
+    // utils
+    // ----------------------------------------------------------------------------------------------------
+    public static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException e) { /* ignored */ }
     }
 
-    public static void allowTimeToConnect(Connection nc, TestHandler handler, long millis) {
+    // ----------------------------------------------------------------------------------------------------
+    // macro utils
+    // ----------------------------------------------------------------------------------------------------
+    public static void allowTimeToConnectAssertOpen(Connection conn, TestHandler handler) {
+        allowTimeToConnectAssertOpen(conn, handler, 5000);
+    }
+
+    public static void allowTimeToConnectAssertOpen(Connection conn, TestHandler handler, long millis) {
         handler.waitForStatusChange(millis, TimeUnit.MILLISECONDS);
-        assertConnected(nc);
+        assertConnected(conn);
     }
 
-    public static void allowTimeToConnect(Connection nc, long ms) throws InterruptedException {
-        sleep(ms);
-        assertConnected(nc);
-    }
-
-    public static void closeConnection(Connection nc) throws InterruptedException {
-        if (nc != null) {
-            nc.close();
-            assertClosed(nc);
+    public static void closeConnectionAssertClosed(Connection conn) throws InterruptedException {
+        if (conn != null) {
+            conn.close();
+            assertClosed(conn);
         }
     }
 }

--- a/src/test/java/io/nats/client/impl/TestMacros.java
+++ b/src/test/java/io/nats/client/impl/TestMacros.java
@@ -1,0 +1,41 @@
+package io.nats.client.impl;
+
+import io.nats.client.Connection;
+import io.nats.client.TestHandler;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.Thread.sleep;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public final class TestMacros {
+
+    public static void assertConnected(Connection nc) {
+        assertSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+    }
+
+    public static void assertClosed(Connection nc) {
+        assertSame(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+    }
+
+    public static void allowTimeToConnect(Connection nc, TestHandler handler) {
+        allowTimeToConnect(nc, handler, 5000);
+    }
+
+    public static void allowTimeToConnect(Connection nc, TestHandler handler, long millis) {
+        handler.waitForStatusChange(millis, TimeUnit.MILLISECONDS);
+        assertConnected(nc);
+    }
+
+    public static void allowTimeToConnect(Connection nc, long ms) throws InterruptedException {
+        sleep(ms);
+        assertConnected(nc);
+    }
+
+    public static void closeConnection(Connection nc) throws InterruptedException {
+        if (nc != null) {
+            nc.close();
+            assertClosed(nc);
+        }
+    }
+}


### PR DESCRIPTION
These test are flappers, failing because of timeout. But they are not testing timing, they are testing state, so timeout should not matter.

While I was in these files... nit fixed to use assertSame when testing connection status / enums