### PR TITLE
get the validation right

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -250,7 +250,7 @@ public class NatsJetStream implements JetStream {
 
     @Override
     public ConsumerInfo addConsumer(String stream, ConsumerConfiguration config) throws InterruptedException, IOException, TimeoutException {
-        validateSubjectStrict(stream);
+        validateStreamName(stream);
         validateNotNull(config, "config");
         return addConsumer(null, stream, config);
     }
@@ -258,7 +258,7 @@ public class NatsJetStream implements JetStream {
     private ConsumerInfo addConsumer(String subject, String stream, ConsumerConfiguration config) throws InterruptedException, IOException, TimeoutException {
         validateStreamName(stream);
         validateNotNull(config, "config");
-        if (subject != null) {
+        if (provided(subject)) {
             config.setDeliverSubject(subject);
         }
         return createOrUpdateConsumer(stream, config);
@@ -503,20 +503,20 @@ public class NatsJetStream implements JetStream {
 
     @Override
     public JetStreamSubscription subscribe(String subject) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         return createSubscription(subject, null, null, null, SubscribeOptions.builder().build());
     }
 
     @Override
     public JetStreamSubscription subscribe(String subject, SubscribeOptions options) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         validateNotNull(options, "options");
         return createSubscription(subject, null, null, null, options);
     }
 
     @Override
     public JetStreamSubscription subscribe(String subject, String queue, SubscribeOptions options) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         validateQueueName(queue);
         validateNotNull(options, "options");
         return createSubscription(subject, queue, null, null, options);
@@ -524,7 +524,7 @@ public class NatsJetStream implements JetStream {
 
     @Override
     public JetStreamSubscription subscribe(String subject, Dispatcher dispatcher, MessageHandler handler) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         validateNotNull(dispatcher, "dispatcher");
         validateNotNull(handler, "handler");
         return createSubscription(subject, null, (NatsDispatcher) dispatcher, handler, null);
@@ -532,7 +532,7 @@ public class NatsJetStream implements JetStream {
 
     @Override
     public JetStreamSubscription subscribe(String subject, Dispatcher dispatcher, MessageHandler handler, SubscribeOptions options) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         validateNotNull(dispatcher, "dispatcher");
         validateNotNull(handler, "handler");
         validateNotNull(options, "options");
@@ -541,7 +541,7 @@ public class NatsJetStream implements JetStream {
 
     @Override
     public JetStreamSubscription subscribe(String subject, String queue, Dispatcher dispatcher, MessageHandler handler) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         validateQueueName(queue);
         validateNotNull(dispatcher, "dispatcher");
         validateNotNull(handler, "handler");
@@ -550,7 +550,7 @@ public class NatsJetStream implements JetStream {
 
     @Override
     public JetStreamSubscription subscribe(String subject, String queue, Dispatcher dispatcher, MessageHandler handler, SubscribeOptions options) throws InterruptedException, TimeoutException, IOException {
-        validateSubjectStrict(subject);
+        validateJsSubscribeSubject(subject);
         validateQueueName(queue);
         validateNotNull(dispatcher, "dispatcher");
         validateNotNull(handler, "handler");

--- a/src/main/java/io/nats/client/impl/NatsMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsMessage.java
@@ -26,8 +26,8 @@ import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 
 import static io.nats.client.support.NatsConstants.*;
+import static io.nats.client.support.Validator.validateMessageSubject;
 import static io.nats.client.support.Validator.validateReplyTo;
-import static io.nats.client.support.Validator.validateSubject;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -79,7 +79,7 @@ public class NatsMessage implements Message {
     // Create a message to publish
     public NatsMessage(String subject, String replyTo, Headers headers, byte[] data, boolean utf8mode) {
 
-        validateSubject(subject);
+        validateMessageSubject(subject);
         validateReplyTo(replyTo);
 
         this.subject = subject;

--- a/src/main/java/io/nats/client/support/Validator.java
+++ b/src/main/java/io/nats/client/support/Validator.java
@@ -19,26 +19,24 @@ public class Validator {
 
     static final Pattern STREAM_PATTERN = Pattern.compile("^[a-zA-Z0-9-]+$");
 
-    public static String validateSubject(String s) {
+    public static String validateMessageSubject(String s) {
         if (nullOrEmpty(s)) {
             throw new IllegalArgumentException("Subject cannot be null or empty.");
         }
         return s;
     }
 
-    public static String validateSubjectStrict(String s) {
-        if (nullOrEmpty(s) || notStrict(s)) {
-            throw new IllegalArgumentException("Subject cannot be null or empty or have whitespace, '.', '>' or '*'.");
+    public static String validateJsSubscribeSubject(String s) {
+        if (provided(s) && containsWhitespace(s)) {
+            throw new IllegalArgumentException("Subject cannot have whitespace if provided.");
         }
-
         return s;
     }
 
     public static String validateQueueName(String s) {
-        if (nullOrEmpty(s)) {
-            throw new IllegalArgumentException("Queue name cannot be null or empty or have whitespace.");
+        if (nullOrEmpty(s) || containsWhitespace(s)) {
+            throw new IllegalArgumentException("Queue cannot be null or empty or have whitespace.");
         }
-
         return s;
     }
 
@@ -50,8 +48,8 @@ public class Validator {
     }
 
     public static String validateStreamName(String s) {
-        if (s != null && doesNotMatch(STREAM_PATTERN, s)) {
-            throw new IllegalArgumentException("Stream is required and must be alpha, numeric or dash.");
+        if (nullOrEmpty(s) || doesNotMatch(STREAM_PATTERN, s)) {
+            throw new IllegalArgumentException("Stream cannot be null or empty and must be alpha, numeric or dash.");
         }
         return s;
     }
@@ -110,6 +108,10 @@ public class Validator {
         return !pattern.matcher(stream).matches();
     }
 
+    public static boolean provided(String s) {
+        return s != null && s.length() > 0;
+    }
+
     public static boolean nullOrEmpty(String s) {
         return s == null || s.length() == 0;
     }
@@ -121,16 +123,6 @@ public class Validator {
     public static boolean containsWhitespace(String s) {
         for (int i = 0; i < s.length(); i++){
             if (Character.isWhitespace(s.charAt(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static boolean notStrict(String s) {
-        for (int i = 0; i < s.length(); i++){
-            char c = s.charAt(i);
-            if (c == '.' || c == '*' || c == '>' || Character.isWhitespace(c)) {
                 return true;
             }
         }

--- a/src/test/java/io/nats/client/support/ValidatorTests.java
+++ b/src/test/java/io/nats/client/support/ValidatorTests.java
@@ -30,15 +30,21 @@ public class ValidatorTests {
     private static final String HAS_GT    = "has>gt";
 
     @Test
-    public void testValidateSubject() {
-        allowed(Validator::validateSubject, PLAIN, HAS_SPACE, HAS_DASH, HAS_DOT, HAS_STAR, HAS_GT);
-        notAllowed(Validator::validateSubject, null, EMPTY);
+    public void testValidateMessageSubject() {
+        allowed(Validator::validateMessageSubject, PLAIN, HAS_SPACE, HAS_DASH, HAS_DOT, HAS_STAR, HAS_GT);
+        notAllowed(Validator::validateMessageSubject, null, EMPTY);
     }
 
     @Test
-    public void testValidateSubjectStrict() {
-        allowed(Validator::validateSubjectStrict, PLAIN, HAS_DASH);
-        notAllowed(Validator::validateSubjectStrict, null, EMPTY, HAS_SPACE, HAS_DOT, HAS_STAR, HAS_GT);
+    public void testValidateJsSubscribeSubject() {
+        allowed(Validator::validateJsSubscribeSubject, null, EMPTY, PLAIN, HAS_DASH, HAS_DOT, HAS_STAR, HAS_GT);
+        notAllowed(Validator::validateJsSubscribeSubject, HAS_SPACE);
+    }
+
+    @Test
+    public void testValidateQueueName() {
+        allowed(Validator::validateQueueName, PLAIN, HAS_DASH, HAS_DOT, HAS_STAR, HAS_GT);
+        notAllowed(Validator::validateQueueName, null, EMPTY, HAS_SPACE);
     }
 
     @Test
@@ -49,8 +55,8 @@ public class ValidatorTests {
 
     @Test
     public void testValidateStreamName() {
-        allowed(Validator::validateStreamName, null, PLAIN, HAS_DASH);
-        notAllowed(Validator::validateStreamName, EMPTY, HAS_SPACE, HAS_DOT, HAS_STAR, HAS_GT);
+        allowed(Validator::validateStreamName, PLAIN, HAS_DASH);
+        notAllowed(Validator::validateStreamName, null, EMPTY, HAS_SPACE, HAS_DOT, HAS_STAR, HAS_GT);
     }
 
     @Test
@@ -82,14 +88,12 @@ public class ValidatorTests {
 
     private void allowed(StringTest test, String... strings) {
         for (String s : strings) {
-            System.out.println("OK [" + s + "]");
             assertEquals(s, test.validate(s));
         }
     }
 
     private void notAllowed(StringTest test, String... strings) {
         for (String s : strings) {
-            System.out.println("NOT [" + s + "]");
             assertThrows(IllegalArgumentException.class, () -> test.validate(s));
         }
     }


### PR DESCRIPTION
NatsMesasage: 
. . . . subject is required, but no other checks

NatsJetStream.addConsumer:
. . . . subject: No subject check, it's not required
. . . . stream:, required, alphanum or dash `^[a-zA-Z0-9-]+$`

NatsJetStream.subscribe:
. . . . subject: not required but if provided cannot contain whitepsace
. . . . queue: required and cannot contain whitespace
