### PR TITLE
340 tls opentls multiple servers in url string / array

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -1337,19 +1337,21 @@ public class Options {
             
             if (servers.size() == 0) {
                 server(DEFAULT_URL);
-            } else if (servers.size() == 1) { // Allow some URI based configs
-                URI serverURI = servers.get(0);
-
-                if (TLS_PROTOCOL.equals(serverURI.getScheme()) && this.sslContext == null)
-                {
-                    try {
-                        this.sslContext = SSLContext.getDefault();
-                    } catch (NoSuchAlgorithmException e) {
-                        throw new IllegalStateException("Unable to create default SSL context", e);
+            }
+            else if (sslContext == null) {
+                for (URI serverURI : servers) {
+                    if (TLS_PROTOCOL.equals(serverURI.getScheme())) {
+                        try {
+                            this.sslContext = SSLContext.getDefault();
+                        } catch (NoSuchAlgorithmException e) {
+                            throw new IllegalStateException("Unable to create default SSL context", e);
+                        }
+                        break;
                     }
-                } else if (OPENTLS_PROTOCOL.equals(serverURI.getScheme()) && this.sslContext == null)
-                {
-                    this.sslContext = SSLUtils.createOpenTLSContext();
+                    else if (OPENTLS_PROTOCOL.equals(serverURI.getScheme())) {
+                        this.sslContext = SSLUtils.createOpenTLSContext();
+                        break;
+                    }
                 }
             }
 

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -33,12 +33,43 @@ public class TLSConnectTests {
         //System.setProperty("javax.net.debug", "all");
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             SSLContext ctx = TestSSLUtils.createTestSSLContext();
-            Options options = new Options.Builder().
-                                server(ts.getURI()).
-                                maxReconnects(0).
-                                sslContext(ctx).
-                                build();
-            assertCanConnect(options);
+            Options options = new Options.Builder()
+                    .server(ts.getURI())
+                    .maxReconnects(0)
+                    .sslContext(ctx)
+                    .build();
+            assertCanConnectAndPubSub(options);
+        }
+    }
+
+    @Test
+    public void testSimpleUrlTLSConnection() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder()
+                    .server(convertToProtocol("tls", ts))
+                    .maxReconnects(0)
+                    .sslContext(ctx)
+                    .build();
+            assertCanConnectAndPubSub(options);
+        }
+    }
+
+    @Test
+    public void testMultipleUrlTLSConnectionSetContext() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer server1 = new NatsTestServer("src/test/resources/tls.conf", false);
+             NatsTestServer server2 = new NatsTestServer("src/test/resources/tls.conf", false);
+        ) {
+            String servers = convertToProtocol("tls", server1, server2);
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder()
+                    .server(servers)
+                    .maxReconnects(0)
+                    .sslContext(ctx)
+                    .build();
+            assertCanConnectAndPubSub(options);
         }
     }
 
@@ -52,7 +83,7 @@ public class TLSConnectTests {
                                 maxReconnects(0).
                                 sslContext(ctx).
                                 build();
-            assertCanConnect(options);
+            assertCanConnectAndPubSub(options);
         }
     }
 
@@ -65,7 +96,7 @@ public class TLSConnectTests {
                                 maxReconnects(0).
                                 sslContext(ctx).
                                 build();
-            assertCanConnect(options);
+            assertCanConnectAndPubSub(options);
         }
     }
 
@@ -77,7 +108,7 @@ public class TLSConnectTests {
                                 maxReconnects(0).
                                 opentls().
                                 build();
-            assertCanConnect(options);
+            assertCanConnectAndPubSub(options);
         }
     }
 
@@ -89,7 +120,7 @@ public class TLSConnectTests {
                                 sslContext(TestSSLUtils.createTestSSLContext()). // override the custom one
                                 maxReconnects(0).
                                 build();
-            assertCanConnect(options);
+            assertCanConnectAndPubSub(options);
         }
     }
 
@@ -101,18 +132,33 @@ public class TLSConnectTests {
                                 sslContext(TestSSLUtils.createTestSSLContext()). // override the custom one
                                 maxReconnects(0).
                                 build();
-            assertCanConnect(options);
+            assertCanConnectAndPubSub(options);
         }
     }
 
     @Test
     public void testURISchemeOpenTLSConnection() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
-            Options options = new Options.Builder().
-                                server("opentls://localhost:"+ts.getPort()).
-                                maxReconnects(0).
-                                build();
-            assertCanConnect(options);
+            Options options = new Options.Builder()
+                                .server(convertToProtocol("opentls", ts))
+                                .maxReconnects(0)
+                                .build();
+            assertCanConnectAndPubSub(options);
+        }
+    }
+
+    @Test
+    public void testMultipleUrlOpenTLSConnection() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer server1 = new NatsTestServer("src/test/resources/tls.conf", false);
+             NatsTestServer server2 = new NatsTestServer("src/test/resources/tls.conf", false);
+        ) {
+            String servers = convertToProtocol("opentls", server1, server2);
+            Options options = new Options.Builder()
+                    .server(servers)
+                    .maxReconnects(0)
+                    .build();
+            assertCanConnectAndPubSub(options);
         }
     }
 

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -28,6 +28,18 @@ import static io.nats.client.utils.TestBase.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TLSConnectTests {
+
+    private String convertToProtocol(String proto, NatsTestServer... servers) {
+        StringBuilder sb = new StringBuilder();
+        for (int x = 0; x < servers.length; x++) {
+            if (x > 0) {
+                sb.append(",");
+            }
+            sb.append(proto).append("://localhost:").append(servers[0].getPort());
+        }
+        return sb.toString();
+    }
+
     @Test
     public void testSimpleTLSConnection() throws Exception {
         //System.setProperty("javax.net.debug", "all");

--- a/src/test/java/io/nats/client/utils/TestBase.java
+++ b/src/test/java/io/nats/client/utils/TestBase.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 
+import static io.nats.examples.ExampleUtils.uniqueEnough;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TestBase {
@@ -191,6 +192,24 @@ public class TestBase {
         standardCloseConnection( standardConnection(options) );
     }
 
+    public static void assertCanConnectAndPubSub() throws IOException, InterruptedException {
+        Connection conn = standardConnection();
+        assertPubSub(conn);
+        standardCloseConnection(conn);
+    }
+
+    public static void assertCanConnectAndPubSub(String serverURL) throws IOException, InterruptedException {
+        Connection conn = standardConnection(serverURL);
+        assertPubSub(conn);
+        standardCloseConnection(conn);
+    }
+
+    public static void assertCanConnectAndPubSub(Options options) throws IOException, InterruptedException {
+        Connection conn = standardConnection(options);
+        assertPubSub(conn);
+        standardCloseConnection(conn);
+    }
+
     public static void assertByteArraysEqual(byte[] data1, byte[] data2) {
         if (data1 == null) {
             assertNull(data2);
@@ -201,6 +220,16 @@ public class TestBase {
         for (int x = 0; x < data1.length; x++) {
             assertEquals(data1[x], data2[x]);
         }
+    }
+
+    public static void assertPubSub(Connection conn) throws InterruptedException {
+        String subject = "sub" + uniqueEnough();
+        String data = "data" + uniqueEnough();
+        Subscription sub = conn.subscribe(subject);
+        conn.publish(subject, data.getBytes());
+        Message m = sub.nextMessage(Duration.ofSeconds(2));
+        assertNotNull(m);
+        assertEquals(data, new String(m.getData()));
     }
 
     // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
when there were multiple servers in the options (either comma delimited string or added by builder, or array, etc.) the ssl context was not created if it was not already supplied as it was set to handle only when there was exactly 1 server