### PR TITLE
DataPort -> NatsChannel Refactor

### DIFF
--- a/src/main/java/io/nats/client/channels/AbstractNatsChannel.java
+++ b/src/main/java/io/nats/client/channels/AbstractNatsChannel.java
@@ -1,0 +1,93 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+
+/**
+ * Delegates all operations to a wrapped {@link NatsChannel}.
+ */
+public abstract class AbstractNatsChannel implements NatsChannel {
+    protected NatsChannel wrap;
+    protected AbstractNatsChannel(NatsChannel wrap) {
+        this.wrap = wrap;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        return wrap.read(dst);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOpen() {
+        return wrap.isOpen();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+        wrap.close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return wrap.write(srcs, offset, length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isSecure() {
+        return wrap.isSecure();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdownInput() throws IOException {
+        wrap.shutdownInput();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String transformConnectUrl(String connectUrl) {
+        return wrap.transformConnectUrl(connectUrl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+	@Override
+	public void upgradeToSecure(Duration timeout) throws IOException, GeneralSecurityException {
+		wrap.upgradeToSecure(timeout);
+	}
+}

--- a/src/main/java/io/nats/client/channels/ConnectTimeoutException.java
+++ b/src/main/java/io/nats/client/channels/ConnectTimeoutException.java
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2021 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -11,20 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.nats.client.utils;
+package io.nats.client.channels;
 
 import java.io.IOException;
 
-import io.nats.client.impl.SocketDataPort;
-
-public class CloseOnUpgradeAttempt extends SocketDataPort {
-    public CloseOnUpgradeAttempt() {
-        super(); // Start with a very small buffer size
+/**
+ * Thrown to indicate there was a timeout when trying to connect.
+ */
+public class ConnectTimeoutException extends IOException {
+    public ConnectTimeoutException(String msg, Throwable cause) {
+        super(msg, cause);
     }
 
-    @Override
-    public void upgradeToSecure() throws IOException {
-        this.close();
-        super.upgradeToSecure();
+    public ConnectTimeoutException(String msg) {
+        super(msg);
     }
 }

--- a/src/main/java/io/nats/client/channels/NatsChannel.java
+++ b/src/main/java/io/nats/client/channels/NatsChannel.java
@@ -1,0 +1,77 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+
+/**
+ * Low-level API for establishing a connection. This allows us to support the
+ * "decorator" design pattern to support TLS, Websockets, and HTTP Proxy support.
+ */
+public interface NatsChannel extends ByteChannel, GatheringByteChannel {
+    /**
+     * When performing the NATS INFO/CONNECT handshake, we may need to
+     * upgrade to a secure connection, but if this connection is already
+     * secured, it should be a no-op.
+     * 
+     * @return true if the connection is already secured.
+     */
+    boolean isSecure();
+
+    /**
+     * Starts the TLS handshake.
+     * 
+     * When NATS handles the INFO message, it contains a tls_required
+     * field, which when set to true triggers the connection to be
+     * upgraded to secure protocol.
+     * 
+     * @param timeout is the max time allowed for performing the TLS handshake.
+     * @throws IOException if there is an input/output error
+     * @throws GeneralSecurityException if there is a problem configuring the SSLContext
+     */
+    void upgradeToSecure(Duration timeout) throws IOException, GeneralSecurityException;
+
+    /**
+     * Shutdown the reader side of the channel.
+     * 
+     * @throws IOException if an IO error occurs.
+     */
+    void shutdownInput() throws IOException;
+
+    /**
+     * When NATS handles the INFO message, it contains connect_urls which
+     * may not be fully qualified with a protocol, and thus when using
+     * these urls during reconnect attempts, the NatsChannelFactory may
+     * not create the correct implementation of NatsChannel.
+     * 
+     * @param connectUrl to transform
+     * @return the transformed connect_url
+     */
+    String transformConnectUrl(String connectUrl);
+
+    @Override
+    default int write(ByteBuffer src) throws IOException {
+        return Math.toIntExact(write(new ByteBuffer[]{src}, 0, 1));
+    }
+
+    @Override
+    default long write(ByteBuffer[] srcs) throws IOException {
+        return write(srcs, 0, srcs.length);
+    }
+}

--- a/src/main/java/io/nats/client/channels/NatsChannelFactory.java
+++ b/src/main/java/io/nats/client/channels/NatsChannelFactory.java
@@ -1,0 +1,102 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.net.ssl.SSLContext;
+import java.security.GeneralSecurityException;
+
+/**
+ * Used to create instances of {@link NatsChannel}.
+ */
+@FunctionalInterface
+public interface NatsChannelFactory {
+    /**
+     * A "sink" factory which has no need to delegate.
+     */
+    @FunctionalInterface
+    interface Chain {
+        NatsChannel connect(URI serverURI, Duration timeout) throws IOException, GeneralSecurityException;
+        default public SSLContext createSSLContext(URI serverURI) throws GeneralSecurityException {
+            return null;
+        }
+    }
+
+    /**
+     * Create a new NatsChannel for the given serverURI, options, and remaining timeout in nanoseconds.
+     * 
+     * @param serverURI is the URI of the server to connect to.
+     * 
+     * @param timeout is the max time that should elapse when attempting to connect.
+     * 
+     * @param next is the next factory in the chain of factories.
+     * 
+     * @return a new nats channel which is ready for reading and writing, otherwise an exception
+     *     should be thrown to indicate why the connection could not be created.
+     * 
+     * @throws IOException if any IO error occurs.
+     * @throws GeneralSecurityException if there is an issue creating the SSLContext.
+     */
+    public NatsChannel connect(URI serverURI, Duration timeout, Chain next) throws IOException, GeneralSecurityException;
+
+    /**
+     * Determine if this serverURI would require an SSLContext and if so, then build
+     * an appropriate context.
+     * 
+     * @param serverURI is the URI to check if an SSLContext is required.
+     * 
+     * @param next is the next channel factory to use if delegating.
+     * 
+     * @throws GeneralSecurityException if a context can not be built.
+     * 
+     * @return a new SSLContext appropriate for this serverURI or null if
+     *     it is not needed.
+     */
+    default public SSLContext createSSLContext(URI serverURI, Chain next) throws GeneralSecurityException {
+        return next.createSSLContext(serverURI);
+    }
+
+    /**
+     * Build out a chain from a list of factories with the specified final factory to
+     * use.
+     * 
+     * @param factories is a list of factories that should be considered.
+     * @param sink the final factory
+     * @return the final built chain.
+     */
+    public static Chain buildChain(List<NatsChannelFactory> factories, Chain sink) {
+        ListIterator<NatsChannelFactory> iter = factories.listIterator(factories.size());
+        while (iter.hasPrevious()) {
+            NatsChannelFactory factory = iter.previous();
+            Chain[] next = new Chain[]{sink};
+            sink = new Chain() {
+                @Override
+                public NatsChannel connect(URI serverURI, Duration timeout) throws IOException, GeneralSecurityException {
+                    return factory.connect(serverURI, timeout, next[0]);
+                }
+
+                @Override
+                public SSLContext createSSLContext(URI serverURI) throws GeneralSecurityException {
+                    return factory.createSSLContext(serverURI, next[0]);
+                }
+            };
+        }
+        return sink;
+    }
+}

--- a/src/main/java/io/nats/client/channels/NatsChannelReference.java
+++ b/src/main/java/io/nats/client/channels/NatsChannelReference.java
@@ -1,0 +1,79 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Wraps a NatsChannel so the reference can be modified at a later point in time.
+ */
+public class NatsChannelReference implements NatsChannel {
+    private AtomicReference<NatsChannel> ref;
+
+    public NatsChannelReference(NatsChannel natsChannel) {
+        this.ref = new AtomicReference<>(natsChannel);
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        return ref.get().read(dst);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return ref.get().isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        ref.get().close();
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return ref.get().write(srcs, offset, length);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return ref.get().isSecure();
+    }
+
+	@Override
+	public void upgradeToSecure(Duration timeout) throws IOException, GeneralSecurityException {
+		ref.get().upgradeToSecure(timeout);
+	}
+
+    @Override
+    public void shutdownInput() throws IOException {
+        ref.get().shutdownInput();
+    }
+
+    @Override
+    public String transformConnectUrl(String connectUrl) {
+        return ref.get().transformConnectUrl(connectUrl);
+    }
+
+    public void set(NatsChannel natsChannel) {
+        this.ref.set(natsChannel);
+    }
+
+    public NatsChannel get() {
+        return ref.get();
+    }
+}

--- a/src/main/java/io/nats/client/channels/SocketNatsChannel.java
+++ b/src/main/java/io/nats/client/channels/SocketNatsChannel.java
@@ -1,0 +1,152 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.time.Duration;
+
+import static java.net.StandardSocketOptions.TCP_NODELAY;
+import static java.net.StandardSocketOptions.SO_RCVBUF;
+import static java.net.StandardSocketOptions.SO_SNDBUF;
+import static io.nats.client.Options.DEFAULT_PORT;
+
+/**
+ * TCP socket subtransport for NATS.
+ */
+public class SocketNatsChannel implements NatsChannel {
+    private static NatsChannelFactory.Chain FACTORY = new Factory();
+
+    private static class Factory implements NatsChannelFactory.Chain {
+        private Factory() {}
+    
+        @Override
+        public NatsChannel connect(
+            URI serverURI,
+            Duration timeout) throws IOException
+        {
+            return SocketNatsChannel.connect(serverURI, timeout);
+        }
+    }
+
+    /**
+     * @return the NatsChannelFactory.Chain implementation
+     *    for a TCP socket.
+     */
+    public static NatsChannelFactory.Chain factory() {
+        return FACTORY;
+    }
+
+    private static NatsChannel connect(
+        URI uri,
+        Duration timeoutDuration)
+        throws IOException
+    {
+        // Code copied from SocketDataPort.connect():
+        try {
+            String host = uri.getHost();
+            int port = uri.getPort();
+            if (port < 0) {
+                port = DEFAULT_PORT;
+            }
+
+            SocketChannel socket = SocketChannel.open();
+            socket.setOption(TCP_NODELAY, true);
+            socket.setOption(SO_RCVBUF, 2 * 1024 * 1024);
+            socket.setOption(SO_SNDBUF, 2 * 1024 * 1024);
+
+            connectWithTimeout(socket, new InetSocketAddress(host, port), timeoutDuration);
+
+            return new SocketNatsChannel(socket);
+        } catch (ConnectTimeoutException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IOException(ex);
+        }
+    }
+
+    private static void connectWithTimeout(SocketChannel socket, SocketAddress address, Duration timeout) throws IOException {
+        Selector selector = Selector.open();
+        try {
+            socket.configureBlocking(false);
+            socket.register(selector, SelectionKey.OP_CONNECT);
+            if (socket.connect(address)) {
+                return;
+            }
+            if (0 == selector.select(timeout.toMillis())) {
+                socket.close();
+                throw new ConnectTimeoutException("Unable to connect within " + timeout);
+            }
+            boolean finished = socket.finishConnect();
+            assert finished;
+        } finally {
+            selector.close();
+            if (socket.isOpen()) {
+                socket.configureBlocking(true);
+            }
+        }
+    }
+
+    private SocketChannel socket;
+
+    private SocketNatsChannel(SocketChannel socket) throws IOException {
+        this.socket = socket;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        return  socket.read(dst);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return socket.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        socket.close();
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return socket.write(srcs, offset, length);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        socket.shutdownInput();
+    }
+
+    @Override
+    public String transformConnectUrl(String connectUrl) {
+        return connectUrl;
+    }
+
+	@Override
+	public void upgradeToSecure(Duration timeout) throws IOException {
+        throw new UnsupportedOperationException("Attempt to upgradeToSecure when TLS is not configured in client");
+	}
+}

--- a/src/main/java/io/nats/client/channels/TLSByteChannel.java
+++ b/src/main/java/io/nats/client/channels/TLSByteChannel.java
@@ -1,0 +1,561 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.GatheringByteChannel;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+
+import static  io.nats.client.support.BufferUtils.append;
+import static  io.nats.client.support.BufferUtils.remaining;
+
+/**
+ * It blows my mind that JDK doesn't provide this functionality by default.
+ * 
+ * This is an implementation of ByteChannel which uses an SSLEngine to encrypt data sent
+ * to a ByteChannel that is being wrapped, and then decrypts received data.
+ */
+public class TLSByteChannel implements ByteChannel, GatheringByteChannel {
+    private static final ByteBuffer[] EMPTY = new ByteBuffer[]{ByteBuffer.allocate(0)};
+
+    private final ByteChannel wrap;
+    private final SSLEngine engine;
+
+    // NOTE: Locks should always be acquired in this order:
+    // readLock > writeLock > stateLock
+    private final Lock readLock = new ReentrantLock();
+    private final Lock writeLock = new ReentrantLock();
+
+    // All of the below state is controlled with this lock:
+    private final Object stateLock = new Object();
+    private Thread readThread = null;
+    private Thread writeThread = null;
+    private State state;
+    // end state protected by the stateLock
+
+    private final ByteBuffer outNetBuffer; // in "get" mode, protected by writeLock
+
+    private final ByteBuffer inNetBuffer; // in "put" mode, protected by readLock
+    private final ByteBuffer inAppBuffer; // in "put" mode, protected by readLock
+
+
+    private enum State {
+        HANDSHAKING_READ,
+        HANDSHAKING_WRITE,
+        HANDSHAKING_TASK,
+        OPEN,
+        CLOSING,
+        CLOSED;
+    }
+
+    public TLSByteChannel(ByteChannel wrap, SSLEngine engine) throws IOException {
+        this.wrap = wrap;
+        this.engine = engine;
+
+        int netBufferSize = engine.getSession().getPacketBufferSize();
+        int appBufferSize = engine.getSession().getApplicationBufferSize();
+
+        outNetBuffer = ByteBuffer.allocate(netBufferSize);
+        outNetBuffer.flip();
+
+        inNetBuffer = ByteBuffer.allocate(netBufferSize);
+        inAppBuffer = ByteBuffer.allocate(appBufferSize);
+
+        engine.beginHandshake();
+        state = toState(engine.getHandshakeStatus());
+    }
+
+    /**
+     * Translate an SSLEngine.HandshakeStatus into internal state.
+     */
+    private static State toState(HandshakeStatus status) {
+        switch (status) {
+        case NEED_TASK:
+            return State.HANDSHAKING_TASK;
+        case NEED_UNWRAP:
+            return State.HANDSHAKING_READ;
+        case NEED_WRAP:
+            return State.HANDSHAKING_WRITE;
+        case FINISHED:
+        case NOT_HANDSHAKING:
+            return State.OPEN;
+        default:
+            throw new IllegalStateException("Unexpected SSLEngine.HandshakeStatus=" + status);
+        }
+    }
+
+    /**
+     * Force a TLS handshake to take place if it has not already happened.
+     * @return false if end of file is observed.
+     * @throws IOException if any underlying read or write call throws.
+     */
+    public boolean handshake() throws IOException {
+        while (true) {
+            boolean needsRead = false;
+            boolean needsWrite = false;
+
+            synchronized (stateLock) {
+                switch (state) {
+                case HANDSHAKING_TASK:
+                    executeTasks();
+                    state = toState(engine.getHandshakeStatus());
+                    break;
+
+                case HANDSHAKING_READ:
+                    needsRead = true;
+                    break;
+
+                case HANDSHAKING_WRITE:
+                    needsWrite = true;
+                    break;
+                default:
+                    return true;
+                }
+            }
+
+            if (needsRead) {
+                if (readImpl(EMPTY[0]) < 0) {
+                    return false;
+                }
+            } else if (needsWrite) {
+                if (writeImpl(EMPTY, 0, 1) < 0) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    /**
+     * Gracefully close the TLS session and the underlying wrap'ed socket.
+     */
+    @Override
+    public void close() throws IOException {
+        if (!wrap.isOpen()) {
+            return;
+        }
+
+        // [1] Make sure any handshake has happened:
+        handshake();
+
+        // [2] Set state to closing, or return if another thread
+        // is already closing.
+        synchronized (stateLock) {
+            if (State.CLOSED == state || State.CLOSING == state) {
+                return;
+            } else {
+                state = State.CLOSING;
+            }
+
+            // [3] Interrupt any reading/writing threads:
+            if (null != readThread) {
+                readThread.interrupt();
+            }
+            if (null != writeThread) {
+                writeThread.interrupt();
+            }
+        }
+
+        // [4] Try to acquire readLock:
+        try {
+            if (!readLock.tryLock(100, TimeUnit.MICROSECONDS)) {
+                wrap.close();
+                return;
+            }
+            try {
+
+                // [5] Try to acquire writeLock:
+                if (!writeLock.tryLock(100, TimeUnit.MICROSECONDS)) {
+                    wrap.close();
+                    return;
+                }
+
+                try {
+                    // [6] Finally, implement close sequence.
+                    closeImpl();
+                } finally {
+                    writeLock.unlock();
+                }
+            } finally {
+                readLock.unlock();
+            }
+        } catch (InterruptedException ex) {
+            // Non-graceful close!
+            Thread.currentThread().interrupt();
+            wrap.close();
+            return;
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return wrap.isOpen();
+    }
+
+    /**
+     * Implement the close procedure.
+     * 
+     * Precondition: read & write locks are acquired
+     * 
+     * Postcondition: state is CLOSED
+     */
+    private void closeImpl() throws IOException {
+        synchronized (stateLock) {
+            if (State.CLOSED == state) {
+                return;
+            }
+            state = State.CLOSING;
+        }
+        try {
+            // NOTE: unread data may be lost. However, we assume this is desired
+            // since we are transitioning to closing:
+            inAppBuffer.clear();
+            if (outNetBuffer.hasRemaining()) {
+                wrap.write(outNetBuffer);
+            }
+            engine.closeOutbound();
+            try {
+                while (!engine.isOutboundDone()) {
+                    if (writeImpl(EMPTY, 0, 1) < 0) {
+                        throw new ClosedChannelException();
+                    }
+                }
+                while (!engine.isInboundDone()) {
+                    if (readImpl(EMPTY[0]) < 0) {
+                        throw new ClosedChannelException();
+                    }
+                }
+                engine.closeInbound();
+            } catch (ClosedChannelException ex) {
+                // already closed, ignore.
+            }
+        } finally {
+            try {
+                // No matter what happens, we need to close the
+                // wrapped channel:
+                wrap.close();
+            } finally {
+                // ...and no matter what happens, we need to
+                // indicate that we are in a CLOSED state:
+                synchronized (stateLock) {
+                    state = State.CLOSED;
+                }
+            }
+        }
+    }
+
+    /**
+     * Read plaintext by decrypting the underlying wrap'ed sockets encrypted bytes.
+     * 
+     * @param dst is the buffer to populate between position and limit.
+     * @return the number of bytes populated or -1 to indicate end of stream,
+     *     and the dst position will also be incremented appropriately.
+     */
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        int result = 0;
+        while (0 == result) {
+            if (!handshake()) {
+                return -1;
+            }
+            if (!dst.hasRemaining()) {
+                return 0;
+            }
+            result = readImpl(dst);
+        }
+        return result;
+    }
+
+    /**
+     * Precondition: handshake() was called, or this code was called
+     *     by the handshake() implementation.
+     */
+    private int readImpl(ByteBuffer dst) throws IOException {
+        readLock.lock();
+        try {
+            // [1] Check if this is a read for a handshake:
+            synchronized (stateLock) {
+                if (isHandshaking(state)) {
+                    if (state != State.HANDSHAKING_READ) {
+                        return 0;
+                    }
+                    dst = EMPTY[0];
+                }
+                readThread = Thread.currentThread();
+            }
+
+            // [2] Satisfy read via inAppBuffer:
+            int count = append(inAppBuffer, dst);
+            if (count > 0) {
+                return count;
+            }
+
+            // [3] Read & decrypt loop:
+            return readAndDecryptLoop(dst);
+        } finally {
+            readLock.unlock();
+            readThread = null;
+        }
+    }
+
+    /**
+     * Return true if we are handshaking.
+     */
+    private static boolean isHandshaking(State state) {
+        switch (state) {
+        case HANDSHAKING_READ:
+        case HANDSHAKING_WRITE:
+        case HANDSHAKING_TASK:
+            return true;
+
+        case CLOSED:
+        case OPEN:
+        case CLOSING:
+        }
+        return false;
+    }
+
+    /**
+     * Precondition: readLock acquired
+     */
+    private int readAndDecryptLoop(ByteBuffer dst) throws IOException {
+        boolean networkRead = inNetBuffer.position() == 0;
+        while (true) {
+            // Read from network:
+            if (networkRead) {
+                synchronized (stateLock) {
+                    if (State.OPEN == state && !dst.hasRemaining()) {
+                        return 0;
+                    }
+                }
+                if (wrap.read(inNetBuffer) < 0) {
+                    return -1;
+                }
+            }
+
+            SSLEngineResult result;
+            synchronized(stateLock) {
+                // Decrypt:
+                inNetBuffer.flip();
+                try {
+                    result = engine.unwrap(inNetBuffer, dst);
+                } finally {
+                    inNetBuffer.compact();
+                }
+                State newState = toState(result.getHandshakeStatus());
+                if (state != State.CLOSING && newState != state) {
+                    state = newState;
+                }
+            }
+
+            SSLEngineResult.Status status = result.getStatus();
+            switch (status) {
+            case BUFFER_OVERFLOW:
+                if (dst == inAppBuffer) {
+                    throw new IllegalStateException(
+                        "SSLEngine indicated app buffer size=" + inAppBuffer.capacity() +
+                        ", but unwrap() returned BUFFER_OVERFLOW with an empty buffer");
+                }
+
+                // Not enough space in dst, so buffer it into inAppBuffer:
+                readAndDecryptLoop(inAppBuffer);
+
+                return append(inAppBuffer, dst);
+
+            case BUFFER_UNDERFLOW:
+                if (!inNetBuffer.hasRemaining()) {
+                    throw new IllegalStateException(
+                        "SSLEngine indicated net buffer size=" + inNetBuffer.capacity() +
+                        ", but unwrap() returned BUFFER_UNDERFLOW with a full buffer");
+                }
+                networkRead = inNetBuffer.hasRemaining();
+                break; // retry network read
+
+            case CLOSED:
+                try {
+                    wrap.close();
+                } finally {
+                    synchronized (stateLock) {
+                        state = State.CLOSED;
+                    }
+                }
+                return -1;
+
+            case OK:
+                return result.bytesProduced();
+
+            default:
+                throw new IllegalStateException("Unexpected status=" + status);
+            }
+        }
+    }
+
+    /**
+     * Write plaintext by encrypting and writing this to the underlying wrap'ed socket.
+     * 
+     * @param srcs are the buffers of plaintext to encrypt.
+     * @param offset is the offset within the array to begin writing.
+     * @param length is the number of buffers within the srcs array that should be written.
+     * @return the number of bytes that got written or -1 to indicate end of
+     *     stream and the src position will also be incremented appropriately.
+     */
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        int result = 0;
+        while (0 == result) {
+            if (!handshake()) {
+                return -1;
+            }
+            if (0 == remaining(srcs, offset, length)) {
+                return 0;
+            }
+            result = writeImpl(srcs, offset, length);
+        }
+        return result;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return Math.toIntExact(write(new ByteBuffer[]{src}, 0, 1));
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs) throws IOException {
+        return write(srcs, 0, srcs.length);
+    }
+
+    /**
+     * While there are delegatedTasks to run, run them.
+     * 
+     * Precondition: stateLock acquired
+     */
+    private void executeTasks() {
+        while (true) {
+            Runnable runnable = engine.getDelegatedTask();
+            if (null == runnable) {
+                break;
+            }
+            runnable.run();
+        }
+    }
+
+    /**
+     * Implement a write operation.
+     * 
+     * @param src is the source buffer to write
+     * @return the number of bytes written or -1 if end of stream.
+     * 
+     * Precondition: write lock is acquired.
+     */
+    private int writeImpl(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        writeLock.lock();
+        try {
+            // [1] Wait until handshake is complete in other thread.
+            synchronized (stateLock) {
+                if (isHandshaking(state)) {
+                    if (state != State.HANDSHAKING_WRITE) {
+                        return 0;
+                    }
+                    srcs = EMPTY;
+                }
+                writeThread = Thread.currentThread();
+            }
+
+            // [2] Write & decrypt loop:
+            return writeAndEncryptLoop(srcs, offset, length);
+        } finally {
+            writeLock.unlock();
+            writeThread = null;
+        }
+    }
+
+
+    private int writeAndEncryptLoop(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        if (offset >= length) {
+            return 0;
+        }
+
+        int count = 0;
+        boolean finalNetFlush = false;
+        int srcsEnd = offset + length;
+        while (true) {
+            SSLEngineResult result = null;
+            synchronized (stateLock) {
+                // Encrypt:
+                outNetBuffer.compact();
+                try {
+                    for (; offset < srcsEnd; offset++, length--) {
+                        ByteBuffer src = srcs[offset];
+                        int startPosition = src.position();
+                        result = engine.wrap(src, outNetBuffer);
+                        count += src.position() - startPosition;
+                        if (result.getStatus() != SSLEngineResult.Status.OK) {
+                            break;
+                        }
+                    }
+                } finally {
+                    outNetBuffer.flip();
+                }
+                State newState = toState(result.getHandshakeStatus());
+                if (state != State.CLOSING && state != newState) {
+                    state = newState;
+                }
+            }
+
+            SSLEngineResult.Status status = result.getStatus();
+            switch (status) {
+            case BUFFER_OVERFLOW:
+                if (outNetBuffer.remaining() == outNetBuffer.capacity()) {
+                    throw new IllegalStateException(
+                        "SSLEngine indicated net buffer size=" + outNetBuffer.capacity() +
+                        ", but wrap() returned BUFFER_OVERFLOW with a full buffer");
+                }
+                break; // retry network write.
+
+            case BUFFER_UNDERFLOW:
+                throw new IllegalStateException("SSLEngine.wrap() should never return BUFFER_UNDERFLOW");
+
+            case CLOSED:
+                finalNetFlush = true;
+                break;
+
+            case OK:
+                finalNetFlush = offset >= srcsEnd;
+                break; // perform a final net write.
+
+            default:
+                throw new IllegalStateException("Unexpected status=" + result.getStatus());
+            }
+
+            // Write to network:
+            if (outNetBuffer.remaining() > 0) {
+                if (wrap.write(outNetBuffer) < 0) {
+                    return -1;
+                }
+            }
+            if (finalNetFlush || 0 == remaining(srcs, offset, length)) {
+                break;
+            }
+        }
+        return count;
+    }
+}

--- a/src/main/java/io/nats/client/channels/TLSNatsChannel.java
+++ b/src/main/java/io/nats/client/channels/TLSNatsChannel.java
@@ -1,0 +1,161 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+import java.util.Arrays;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+import io.nats.client.support.SSLUtils;
+
+import static io.nats.client.Options.DEFAULT_PORT;
+import static io.nats.client.support.NatsConstants.TLS_PROTOCOL;
+import static io.nats.client.support.NatsConstants.OPENTLS_PROTOCOL;
+import static io.nats.client.support.WithTimeout.withTimeout;
+import static io.nats.client.support.URIUtils.withDefaultPort;
+
+public class TLSNatsChannel extends AbstractNatsChannel {
+    @FunctionalInterface
+    public interface CreateSSLEngine {
+        SSLEngine create(URI serverURI) throws GeneralSecurityException;
+    }
+    private static class Factory implements NatsChannelFactory {
+        private CreateSSLEngine createSSLEngine;
+
+        // SslContext.createSSLEngine(uri.getHost(), uri.getPort())
+        private Factory(CreateSSLEngine createSSLEngine) {
+            this.createSSLEngine = createSSLEngine;
+        }
+
+        @Override
+        public NatsChannel connect(
+            URI serverURI,
+            Duration timeout,
+            Chain next) throws IOException, GeneralSecurityException
+        {
+            if (null != createSSLEngine) {
+                SSLEngine sslEngine = createSSLEngine.create(withDefaultPort(serverURI, DEFAULT_PORT));
+                if (null != sslEngine) {
+                    return new TLSNatsChannel(
+                        next.connect(serverURI, timeout),
+                        sslEngine);
+                }
+            }
+            return next.connect(serverURI, timeout);
+        }
+
+        @Override
+        public SSLContext createSSLContext(URI serverURI, Chain next) throws GeneralSecurityException {
+            if (TLS_PROTOCOL.equals(serverURI.getScheme())) {
+                return SSLContext.getDefault();
+            }
+            else if (OPENTLS_PROTOCOL.equals(serverURI.getScheme())) {
+                return SSLUtils.createOpenTLSContext();
+            }
+            return next.createSSLContext(serverURI);
+        }
+    }
+
+    /**
+     * @param createSSLEngine is called if {@link NatsChannel#upgradeToSecure(Duration)}
+     *     is called.
+     * @return a nats channel factory that will connect using TLS if the server URI
+     *     is tls or opentls. Note that the TLS handshake is delayed until {@link #upgradeToSecure(Duration)}
+     *     is called.
+     */
+    public static NatsChannelFactory factory(CreateSSLEngine createSSLEngine) {
+        return new Factory(createSSLEngine);
+    }
+
+    private TLSByteChannel byteChannel;
+    private SSLEngine sslEngine;
+
+    private TLSNatsChannel(NatsChannel wrap, SSLEngine sslEngine) {
+        super(wrap);
+        this.sslEngine = sslEngine;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return null != byteChannel;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        if (null == byteChannel) {
+            wrap.shutdownInput();
+        }
+        // cannot call shutdownInput on sslSocket
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (null == byteChannel) {
+            wrap.close();
+        } else {
+            // Ensures proper close sequence of TLS:
+            byteChannel.close();
+        }
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        if (null == byteChannel) {
+            return wrap.read(dst);
+        } else {
+            return byteChannel.read(dst);
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        if (null == byteChannel) {
+            return wrap.isOpen();
+        } else {
+            return byteChannel.isOpen();
+        }
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return byteChannel.write(srcs, offset, length);
+    }
+
+    @Override
+    public String transformConnectUrl(String connectUrl) {
+        return wrap.transformConnectUrl(connectUrl);
+    }
+
+	@Override
+	public void upgradeToSecure(Duration timeout) throws IOException {
+        if (null != this.byteChannel) {
+            // Already upgraded, no-op.
+            return;
+        }
+        withTimeout(() -> {
+            sslEngine.setUseClientMode(true);
+            this.byteChannel = new TLSByteChannel(wrap, sslEngine);
+            this.byteChannel.handshake();
+            // Dispose of unnecessary resources:
+            sslEngine = null;
+            return null;
+        }, timeout, cause -> new ConnectTimeoutException("Timeout performing TLS handshake", cause));
+    }
+}

--- a/src/main/java/io/nats/client/impl/AdaptDataPortToNatsChannelFactory.java
+++ b/src/main/java/io/nats/client/impl/AdaptDataPortToNatsChannelFactory.java
@@ -1,0 +1,159 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.impl;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+
+import io.nats.client.channels.ConnectTimeoutException;
+import io.nats.client.channels.NatsChannel;
+import io.nats.client.channels.NatsChannelFactory;
+import io.nats.client.support.SSLUtils;
+import io.nats.client.Options;
+
+import static io.nats.client.support.NatsConstants.TLS_PROTOCOL;
+import static io.nats.client.support.NatsConstants.OPENTLS_PROTOCOL;
+import static io.nats.client.support.BufferUtils.remaining;
+import static io.nats.client.support.WithTimeout.withTimeout;
+
+/**
+ * Adapter for legacy implementations of DataPort.
+ * 
+ * <p><b>NOTES:</b>
+ * <ul>
+ *   <li>The NatsConnection passed into connect() is a completely disconnected instance, and thus only the
+ *       {@link NatsConnection#getOptions() getOptions()} method may be relied upon.
+ *   <li>{@link DataPort#upgradeToSecure() upgradeToSecure()} will never be called, but if there is a
+ *       need to upgrade to a secure connection, this adapted DataPort instance will be wrapped automatically,
+ *       and thus the TLS upgrade should happen transparently.
+ *   <li>{@link DataPort#flush() flush()} will never be called.
+ * </ul>
+ */
+@Deprecated
+public class AdaptDataPortToNatsChannelFactory implements NatsChannelFactory.Chain {
+    private Supplier<DataPort> dataPortSupplier;
+    private Options options;
+
+    public AdaptDataPortToNatsChannelFactory(Supplier<DataPort> dataPortSupplier, Options options) {
+        this.dataPortSupplier = dataPortSupplier;
+        this.options = options;
+    }
+
+    @Override
+    public NatsChannel connect(
+        URI serverURI,
+        Duration timeout)
+        throws IOException
+    {
+        DataPort dataPort = dataPortSupplier.get();
+        dataPort.connect(serverURI.toString(), new NatsConnection(options), timeout.toNanos());
+        return new Adapter(dataPort);
+    }
+
+    private static class Adapter implements NatsChannel {
+        private DataPort dataPort;
+        private boolean isOpen = true;
+
+        private Adapter(DataPort dataPort) {
+            this.dataPort = dataPort;
+        }
+
+        @Override
+        public int read(ByteBuffer original) throws IOException {
+            ByteBuffer dst = original;
+            if (!original.hasArray()) {
+                dst = ByteBuffer.allocate(original.remaining());
+            }
+            int offset = dst.arrayOffset();
+            int length = dataPort.read(dst.array(), offset + dst.position(), dst.remaining());
+            if (length > 0) {
+                dst.position(dst.position() + length);
+            }
+            if (original != dst) {
+                dst.flip();
+                original.put(dst);
+            }
+            return length;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return isOpen;
+        }
+
+        @Override
+        public void close() throws IOException {
+            dataPort.close();
+        }
+
+        @Override
+        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+            int size = Math.toIntExact(remaining(srcs, offset, length));
+            // NOTE: We are allocating a new buffer on every write, not very efficient!
+            ByteBuffer buff = ByteBuffer.allocate(size);
+            int endOffset = offset + length;
+            while (offset < endOffset) {
+                buff.put(srcs[offset++]);
+            }
+            dataPort.write(buff.array(), size);
+
+            return size;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public void shutdownInput() throws IOException {
+            dataPort.shutdownInput();
+        }
+
+        @Override
+        public String transformConnectUrl(String connectUrl) {
+            return connectUrl;
+        }
+
+		@Override
+		public void upgradeToSecure(Duration timeout) throws IOException {
+            withTimeout(() -> {
+                dataPort.upgradeToSecure();
+                return null;
+            }, timeout, ex -> new ConnectTimeoutException("Failed to upgrade to secure using a legacy DataPort", ex));
+		}
+    }
+
+    @Override
+    public SSLContext createSSLContext(URI serverURI) throws GeneralSecurityException {
+        // Original data port implementation only supported these uris:
+        if (TLS_PROTOCOL.equals(serverURI.getScheme())) {
+            return SSLContext.getDefault();
+        }
+        else if (OPENTLS_PROTOCOL.equals(serverURI.getScheme())) {
+            // Previous code would return null if Exception is thrown... but if that
+            // happens then the exception will only be deferred until the SSLContext
+            // is required, therefore I believe it is better to NOT catch the
+            // exception.
+            return SSLUtils.createOpenTLSContext();
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/nats/client/impl/DataPort.java
+++ b/src/main/java/io/nats/client/impl/DataPort.java
@@ -19,7 +19,10 @@ import java.io.IOException;
  * A data port represents the connection to the network. This could have been called
  * transport but that seemed too big a concept. This interface just allows a wrapper around
  * the core communication code.
+ * 
+ * Please see the replacement: {@link NatsChannel}.
  */
+@Deprecated
 public interface DataPort {
     void connect(String serverURI, NatsConnection conn, long timeoutNanos) throws IOException;
 

--- a/src/main/java/io/nats/client/impl/DefaultNatsChannelFactory.java
+++ b/src/main/java/io/nats/client/impl/DefaultNatsChannelFactory.java
@@ -1,0 +1,17 @@
+package io.nats.client.impl;
+
+import java.util.Arrays;
+
+import io.nats.client.Options;
+import io.nats.client.channels.NatsChannelFactory;
+import io.nats.client.channels.SocketNatsChannel;
+import io.nats.client.channels.TLSNatsChannel;
+
+public interface DefaultNatsChannelFactory {
+    public static NatsChannelFactory.Chain create(Options options) {
+        return NatsChannelFactory.buildChain(
+            Arrays.asList(
+                TLSNatsChannel.factory(options::createSSLEngine)),
+            SocketNatsChannel.factory());
+    }
+}

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -13,6 +13,7 @@
 
 package io.nats.client.impl;
 
+import io.nats.client.channels.NatsChannel;
 import io.nats.client.impl.NatsMessage.InternalMessageFactory;
 import io.nats.client.support.IncomingHeadersProcessor;
 
@@ -64,8 +65,8 @@ class NatsConnectionReader implements Runnable {
     private int bufferPosition;
 
     private Future<Boolean> stopped;
-    private Future<DataPort> dataPortFuture;
-    private DataPort dataPort;
+    private Future<NatsChannel> natsChannelFuture;
+    private NatsChannel natsChannel;
     private final AtomicBoolean running;
 
     private final boolean utf8Mode;
@@ -89,8 +90,8 @@ class NatsConnectionReader implements Runnable {
     // Should only be called if the current thread has exited.
     // Use the Future from stop() to determine if it is ok to call this.
     // This method resets that future so mistiming can result in badness.
-    void start(Future<DataPort> dataPortFuture) {
-        this.dataPortFuture = dataPortFuture;
+    void start(Future<NatsChannel> natsChannelFuture) {
+        this.natsChannelFuture = natsChannelFuture;
         this.running.set(true);
         this.stopped = connection.getExecutor().submit(this, Boolean.TRUE);
     }
@@ -100,9 +101,9 @@ class NatsConnectionReader implements Runnable {
     // method does.
     Future<Boolean> stop() {
         this.running.set(false);
-        if (dataPort != null) {
+        if (natsChannel != null) {
             try {
-                dataPort.shutdownInput();
+                natsChannel.shutdownInput();
             } catch (IOException e) {
                 // we don't care, we are shutting down anyway
             }
@@ -113,14 +114,14 @@ class NatsConnectionReader implements Runnable {
     @Override
     public void run() {
         try {
-            dataPort = this.dataPortFuture.get(); // Will wait for the future to complete
+            natsChannel = this.natsChannelFuture.get(); // Will wait for the future to complete
             this.mode = Mode.GATHER_OP;
             this.gotCR = false;
             this.opPos = 0;
 
             while (this.running.get()) {
                 this.bufferPosition = 0;
-                int bytesRead = dataPort.read(this.buffer, 0, this.buffer.length);
+                int bytesRead = natsChannel.read(ByteBuffer.wrap(this.buffer, 0, this.buffer.length));
 
                 if (bytesRead > 0) {
                     connection.getNatsStatistics().registerRead(bytesRead);

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -123,6 +123,6 @@ public class SocketDataPort implements DataPort {
     }
 
     public void flush() throws IOException {
-        out.flush();
+        // Never called
     }
 }

--- a/src/main/java/io/nats/client/support/BufferUtils.java
+++ b/src/main/java/io/nats/client/support/BufferUtils.java
@@ -1,0 +1,243 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Note that a ByteBuffer is always in one of two modes:
+ * 
+ * <ul>
+ *   <li>Get mode: Valid data is between position and limit. Some documentation may refer to
+ *       this as "read" mode, since the buffer is ready for various <code>.get()</code> method calls,
+ *       however this can be confusing, since you would NEVER call the
+ *       {@link java.nio.channels.ReadableByteChannel#read(ByteBuffer)} method when operating in
+ *       this mode. This may also be referred to as "flush" mode, but nothing in the Buffer
+ *       documentation refers to the term "flush", and thus we use the term "get" mode here.
+ *   <li>Put mode: Valid data is between 0 and position. Some documentation may refer to this as
+ *       "write" mode, since the buffer is ready for varous <code>.put()</code> method calls,
+ *       however this can be confusing since you would NEVER call the
+ *       {@link java.nio.channels.WritableByteChannel#write(ByteBuffer)} method when operating in
+ *       this mode. This may also be referred to as "fill" mode, but the term fill is only used
+ *       in one place in the Buffer.clear() documentation.
+ * </ul>
+ * 
+ * All documentation will be using the terms "get mode" or "put mode".
+ */
+public interface BufferUtils {
+    static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+    static final char SUBSTITUTE_CHAR = 0x2423;
+
+    /**
+     * It is not to uncommon to buffer data into a temporary buffer
+     * and then append this temporary buffer into a destination buffer.
+     * This method makes this operation easy since your temporary buffer
+     * is typically in "put" mode and your destination is always in "put"
+     * mode, and you need to take into account that the temporary buffer
+     * may contain more bytes than your destination buffer, but you don't
+     * want a BufferOverflowException to occur, instead you just want to
+     * fullfill as many bytes from your temporary buffer as is possible.
+     * 
+     * See <code>org.eclipse.jetty.util.BufferUtil.append(ByteBuffer, ByteBuffer)</code>
+     * for a similar method.
+     * 
+     * @param src is a buffer in "put" mode which will be flip'ed
+     *     and then "safely" put into dst followed by a compact call.
+     * @param dst is a buffer in "put" mode which will be populated
+     *     from src.
+     * @param max is the max bytes to transfer.
+     * @return min(src.position(), dst.position(), max)
+     */
+    static int append(ByteBuffer src, ByteBuffer dst, int max) {
+        if (src.position() < max) {
+            max = src.position();
+        }
+        if (dst.remaining() < max) {
+            max = dst.remaining();
+        }
+        src.flip();
+        try {
+            ByteBuffer slice = src.slice();
+            slice.limit(max);
+            dst.put(slice);
+        } finally {
+            src.position(max);
+            src.compact();
+        }
+        return max;
+    }
+
+    /**
+     * Delegates to {@link #append(ByteBuffer,ByteBuffer,int)}, with
+     * max set to Integer.MAX_VALUE.
+     * 
+     * @param src is a buffer in "put" mode which will be flip'ed
+     *     and then "safely" put into dst followed by a compact call.
+     * @param dst is a buffer in "put" mode which will be populated
+     *     from src.
+     * @return min(src.position(), dst.position())
+     */
+    static int append(ByteBuffer src, ByteBuffer dst) {
+        return append(src, dst, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Throws BufferUnderflowException if there are insufficient capacity in
+     * buffer to fillfill the request.
+     * 
+     * @param readBuffer is in "put" mode (0 - position are valid)
+     * @param reader is a reader used to populate the buffer if insufficient remaining
+     *    bytes exist in buffer. May be null if buffer should not be populated.
+     * @throws BufferUnderflowException if the buffer has insufficient capacity
+     *    to read a full line.
+     * @throws IOException if reader.read() throws this exception.
+     * @return a line without line terminators or null if end of channel.
+     */
+    static String readLine(ByteBuffer readBuffer, ReadableByteChannel reader) throws IOException {
+        if (null == readBuffer) {
+            throw new NullPointerException("Expected non-null readBuffer");
+        }
+        int end = 0;
+        boolean foundCR = false;
+        int newlineLength = 1;
+      FIND_END:
+        while (true) {
+            if (end >= readBuffer.position()) {
+                if (readBuffer.position() == readBuffer.limit()) {
+                    // Insufficient capacity in ByteBuffer to read a full line!
+                    throw new BufferUnderflowException();
+                }
+                if (null == reader || reader.read(readBuffer) < 0) {
+                    if (end > 0) {
+                        if (!foundCR) {
+                            newlineLength = 0;
+                        }
+                        break FIND_END;
+                    }
+                    return null;
+                }
+            }
+            switch (readBuffer.get(end++)) {
+            case '\r':
+                if (foundCR) {
+                    --end;
+                    break FIND_END; // Legacy MAC end of line
+                }
+                foundCR = true;
+                break;
+            case '\n':
+                if (foundCR) {
+                    newlineLength++;
+                }
+                break FIND_END;
+            default:
+                if (foundCR) {
+                    --end;
+                    break FIND_END; // Legacy MAC end of line
+                }
+            }
+        }
+
+        String result;
+        readBuffer.flip();
+        try {
+            ByteBuffer slice = readBuffer.slice();
+            slice.limit(end - newlineLength);
+            result = UTF_8.decode(slice).toString();
+        } finally {
+            readBuffer.position(end);
+            readBuffer.compact();
+        }
+        return result;
+    }
+
+    static long remaining(ByteBuffer[] buffers, int offset, int length) {
+        int total = 0;
+        int end = offset + length;
+        while (offset < end) {
+            total += buffers[offset++].remaining();
+        }
+        return total;
+    }
+
+    /**
+     * Utility method for stringifying a bytebuffer (use ByteBuffer.wrap(byte[])
+     * if you want to stringify a byte array). Mostly useful for debugging or
+     * tracing.
+     * 
+     * @param bytes is the byte buffer.
+     * @param off is the offset within the byte buffer to begin.
+     * @param len is the number of bytes to print.
+     * @return a "hexdump" of the bytes
+     */
+    static String hexdump(ByteBuffer bytes, int off, int len) {
+        int end = off + len;
+        StringBuilder sb = new StringBuilder();
+        for (int i=off; i < end;) {
+            sb.append(String.format("%04x ", i));
+            int start = i;
+            do {
+                int ch = bytes.get(i) & 0xFF;
+                sb.append(" ");
+                if (i % 16 == 8) {
+                    sb.append(" ");
+                }
+                sb.append(HEX_ARRAY[ch >>> 4]);
+                sb.append(HEX_ARRAY[ch & 0x0F]);
+            } while (++i % 16 != 0 && i < end);
+            if (i % 16 != 0) {
+                sb.append(new String(new char[16 - i % 16]).replace("\0", "   "));
+                if (i % 16 < 7) {
+                    sb.append(" ");
+                }
+            }
+            sb.append("  ");
+            i = start;
+            do {
+                char ch = (char)bytes.get(i);
+                if (ch < 0x21) {
+                    // Control chars:
+                    switch (ch) {
+                    case ' ':
+                        sb.append((char)0x2420);
+                        break;
+                    case '\t':
+                        sb.append((char)0x2409);
+                        break;
+                    case '\r':
+                        sb.append((char)0x240D);
+                        break;
+                    case '\n':
+                        sb.append((char)0x2424);
+                        break;
+                    default:
+                        sb.append(SUBSTITUTE_CHAR);
+                    }
+                } else if (ch < 0x7F) {
+                    sb.append(ch);
+                } else {
+                    // control chars:
+                    sb.append(SUBSTITUTE_CHAR);
+                }
+            } while (++i % 16 != 0 && i < end);
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/nats/client/support/SSLUtils.java
+++ b/src/main/java/io/nats/client/support/SSLUtils.java
@@ -18,6 +18,8 @@ import io.nats.client.Options;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
+
+import java.security.GeneralSecurityException;
 import java.security.cert.X509Certificate;
 
 import static io.nats.client.support.RandomUtils.SRAND;
@@ -35,16 +37,9 @@ public class SSLUtils {
         }
     } };
 
-    public static SSLContext createOpenTLSContext() {
-        SSLContext context = null;
-
-        try {
-            context = SSLContext.getInstance(Options.DEFAULT_SSL_PROTOCOL);
-            context.init(null, trustAllCerts, SRAND);
-        } catch (Exception e) {
-            context = null;
-        }
-
+    public static SSLContext createOpenTLSContext() throws GeneralSecurityException {
+        SSLContext context = SSLContext.getInstance(Options.DEFAULT_SSL_PROTOCOL);
+        context.init(null, trustAllCerts, SRAND);
         return context;
     }
 }

--- a/src/main/java/io/nats/client/support/SneakyThrow.java
+++ b/src/main/java/io/nats/client/support/SneakyThrow.java
@@ -1,0 +1,53 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+/**
+ * Sometimes you want to throw a checked exception, but you can't since you
+ * are in the confines of an interface which does NOT throw this checked
+ * exception.
+ * 
+ * You could chain the exception and have ugly "caused by" stack traces and
+ * more boiler-plate code.
+ * 
+ * Or you can use sneaky throws to defeat the compiler.
+ */
+public interface SneakyThrow {
+    static RuntimeException USELESS_EXCEPTION = new RuntimeException();
+
+    /**
+     * Usage:
+     * 
+     * <pre>
+     * throw sneakyThrow(new Exception())
+     * </pre>
+     * 
+     * This function returns a runtime exception so you can trick the compiler
+     * into thinking that your code will throw a runtime exception rather than
+     * a potentially checked exception.
+     * 
+     * @param <E> temp type used for casting the exception.
+     * @param ex is an arbitrary exception that you want to throw
+     * @return a fake RuntimeException so you can teach the compiler that no
+     *     subsequent code is reachable by `throw`ing this fake exception.
+     * @throws E is the type used for casting the real exception
+     */
+    @SuppressWarnings("unchecked")
+    static <E extends Throwable> RuntimeException sneakyThrow(Throwable ex) throws E {
+        if (true) {
+            throw (E) ex;
+        }
+        return USELESS_EXCEPTION;
+    }
+}

--- a/src/main/java/io/nats/client/support/URIUtils.java
+++ b/src/main/java/io/nats/client/support/URIUtils.java
@@ -1,0 +1,51 @@
+package io.nats.client.support;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public interface URIUtils {
+    static URI withScheme(URI uri, String scheme) {
+        try {
+            return new URI(scheme, uri.getSchemeSpecificPart(), uri.getFragment());
+        } catch (URISyntaxException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static URI withDefaultPort(URI uri, int defaultPort) {
+        if (uri.getPort() >= 0) {
+            return uri;
+        }
+        return withPort(uri, defaultPort);
+    }
+
+    static URI withPort(URI uri, int port) {
+        try {
+            return new URI(
+                uri.getScheme(),
+                uri.getUserInfo(),
+                uri.getHost(),
+                port,
+                uri.getPath(),
+                uri.getQuery(),
+                uri.getFragment());
+        } catch (URISyntaxException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static URI withHost(URI uri, String host) {
+        try {
+            return new URI(
+                uri.getScheme(),
+                uri.getUserInfo(),
+                host,
+                uri.getPort(),
+                uri.getPath(),
+                uri.getQuery(),
+                uri.getFragment());
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException("Illegal hostname=" + host, ex);
+        }
+    }
+}

--- a/src/main/java/io/nats/client/support/WithTimeout.java
+++ b/src/main/java/io/nats/client/support/WithTimeout.java
@@ -1,0 +1,60 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import static io.nats.client.support.SneakyThrow.sneakyThrow;
+
+public interface WithTimeout {
+    /**
+     * Executes a call with a specified timeout.
+     * 
+     * @param <T> is the result type of your function to call
+     * @param <E> is the final type of exception which will be thrown.
+     * @param call is a function to call
+     * @param timeout is the max time that said function may execute before
+     *    it is interrupted
+     * @param createException is a function used to wrap the InterruptedException or
+     *    TimeoutException so that you can chain your exceptions if desired.
+     * @return the result of the function call.
+     * @throws E if a timeout or interrupted exception occurs, after being filtered
+     *    through createException.
+     */
+    static <T, E extends Throwable> T withTimeout(Callable<T> call, Duration timeout, Function<Throwable, E> createException) throws E {
+        ExecutorService	executor = Executors.newSingleThreadExecutor();
+        Future<T> future = executor.submit(call);
+        try {
+            return future.get(timeout.toNanos(), TimeUnit.NANOSECONDS);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw createException.apply(ex);
+        } catch (TimeoutException ex) {
+            future.cancel(true);
+            throw createException.apply(ex);
+        } catch (ExecutionException ex) {
+            throw sneakyThrow(ex.getCause());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/io/nats/client/channels/BaseNatsChannel.java
+++ b/src/test/java/io/nats/client/channels/BaseNatsChannel.java
@@ -1,0 +1,49 @@
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+
+public class BaseNatsChannel implements NatsChannel {
+    private boolean isOpen = true;
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        return -1;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return isOpen;
+    }
+
+    @Override
+    public void close() throws IOException {
+        isOpen = false;
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return -1;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+    }
+
+    @Override
+    public String transformConnectUrl(String connectUrl) {
+        return connectUrl;
+    }
+
+	@Override
+	public void upgradeToSecure(Duration timeout) throws IOException, GeneralSecurityException {
+	}
+    
+}

--- a/src/test/java/io/nats/client/channels/ByteBufferChannel.java
+++ b/src/test/java/io/nats/client/channels/ByteBufferChannel.java
@@ -1,0 +1,90 @@
+package io.nats.client.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.GatheringByteChannel;
+
+import static io.nats.client.support.BufferUtils.append;
+
+/**
+ * Simple class that buffers all reads into an internal ByteBuffer and satisifes
+ * all writes via the same ByteBuffer. Really only intended for tests.
+ */
+public class ByteBufferChannel implements ByteChannel, GatheringByteChannel {
+    private ByteBuffer buffer;
+    private boolean closed = false;
+
+    public ByteBufferChannel(ByteBuffer initialBuffer) {
+        assert null != initialBuffer;
+        this.buffer = initialBuffer;
+    }
+
+    /**
+     * Access the internal ByteBuffer, but note that it may change if
+     * write() calls require the space to be expanded.
+     * 
+     * NOTE: This buffer is ALWAYS in "put" mode.
+     */
+    public ByteBuffer getByteBuffer() {
+        return buffer;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        if (closed) {
+            throw new ClosedChannelException();
+        }
+        int result = append(buffer, dst);
+        // Translate 0 into end of stream:
+        return result == 0 ? -1 : result;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        if (closed) {
+            throw new ClosedChannelException();
+        }
+        long size = 0;
+        int endOffset = offset + length;
+        while (offset < endOffset) {
+            ByteBuffer src = srcs[offset++];
+            ensureRemaining(src.remaining());
+            int position = buffer.position();
+            buffer.put(src);
+            size += buffer.position() - position;
+        }
+        return size;
+    }
+
+    private void ensureRemaining(int remaining) {
+        if (buffer.remaining() >= remaining) {
+            return;
+        }
+        ByteBuffer newBuffer = ByteBuffer.allocate(buffer.position() + remaining);
+        buffer.flip();
+        newBuffer.put(buffer);
+        buffer = newBuffer;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return Math.toIntExact(write(new ByteBuffer[]{src}, 0, 1));
+    }
+
+    @Override
+    public long write(ByteBuffer[] srcs) throws IOException {
+        return write(srcs, 0, srcs.length);
+    }
+}

--- a/src/test/java/io/nats/client/channels/NatsChannelTests.java
+++ b/src/test/java/io/nats/client/channels/NatsChannelTests.java
@@ -1,0 +1,51 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import io.nats.client.Options;
+
+public class NatsChannelTests {
+    @Test
+    public void testReference() throws IOException {
+        NatsChannelReference ref = new NatsChannelReference(new BaseNatsChannel());
+        assertTrue(ref.isOpen());
+        ref.close();
+        assertFalse(ref.isOpen());
+        ref.set(new BaseNatsChannel());
+        assertTrue(ref.isOpen());
+        assertEquals(-1L, ref.write(new ByteBuffer[]{ByteBuffer.allocate(10)}));
+    }
+
+    @Test
+    public void testSocketNatsChannel() throws Exception {
+        NatsChannelFactory.Chain factory = SocketNatsChannel.factory();
+        assertNull(factory.createSSLContext(new URI("tls://example.com")));
+        assertThrows(
+            ConnectTimeoutException.class,
+            () -> factory.connect(new URI("nats://10.255.255.1"), Duration.ofMillis(10)));
+    }
+}

--- a/src/test/java/io/nats/client/channels/TLSByteChannelTests.java
+++ b/src/test/java/io/nats/client/channels/TLSByteChannelTests.java
@@ -1,0 +1,306 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.channels.ByteChannel;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+
+import org.junit.jupiter.api.Test;
+
+import io.nats.client.NatsTestServer;
+import io.nats.client.TestSSLUtils;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+public class TLSByteChannelTests {
+    private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
+
+    @Test
+    public void testShortAppRead() throws Exception {
+        // Scenario: Net read TLS frame which is larger than the read buffer.
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            URI uri = new URI(ts.getURI());
+            NatsChannel socket = SocketNatsChannel.factory().connect(uri, Duration.ofSeconds(2));
+            ByteBuffer info = ByteBuffer.allocate(1024 * 1024);
+            socket.read(info);
+    
+            TLSByteChannel tls = new TLSByteChannel(socket, createSSLEngine(uri));
+
+            write(tls, "CONNECT {}\r\n");
+
+            ByteBuffer oneByte = ByteBuffer.allocate(1);
+            assertEquals(1, tls.read(oneByte));
+            assertEquals(1, oneByte.position());
+            assertEquals((byte)'+', oneByte.get(0)); // got 0?
+            oneByte.clear();
+
+            assertEquals(1, tls.read(oneByte));
+            assertEquals((byte)'O', oneByte.get(0));
+            oneByte.clear();
+
+            assertEquals(1, tls.read(oneByte));
+            assertEquals((byte)'K', oneByte.get(0));
+            oneByte.clear();
+
+            // Follow up with a larger buffer read,
+            // ...to ensure that we don't block on
+            // a net read:
+            info.clear();
+            int result = tls.read(info);
+            assertEquals(2, result);
+            assertEquals(2, info.position());
+            assertEquals((byte)'\r', info.get(0));
+            assertEquals((byte)'\n', info.get(1));
+            oneByte.clear();
+
+            assertTrue(tls.isOpen());
+            assertTrue(socket.isOpen());
+            tls.close();
+            assertFalse(tls.isOpen());
+            assertFalse(socket.isOpen());
+        }
+    }
+
+    @Test
+    public void testImmediateClose() throws Exception {
+        // Scenario: Net read TLS frame which is larger than the read buffer.
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            URI uri = new URI(ts.getURI());
+            NatsChannel socket = SocketNatsChannel.factory().connect(uri, Duration.ofSeconds(2));
+            ByteBuffer info = ByteBuffer.allocate(1024 * 1024);
+            socket.read(info);
+    
+            TLSByteChannel tls = new TLSByteChannel(socket, createSSLEngine(uri));
+
+            assertTrue(tls.isOpen());
+            assertTrue(socket.isOpen());
+            tls.close();
+            assertFalse(tls.isOpen());
+            assertFalse(socket.isOpen());
+        }
+    }
+
+    @Test
+    public void testRenegotiation() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            URI uri = new URI(ts.getURI());
+            NatsChannel socket = SocketNatsChannel.factory().connect(uri, Duration.ofSeconds(2));
+            ByteBuffer readBuffer = ByteBuffer.allocate(1024 * 1024);
+            socket.read(readBuffer);
+    
+            SSLEngine sslEngine = createSSLEngine(uri);
+            TLSByteChannel tls = new TLSByteChannel(socket, sslEngine);
+
+            write(tls, "CONNECT {}\r\n");
+
+            readBuffer.clear();
+            tls.read(readBuffer);
+            readBuffer.flip();
+            assertEquals(ByteBuffer.wrap("+OK\r\n".getBytes(UTF_8)), readBuffer);
+
+            // Now force a renegotiation:
+            sslEngine.getSession().invalidate();
+            sslEngine.beginHandshake();
+
+            // nats-server doesn't support renegotion, we just get this error:
+            // javax.net.ssl.SSLException: Received fatal alert: unexpected_message
+            assertThrows(SSLException.class,
+                () -> tls.write(new ByteBuffer[]{ByteBuffer.wrap("PING\r\n".getBytes(UTF_8))}));
+        }
+    }
+
+    @Test
+    public void testConcurrentHandshake() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            URI uri = new URI(ts.getURI());
+            NatsChannel socket = SocketNatsChannel.factory().connect(uri, Duration.ofSeconds(2));
+            ByteBuffer readBuffer = ByteBuffer.allocate(1024 * 1024);
+            socket.read(readBuffer);
+
+            int numThreads = 10;
+            SSLEngine sslEngine = createSSLEngine(uri);
+            TLSByteChannel tls = new TLSByteChannel(socket, sslEngine);
+
+            CountDownLatch threadsReady = new CountDownLatch(numThreads);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+            Future<Void>[] futures = new Future[numThreads];
+            for (int i = 0; i < 10; i++) {
+                boolean isRead = i % 2 == 0;
+                futures[i] = executor.submit(() -> {
+                    threadsReady.countDown();
+                    startLatch.await();
+                    if (isRead) {
+                        tls.read(EMPTY);
+                    } else {
+                        tls.write(EMPTY);
+                    }
+                    return null;
+                });
+            }
+
+            threadsReady.await();
+            startLatch.countDown();
+
+            // Make sure no exception happend on any thread:
+            for (int i=0; i < 10; i++) {
+                futures[i].get();
+            }
+
+            write(tls, "CONNECT {}\r\n");
+
+            readBuffer.clear();
+            tls.read(readBuffer);
+            readBuffer.flip();
+            assertEquals(ByteBuffer.wrap("+OK\r\n".getBytes(UTF_8)), readBuffer);
+
+            tls.close();
+        }
+    }
+
+    @Test
+    public void testConcurrentClose() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            URI uri = new URI(ts.getURI());
+            NatsChannel socket = SocketNatsChannel.factory().connect(uri, Duration.ofSeconds(2));
+            ByteBuffer readBuffer = ByteBuffer.allocate(1024 * 1024);
+            socket.read(readBuffer);
+
+            int numThreads = 10;
+            SSLEngine sslEngine = createSSLEngine(uri);
+            TLSByteChannel tls = new TLSByteChannel(socket, sslEngine);
+            tls.handshake();
+
+            CountDownLatch threadsReady = new CountDownLatch(numThreads);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+            Future<Void>[] futures = new Future[numThreads];
+            for (int i = 0; i < 10; i++) {
+                futures[i] = executor.submit(() -> {
+                    threadsReady.countDown();
+                    startLatch.await();
+                    tls.close();
+                    return null;
+                });
+            }
+
+            threadsReady.await();
+            startLatch.countDown();
+
+            // Make sure no exception happend on any thread:
+            for (int i=0; i < 10; i++) {
+                futures[i].get();
+            }
+        }
+    }
+
+    @Test
+    public void testShortNetRead() throws Exception {
+        // Scenario: Net read TLS frame which is larger than the read buffer.
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
+            URI uri = new URI(ts.getURI());
+            NatsChannel socket = SocketNatsChannel.factory().connect(uri, Duration.ofSeconds(2));
+
+            AtomicBoolean readOneByteAtATime = new AtomicBoolean(true);
+            NatsChannel wrapper = new AbstractNatsChannel(socket) {
+                ByteBuffer readBuffer = ByteBuffer.allocate(1);
+
+                @Override
+                public int read(ByteBuffer dst) throws IOException {
+                    if (!readOneByteAtATime.get()) {
+                        return socket.read(dst);
+                    }
+                    readBuffer.clear();
+                    int result = socket.read(readBuffer);
+                    if (result <= 0) {
+                        return result;
+                    }
+                    readBuffer.flip();
+                    dst.put(readBuffer);
+                    return result;
+                }
+
+                @Override
+                public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+                    return socket.write(srcs, offset, length);
+                }
+
+                @Override
+                public boolean isSecure() {
+                    return false;
+                }
+
+                @Override
+                public String transformConnectUrl(String connectUrl) {
+                    return connectUrl;
+                }
+
+            };
+
+            ByteBuffer info = ByteBuffer.allocate(1024 * 1024);
+            socket.read(info);
+
+            TLSByteChannel tls = new TLSByteChannel(wrapper, createSSLEngine(uri));
+
+            // Peform handshake:
+            tls.read(ByteBuffer.allocate(0));
+
+            // Send connect & ping, but turn off one-byte at a time for readint PONG:
+            readOneByteAtATime.set(false);
+            write(tls, "CONNECT {}\r\nPING\r\n");
+
+            info.clear();
+            tls.read(info);
+            info.flip();
+
+            assertEquals(
+                ByteBuffer.wrap(
+                    "+OK\r\nPONG\r\n"
+                    .getBytes(UTF_8)),
+                info);
+
+            tls.close();
+        }
+    }
+
+    private static SSLEngine createSSLEngine(URI uri) throws Exception {
+        SSLContext ctx = TestSSLUtils.createTestSSLContext();
+
+        SSLEngine engine = ctx.createSSLEngine(uri.getHost(), uri.getPort());
+        engine.setUseClientMode(true);
+
+        return engine;
+    }
+
+    private static void write(ByteChannel channel, String str) throws IOException {
+        channel.write(ByteBuffer.wrap(str.getBytes(UTF_8)));
+    }
+}

--- a/src/test/java/io/nats/client/channels/TLSNatsChannelTests.java
+++ b/src/test/java/io/nats/client/channels/TLSNatsChannelTests.java
@@ -1,0 +1,86 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.channels;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.Test;
+
+public class TLSNatsChannelTests {
+    static class WrappedException extends RuntimeException {
+    }
+
+    @Test
+    public void testTimeoutDuringConnect() throws Exception {
+        NatsChannel wrapped = new BaseNatsChannel() {
+            @Override
+            public int read(ByteBuffer dst) throws IOException {
+                try {
+                    Thread.sleep(10_000);
+                } catch (InterruptedException ex) {
+                    throw new IOException(ex);
+                }
+                return 0;
+            }
+
+            @Override
+            public int write(ByteBuffer src) throws IOException {
+                try {
+                    Thread.sleep(10_000);
+                } catch (InterruptedException ex) {
+                    throw new IOException(ex);
+                }
+                return 0;
+            }
+        };
+        NatsChannel channel = TLSNatsChannel.factory(uri -> SSLContext.getDefault().createSSLEngine())
+        .connect(
+            new URI("tls://example.com"),
+            Duration.ofSeconds(1),
+            (u,t) -> wrapped);
+        assertThrows(
+            ConnectTimeoutException.class,
+            () -> channel.upgradeToSecure(Duration.ofSeconds(1)));
+    }
+
+    @Test
+    public void testExceptionDuringConnect() throws Exception {
+        NatsChannel wrapped = new BaseNatsChannel() {
+            @Override
+            public int read(ByteBuffer dst) throws IOException {
+                throw new WrappedException();
+            }
+
+            @Override
+            public int write(ByteBuffer src) throws IOException {
+                throw new WrappedException();
+            }
+        };
+        NatsChannel channel = TLSNatsChannel.factory(uri -> SSLContext.getDefault().createSSLEngine())
+            .connect(
+                new URI("tls://example.com"),
+                Duration.ofSeconds(1),
+                (u,t) -> wrapped);
+        assertThrows(
+            WrappedException.class,
+            () -> channel.upgradeToSecure(Duration.ofSeconds(5)));
+    }
+}

--- a/src/test/java/io/nats/client/impl/AdaptDataPortToNatsChannelFactoryTests.java
+++ b/src/test/java/io/nats/client/impl/AdaptDataPortToNatsChannelFactoryTests.java
@@ -1,0 +1,135 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import io.nats.client.Options;
+import io.nats.client.channels.NatsChannel;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class AdaptDataPortToNatsChannelFactoryTests {
+    enum Method {
+        READ,
+        WRITE,
+        SHUTDOWN_INPUT,
+        CLOSE,
+        FLUSH;
+    }
+
+    @Test
+    public void test() throws IOException, URISyntaxException {
+        Method[] method = new Method[1];
+        byte[][] buff = new byte[1][];
+        NatsChannel natsChannel = new AdaptDataPortToNatsChannelFactory(
+            () ->
+            new DataPort() {
+                boolean connected;
+
+                @Override
+                public void connect(String serverURI, NatsConnection conn, long timeoutNanos) throws IOException {
+                    try {
+                        assertEquals("nats://server:42", serverURI);
+                        assertEquals(new URI("nats://options:42"), conn.getOptions().getServers().iterator().next());
+                        connected = true;
+                    } catch (Exception ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }
+
+                @Override
+                public void upgradeToSecure() throws IOException {
+                    // Can't be called.
+                }
+
+                @Override
+                public int read(byte[] dst, int off, int len) throws IOException {
+                    method[0] = Method.READ;
+                    int maxLen = buff[0].length;
+                    if (len > maxLen) {
+                        len = maxLen;
+                    }
+                    System.arraycopy(buff[0], 0, dst, off, len);
+                    return len;
+                }
+
+                @Override
+                public void write(byte[] src, int toWrite) throws IOException {
+                    method[0] = Method.WRITE;
+                    buff[0] = Arrays.copyOfRange(src, 0, toWrite);
+                }
+
+                @Override
+                public void shutdownInput() throws IOException {
+                    assertTrue(connected);
+                    method[0] = Method.SHUTDOWN_INPUT;
+                }
+
+                @Override
+                public void close() throws IOException {
+                    method[0] = Method.CLOSE;
+                }
+
+                @Override
+                public void flush() throws IOException {
+                    // Can't be called.
+                }
+
+            },
+            new Options.Builder().server("nats://options:42").build()).connect(new URI("nats://server:42"), Duration.ofNanos(42));
+        natsChannel.shutdownInput();
+        assertEquals(Method.SHUTDOWN_INPUT, method[0]);
+        natsChannel.close();
+        assertEquals(Method.CLOSE, method[0]);
+
+
+        ByteBuffer bb = ByteBuffer.allocateDirect(10);
+        bb.position(3);
+        assertTrue(!bb.hasArray());
+        buff[0] = "hello".getBytes(UTF_8);
+        natsChannel.read(bb);
+        assertEquals(Method.READ, method[0]);
+        bb.flip();
+        bb.position(3);
+        assertEquals(ByteBuffer.wrap(buff[0]), bb);
+
+        buff[0] = new byte[10];
+        natsChannel.write(bb);
+        assertEquals(Method.WRITE, method[0]);
+        bb.flip();
+        bb.position(3);
+        assertEquals(ByteBuffer.wrap(buff[0]), bb);
+    }
+
+    @Test
+    public void socketDataPortTestForCoverage() throws IOException {
+        SocketDataPort dataPort = new SocketDataPort();
+        dataPort.flush(); // would never be called.
+
+        Options options = new Options.Builder().server("nats://example.com:42").build();
+        assertThrows(IOException.class, () -> dataPort.connect("nats://example.com:42", new NatsConnection(options), Duration.ofMillis(10).toNanos()));
+    }
+}

--- a/src/test/java/io/nats/client/impl/ErrorListenerTests.java
+++ b/src/test/java/io/nats/client/impl/ErrorListenerTests.java
@@ -229,7 +229,7 @@ public class ErrorListenerTests {
                 for (int i = 0; i < maxMessages + 1; i++) {
                     nc.publish("subject" + i, ("message" + i).getBytes());
                 }
-                nc.getWriter().start(nc.getDataPortFuture());
+                nc.getWriter().start(nc.getNatsChannelFuture());
 
                 nc.flush(Duration.ofSeconds(2));
             } finally {
@@ -238,7 +238,7 @@ public class ErrorListenerTests {
         }
 
         List<Message> discardedMessages = handler.getDiscardedMessages();
-        assertEquals(1, discardedMessages.size());
+        assertEquals(1, discardedMessages.size(), "Discarded messages=" + discardedMessages);
         assertEquals("subject10", discardedMessages.get(0).getSubject());
         assertEquals("message10", new String(discardedMessages.get(0).getData()));
     }

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -587,7 +587,7 @@ public class ReconnectTests {
             for (int i = 0; i < 100; i++) {
                 // stop and start in a loop without waiting for the future to complete
                 nc.getWriter().stop();
-                nc.getWriter().start(nc.getDataPortFuture());
+                nc.getWriter().start(nc.getNatsChannelFuture());
             }
 
             nc.getWriter().stop();

--- a/src/test/java/io/nats/client/support/BufferUtilsTests.java
+++ b/src/test/java/io/nats/client/support/BufferUtilsTests.java
@@ -1,0 +1,126 @@
+package io.nats.client.support;
+
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+import io.nats.client.channels.ByteBufferChannel;
+
+import static io.nats.client.support.BufferUtils.hexdump;
+import static io.nats.client.support.BufferUtils.readLine;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BufferUtilsTests {
+    @Test
+    public void testHexdump() {
+        byte[] allBytes = new byte[257];
+        for (int i=0; i < 256; i++) {
+            allBytes[i] = (byte)i;
+        }
+        assertEquals(
+            "0000  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  ␣␣␣␣␣␣␣␣␣␉␤␣␣␍␣␣\n" +
+            "0010  10 11 12 13 14 15 16 17  18 19 1A 1B 1C 1D 1E 1F  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "0020  20 21 22 23 24 25 26 27  28 29 2A 2B 2C 2D 2E 2F  ␠!\"#$%&'()*+,-./\n" +
+            "0030  30 31 32 33 34 35 36 37  38 39 3A 3B 3C 3D 3E 3F  0123456789:;<=>?\n" +
+            "0040  40 41 42 43 44 45 46 47  48 49 4A 4B 4C 4D 4E 4F  @ABCDEFGHIJKLMNO\n" +
+            "0050  50 51 52 53 54 55 56 57  58 59 5A 5B 5C 5D 5E 5F  PQRSTUVWXYZ[\\]^_\n" +
+            "0060  60 61 62 63 64 65 66 67  68 69 6A 6B 6C 6D 6E 6F  `abcdefghijklmno\n" +
+            "0070  70 71 72 73 74 75 76 77  78 79 7A 7B 7C 7D 7E 7F  pqrstuvwxyz{|}~␣\n" +
+            "0080  80 81 82 83 84 85 86 87  88 89 8A 8B 8C 8D 8E 8F  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "0090  90 91 92 93 94 95 96 97  98 99 9A 9B 9C 9D 9E 9F  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "00a0  A0 A1 A2 A3 A4 A5 A6 A7  A8 A9 AA AB AC AD AE AF  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "00b0  B0 B1 B2 B3 B4 B5 B6 B7  B8 B9 BA BB BC BD BE BF  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "00c0  C0 C1 C2 C3 C4 C5 C6 C7  C8 C9 CA CB CC CD CE CF  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "00d0  D0 D1 D2 D3 D4 D5 D6 D7  D8 D9 DA DB DC DD DE DF  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "00e0  E0 E1 E2 E3 E4 E5 E6 E7  E8 E9 EA EB EC ED EE EF  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "00f0  F0 F1 F2 F3 F4 F5 F6 F7  F8 F9 FA FB FC FD FE FF  ␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣␣\n" +
+            "0100  00                                                ␣\n",
+            hexdump(ByteBuffer.wrap(allBytes), 0, allBytes.length));
+    }
+
+    @Test
+    public void testNullReadLine() throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("Hello\nWorld".getBytes(UTF_8)));
+        assertThrows(NullPointerException.class, () -> readLine(null, channel));
+    }
+
+    @Test
+    public void testReadLineSmallBuffer() throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("Hello\n\nWorld".getBytes(UTF_8)));
+        ByteBuffer tmp = ByteBuffer.allocate(8);
+        assertEquals("Hello", readLine(tmp, channel));
+        assertEquals("", readLine(tmp, channel));
+        assertEquals("World", readLine(tmp, channel));
+        assertNull(readLine(tmp, channel));
+    }
+
+    @Test
+    public void testReadLineCRLF() throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("Hello\r\n\r\nWorld\r\n".getBytes(UTF_8)));
+        ByteBuffer tmp = ByteBuffer.allocate(8);
+        assertEquals("Hello", readLine(tmp, channel));
+        assertEquals("", readLine(tmp, channel));
+        assertEquals("World", readLine(tmp, channel));
+        assertNull(readLine(tmp, channel));
+    }
+
+    @Test
+    public void testReadLineCR() throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("Hello\r\rWorld\r".getBytes(UTF_8)));
+        ByteBuffer tmp = ByteBuffer.allocate(8);
+        assertEquals("Hello", readLine(tmp, channel));
+        assertEquals("", readLine(tmp, channel));
+        assertEquals("World", readLine(tmp, channel));
+        assertNull(readLine(tmp, channel));
+    }
+
+    @Test
+    public void testFinalNewline() throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("Hello\nWorld\n".getBytes(UTF_8)));
+        ByteBuffer tmp = ByteBuffer.allocate(8);
+        assertEquals("Hello", readLine(tmp, channel));
+        assertEquals("World", readLine(tmp, channel));
+        assertNull(readLine(tmp, channel));
+    }
+
+    @Test
+    public void testBufferUnderflow() throws IOException {
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("Hello\nWorld".getBytes(UTF_8)));
+        ByteBuffer tmp = ByteBuffer.allocate(3);
+        assertThrows(BufferUnderflowException.class, () -> {
+            String result = readLine(tmp, channel);
+            throw new RuntimeException("unexpected result=" + result);
+        });
+    }
+
+    @Test
+    public void testReadLineNullChannel() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(ByteBuffer.wrap("Hello\nWorld".getBytes(UTF_8)));
+        assertEquals("Hello", readLine(buffer, null));
+        assertEquals("World", readLine(buffer, null));
+        assertNull(readLine(buffer, null));
+    }
+
+    @Test
+    public void testReadLineBufferAndChannel() throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(1024);
+        buffer.put(ByteBuffer.wrap("Hell".getBytes(UTF_8)));
+
+        ByteBufferChannel channel = new ByteBufferChannel(ByteBuffer.allocate(1024));
+        channel.write(ByteBuffer.wrap("o\nWorld".getBytes(UTF_8)));
+        assertEquals("Hello", readLine(buffer, channel));
+        assertEquals("World", readLine(buffer, channel));
+        assertNull(readLine(buffer, channel));
+    }
+}

--- a/src/test/java/io/nats/client/support/WithTimeoutTests.java
+++ b/src/test/java/io/nats/client/support/WithTimeoutTests.java
@@ -1,0 +1,49 @@
+package io.nats.client.support;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import static io.nats.client.support.WithTimeout.withTimeout;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WithTimeoutTests {
+    public class CustomException extends Exception {
+    }
+
+    public class WrapException extends Exception {
+        public WrapException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    @Test
+    public void customExceptionTest() {
+        // Any "normal" exception should NOT be wrapped:
+        assertThrows(CustomException.class,
+            () -> {
+                withTimeout(() -> {
+                    if (true) throw new CustomException();
+                    return "";
+                }, Duration.ofSeconds(2), e -> new WrapException(e));
+            });
+    }
+
+    @Test
+    public void interruptedExceptionTest() {
+        // Any "normal" exception should NOT be wrapped:
+        WrapException ex = assertThrows(WrapException.class,
+            () -> {
+                // Mark the current thread as interrupted:
+                Thread.currentThread().interrupt();
+                withTimeout(() -> {
+                    if (true) throw new RuntimeException("unreachable");
+                    return "";
+                }, Duration.ofSeconds(2), e -> new WrapException(e));
+            });
+        // Clear the interrupt status:
+        assertTrue(Thread.interrupted());
+        assertEquals(InterruptedException.class, ex.getCause().getClass());
+    }
+}


### PR DESCRIPTION
This refactor prepares for laying sub-transports "under" NATS. Specifically, websockets (and HTTP proxies) would all be sub-transports.

To accomplish this, I have created a new `NatsChannel` abstraction which replaces the `DataPort` abstraction so that implementations of `NatsChannel` can be layered on top of each other (using the decorator design pattern). This is similar to how Java IO layers InputStream/BufferedInputStream/Reader on top of each other.

To support this, I added an `isSecure()` method to `NatsChannel` which replaces the need for the `upgradeToSecure()` method... more specifically, if an upgrade to secure is made, and the current `NatsChannel.isSecure()` returns false, then `NatsConnection` will now create a `TLSNatsChannel` which wraps the lower-level `NatsChannel`.

This allows us to re-use the `TLSNatsChannel` for our websocket implementation, and the websocket implementation can just implement `NatsChannel`.

Decisions made:
* After talking to @scottf about possibly making `NatsChannel` async, the decision was made to NOT make the code more complicated by making it async.
* The following APIs are not backwards compatible:
  * `Options.getDataPortType()` removed
  * `Options.buildDataPort()` removed
  * Custom implementations of `DataPort` will never have the `DataPort.upgradeToSecure()` method called.
  * Custom implementations of `DataPort` will never have the `DataPort.flush()` method called.
  * Custom implementations of `DataPort.connect()` will have a "fake" `NatsConnection` passed in and the only "useful" information in that object will be the `Options`.

Open Items:
* I can't help but notice that the `NatsConnectionWriter.flushBuffer()` doesn't work (even prior to my change) as expected. I believe the "proper" way to handle flushing the queue is to enqueue a "fake" message that indicates that a flush is desired, and then wait for that message to be flushed. More specifically, the previous code was calling `SocketOutputStream.flush()` which is known to be an empty implementation: https://bugs.java.com/bugdatabase/view_bug.do;jsessionid=61e3ecc1489150ffffffffcc5ccaf3f797827?bug_id=4358695 Therefore, I did NOT include the `flush()` call in the new `NatsChannel` abstraction.
* How to handle connect_urls in the INFO message that have no protocol (in preparation for websocket support)?