### PR TITLE
cluster name required in test config

### DIFF
--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -491,8 +491,8 @@ public class ReconnectTests {
         int ts2CPort = NatsTestServer.nextPort();
 
         String[] tsInserts = {
-                "",
                 "cluster {",
+                "name: testClusterName",
                 "listen: localhost:" + tsCPort,
                 "routes = [",
                 "nats-route://localhost:" + ts2CPort,
@@ -501,6 +501,7 @@ public class ReconnectTests {
         };
         String[] ts2Inserts = {
                 "cluster {",
+                "name: testClusterName",
                 "listen: localhost:" + ts2CPort,
                 "routes = [",
                 "nats-route://127.0.0.1:" + tsCPort,

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -533,7 +533,7 @@ public class ReconnectTests {
             handler.prepForStatusChange(Events.RECONNECTED);
 
             ts.close();
-            flushAndWait(nc, handler, VERY_LONG_TIMEOUT_MS, VERY_LONG_TIMEOUT_MS);
+            flushAndWaitLong(nc, handler);
             assertConnected(nc);
 
             URI uri = options.createURIForServer(nc.getConnectedUrl());


### PR DESCRIPTION
The config for a cluster needs a name. This test was somehow working, but was a flapper. Not sure why it worked sometimes without a cluster name, but should always work now.