### PR TITLE
Add a flushBuffer API

### DIFF
--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -13,6 +13,7 @@
 
 package io.nats.client;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -384,8 +385,10 @@ public interface Connection extends AutoCloseable {
 
     /**
      * Immediately flushes the underlying connection buffer if the connection is valid.
+     * @throws IOException the connection flush fails
+     * @throws IllegalStateException the connection is not connected
      */
-    public void flushBuffer();
+    public void flushBuffer() throws IOException;
 
     /**
      * Gets a context for publishing and subscribing to subjects backed by Jetstream streams

--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -383,6 +383,11 @@ public interface Connection extends AutoCloseable {
     public String createInbox();
 
     /**
+     * Immediately flushes the underlying connection buffer if the connection is valid.
+     */
+    public void flushBuffer();
+
+    /**
      * Gets a context for publishing and subscribing to subjects backed by Jetstream streams
      * and consumers.
      * @return a JetStream instance.

--- a/src/main/java/io/nats/client/impl/DataPort.java
+++ b/src/main/java/io/nats/client/impl/DataPort.java
@@ -36,4 +36,6 @@ public interface DataPort {
     public void write(byte[] src, int toWrite) throws IOException;
 
     public void close() throws IOException;
+
+    public void flush() throws IOException;
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1868,16 +1868,12 @@ class NatsConnection implements Connection {
     }
 
     @Override
-    public void flushBuffer() {
+    public void flushBuffer() throws IOException {
         if (!isConnected()) {
-            return;
+            throw new IllegalStateException("Connection is not active.");
         }
 
-        try  {
-            dataPort.flush();
-        } catch (Exception e) {
-            // NOOP
-        }
+        dataPort.flush();
     }
 
     @Override

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1868,6 +1868,19 @@ class NatsConnection implements Connection {
     }
 
     @Override
+    public void flushBuffer() {
+        if (!isConnected()) {
+            return;
+        }
+
+        try  {
+            dataPort.flush();
+        } catch (Exception e) {
+            // NOOP
+        }
+    }
+
+    @Override
     public JetStream jetStream() throws InterruptedException, TimeoutException {
         return jetStream(null);
     }

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -29,6 +29,9 @@ import javax.net.ssl.SSLSocketFactory;
 
 import io.nats.client.Options;
 
+/**
+ * This class is not theadsafe.  Caller must ensure thread safety.
+ */
 public class SocketDataPort implements DataPort {
 
     private NatsConnection connection;
@@ -111,5 +114,9 @@ public class SocketDataPort implements DataPort {
         } else {
             socket.close();
         }
+    }
+
+    public void flush() throws IOException {
+        out.flush();
     }
 }

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static io.nats.client.impl.TestMacros.*;
@@ -149,10 +150,11 @@ public class ConnectTests {
 
     @Test
     public void testConnectionFailureWithFallback() throws IOException, InterruptedException {
-        
+
         try (NatsTestServer ts = new NatsTestServer(false)) {
             try (NatsServerProtocolMock fake = new NatsServerProtocolMock(ExitAt.EXIT_AFTER_PING)) {
-                Options options = new Options.Builder().connectionTimeout(Duration.ofSeconds(5)).server(fake.getURI()).server(ts.getURI()).build();
+                Options options = new Options.Builder().connectionTimeout(Duration.ofSeconds(5)).server(fake.getURI())
+                        .server(ts.getURI()).build();
                 Connection nc = Nats.connect(options);
                 try {
                     assertConnected(nc);
@@ -197,7 +199,7 @@ public class ConnectTests {
                 int two = 0;
 
                 // should get at least 1 for each
-                for (int i=0; i < 10; i++) {
+                for (int i = 0; i < 10; i++) {
                     Connection nc = Nats.connect(ts1.getURI() + "," + ts2.getURI());
                     try {
                         assertConnected(nc);
@@ -226,8 +228,8 @@ public class ConnectTests {
                 int two = 0;
 
                 // should get at least 1 for each
-                for (int i=0; i < 10; i++) {
-                    String[] servers = {ts1.getURI(), ts2.getURI()};
+                for (int i = 0; i < 10; i++) {
+                    String[] servers = { ts1.getURI(), ts2.getURI() };
                     Options options = new Options.Builder().noRandomize().servers(servers).build();
                     Connection nc = Nats.connect(options);
                     try {
@@ -313,18 +315,15 @@ public class ConnectTests {
             }
         });
     }
-    
+
     @Test
     public void testAsyncConnection() throws IOException, InterruptedException {
         TestHandler handler = new TestHandler();
         Connection nc = null;
 
         try (NatsTestServer ts = new NatsTestServer(false)) {
-            Options options = new Options.Builder().
-                                        server(ts.getURI()).
-                                        connectionListener(handler).
-                                        build();
-           handler.prepForStatusChange(Events.CONNECTED);
+            Options options = new Options.Builder().server(ts.getURI()).connectionListener(handler).build();
+            handler.prepForStatusChange(Events.CONNECTED);
 
             Nats.connectAsynchronously(options, false);
 
@@ -339,19 +338,15 @@ public class ConnectTests {
             }
         }
     }
-    
+
     @Test
     public void testAsyncConnectionWithReconnect() throws IOException, InterruptedException {
         TestHandler handler = new TestHandler();
         Connection nc = null;
         int port = NatsTestServer.nextPort();
-        Options options = new Options.Builder().
-                                server("nats://localhost:"+port).
-                                maxReconnects(-1).
-                                reconnectWait(Duration.ofMillis(100)).
-                                connectionListener(handler).
-                                build();
-        
+        Options options = new Options.Builder().server("nats://localhost:" + port).maxReconnects(-1)
+                .reconnectWait(Duration.ofMillis(100)).connectionListener(handler).build();
+
         try {
             Nats.connectAsynchronously(options, true);
 
@@ -368,28 +363,22 @@ public class ConnectTests {
             closeThenAssertClosed(nc);
         }
     }
-    
+
     @Test
     public void testThrowOnAsyncWithoutListener() {
         assertThrows(IllegalArgumentException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer(false)) {
-                Options options = new Options.Builder().
-                                            server(ts.getURI()).
-                                            build();
+                Options options = new Options.Builder().server(ts.getURI()).build();
                 Nats.connectAsynchronously(options, false);
             }
         });
     }
-    
+
     @Test
     public void testErrorOnAsync() throws IOException, InterruptedException {
         TestHandler handler = new TestHandler();
-        Options options = new Options.Builder().
-                                    server("nats://localhost:"+NatsTestServer.nextPort()).
-                                    connectionListener(handler).
-                                    errorListener(handler).
-                                    noReconnect().
-                                    build();
+        Options options = new Options.Builder().server("nats://localhost:" + NatsTestServer.nextPort())
+                .connectionListener(handler).errorListener(handler).noReconnect().build();
         handler.prepForStatusChange(Events.CLOSED);
         Nats.connectAsynchronously(options, false);
         handler.waitForStatusChange(10, TimeUnit.SECONDS);
@@ -402,12 +391,9 @@ public class ConnectTests {
     public void testConnectionTimeout() {
         assertThrows(IOException.class, () -> {
             try (NatsServerProtocolMock ts = new NatsServerProtocolMock(ExitAt.SLEEP_BEFORE_INFO)) { // will sleep for 3
-                Options options = new Options.Builder().
-                                            server(ts.getURI()).
-                                            noReconnect().
-                                            traceConnection().
-                                            connectionTimeout(Duration.ofSeconds(2)). // 2 is also the default but explicit for test
-                                            build();
+                Options options = new Options.Builder().server(ts.getURI()).noReconnect().traceConnection()
+                        .connectionTimeout(Duration.ofSeconds(2)). // 2 is also the default but explicit for test
+                build();
                 Connection nc = Nats.connect(options);
                 assertNotSame(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
             }
@@ -417,11 +403,9 @@ public class ConnectTests {
     @Test
     public void testSlowConnectionNoTimeout() throws IOException, InterruptedException {
         try (NatsServerProtocolMock ts = new NatsServerProtocolMock(ExitAt.SLEEP_BEFORE_INFO)) {
-            Options options = new Options.Builder().
-                                        server(ts.getURI()).
-                                        noReconnect().
-                                        connectionTimeout(Duration.ofSeconds(6)). // longer than the sleep
-                                        build();
+            Options options = new Options.Builder().server(ts.getURI()).noReconnect()
+                    .connectionTimeout(Duration.ofSeconds(6)). // longer than the sleep
+                    build();
             Connection nc = Nats.connect(options);
             try {
                 assertConnected(nc);
@@ -430,14 +414,11 @@ public class ConnectTests {
             }
         }
     }
-    
+
     @Test
     public void testTimeCheckCoverage() throws IOException, InterruptedException {
         try (NatsTestServer ts = new NatsTestServer(Options.DEFAULT_PORT, false)) {
-            Options options = new Options.Builder().
-                                        server(ts.getURI()).
-                                        traceConnection().
-                                        build();
+            Options options = new Options.Builder().server(ts.getURI()).traceConnection().build();
             Connection nc = Nats.connect(options);
             try {
                 assertConnected(nc);
@@ -456,4 +437,88 @@ public class ConnectTests {
             assertTrue(e.getMessage().contains("testserver.alsonotnats:4223"));
         }
     }
+
+    @Test
+    public void testFlushBuffer() throws IOException, InterruptedException {
+        try (NatsTestServer ts = new NatsTestServer(Options.DEFAULT_PORT, false)) {
+            Connection nc = Nats.connect(ts.getURI());
+            try {
+                assertConnected(nc);
+
+                // test connected
+                nc.flushBuffer();
+
+                ts.shutdown();
+                sleep(100);
+
+                // test while reconnecting
+                nc.flushBuffer();
+            } finally {
+                closeThenAssertClosed(nc);
+                // test when closed.
+                nc.flushBuffer();
+            }
+        }
+    }
+
+    @Test
+    public void testFlushBufferThreadSafety() throws IOException, InterruptedException {
+        try (NatsTestServer ts = new NatsTestServer(Options.DEFAULT_PORT, false)) {
+            Connection nc = Nats.connect(ts.getURI());
+            try {
+                assertConnected(nc);
+
+                // use two latches to sync the threads as close as
+                // possible.
+                CountDownLatch pubLatch = new CountDownLatch(1);
+                CountDownLatch flushLatch = new CountDownLatch(1);
+                CountDownLatch completedLatch = new CountDownLatch(1);
+
+
+                Thread t = new Thread("publisher") {
+                    public void run() {
+                        byte[] payload = new byte[5];
+                        pubLatch.countDown();
+                        try {
+                            flushLatch.await(2, TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            // NOOP
+                        }
+                        for (int i = 1; i <= 50000; i++) {
+                            nc.publish("foo", payload);
+                            if (i % 2000 == 0) {
+                                nc.flushBuffer();
+                            }
+                        }
+                        completedLatch.countDown();
+                    }
+                };
+                
+                t.start();
+
+                // sync up the current thread and the publish thread
+                // to get the most out of the test.
+                try {
+                   pubLatch.await(2, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    // NOOP
+                }
+                flushLatch.countDown();
+
+                // flush as fast as we can while the publisher
+                // is publishing.
+                while (t.isAlive()) {
+                    nc.flushBuffer();
+                }
+
+                // cleanup and doublecheck the thread is done.
+                t.join(2000);
+
+                // make sure the publisher actually completed.
+                assertTrue(completedLatch.await(10, TimeUnit.SECONDS));
+            } finally {
+                closeThenAssertClosed(nc);
+            }
+        }
+    }     
 }


### PR DESCRIPTION
This PR adds a flush buffer API to flush the underlying socket (through the socket output stream).

I did use a synchronized API on the connection writer because research seemed to indicate the best performance with a smaller number of threads - at least in older versions of java.  It also fit well with the current architecture since there is no connection level locking.  Instead publish synchronization resolves around the message writer and message queue.  There's a small chance when publishing and immediately doing a flushBuffer, the flushBuffer will beat the message writer, but without major surgery I'm not sure how to fix that.

Regardless, I was able to exceed capacity of the underlying message queue unless I flushed in the test itself so performance doesn't seem to be impacted much.

CC /@scottf @RichardHightower 

Signed-off-by: Colin Sullivan <colin@synadia.com>