### PR TITLE
use internal error codes

### DIFF
--- a/src/main/java/io/nats/client/JetStreamApiException.java
+++ b/src/main/java/io/nats/client/JetStreamApiException.java
@@ -37,8 +37,17 @@ public class JetStreamApiException extends Exception {
      *
      * @return the code
      */
-    public long getErrorCode() {
+    public int getErrorCode() {
         return apiResponse.getErrorCode();
+    }
+
+    /**
+     * Get the error code from the response
+     *
+     * @return the code
+     */
+    public int getApiErrorCode() {
+        return apiResponse.getApiErrorCode();
     }
 
     /**

--- a/src/main/java/io/nats/client/api/ApiResponse.java
+++ b/src/main/java/io/nats/client/api/ApiResponse.java
@@ -63,8 +63,12 @@ public abstract class ApiResponse<T> {
         return type;
     }
 
-    public long getErrorCode() {
+    public int getErrorCode() {
         return error == null ? NOT_SET : error.getCode();
+    }
+
+    public int getApiErrorCode() {
+        return error == null ? NOT_SET : error.getApiErrorCode();
     }
 
     public String getDescription() {

--- a/src/main/java/io/nats/client/api/Error.java
+++ b/src/main/java/io/nats/client/api/Error.java
@@ -25,7 +25,8 @@ public class Error {
     public static final int NOT_SET = -1;
 
     private final String json;
-    private final Integer code;
+    private final int code;
+    private final int apiErrorCode;
     private final String desc;
 
     static Error optionalInstance(String json) {
@@ -36,11 +37,16 @@ public class Error {
     Error(String json) {
         this.json = json;
         code = JsonUtils.readInt(json, CODE_RE, NOT_SET);
-        desc = JsonUtils.readString(json, DESCRIPTION_RE, null);
+        apiErrorCode = JsonUtils.readInt(json, ERR_CODE_RE, NOT_SET);
+        desc = JsonUtils.readString(json, DESCRIPTION_RE, "Unknown JetStream Error");
     }
 
-    public long getCode() {
+    public int getCode() {
         return code;
+    }
+
+    public int getApiErrorCode() {
+        return apiErrorCode;
     }
 
     public String getDescription() {
@@ -49,12 +55,17 @@ public class Error {
 
     @Override
     public String toString() {
-        if (desc == null) {
-            return code == NOT_SET
-                    ? "Unknown JetStream Error: " + json
-                    : "Unknown JetStream Error (" + code + ")";
+        if (code == NOT_SET) {
+            if (apiErrorCode == NOT_SET) {
+                return desc;
+            }
+            return desc + " [" + apiErrorCode + "]";
         }
 
-        return desc+ " (" + code + ")";
+        if (apiErrorCode == NOT_SET) {
+            return desc + " (" + code + ")";
+        }
+
+        return desc + " (" + code + ") [" + apiErrorCode + "]";
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -590,7 +590,7 @@ public class NatsJetStream implements JetStream, JetStreamManagement, NatsJetStr
             return getConsumerInfo(stream, consumer);
         }
         catch (JetStreamApiException e) {
-            if (e.getErrorCode() == 404 && e.getErrorDescription().contains("consumer")) {
+            if (e.getApiErrorCode() == JS_CONSUMER_NOT_FOUND_ERR) {
                 return null;
             }
             throw e;

--- a/src/main/java/io/nats/client/support/ApiConstants.java
+++ b/src/main/java/io/nats/client/support/ApiConstants.java
@@ -46,6 +46,7 @@ public interface ApiConstants {
     String DUPLICATE        = "duplicate";
     String DUPLICATE_WINDOW = "duplicate_window";
     String DURABLE_NAME     = "durable_name";
+    String ERR_CODE         = "err_code";
     String ERROR            = "error";
     String EXTERNAL         = "external";
     String FILTER_SUBJECT   = "filter_subject";
@@ -146,6 +147,7 @@ public interface ApiConstants {
     Pattern DUPLICATE_RE        = boolean_pattern(DUPLICATE);
     Pattern DUPLICATE_WINDOW_RE = number_pattern(DUPLICATE_WINDOW);
     Pattern DURABLE_NAME_RE     = string_pattern(DURABLE_NAME);
+    Pattern ERR_CODE_RE         = number_pattern(ERR_CODE);
     Pattern FILTER_SUBJECT_RE   = string_pattern(FILTER_SUBJECT);
     Pattern FIRST_SEQ_RE        = number_pattern(FIRST_SEQ);
     Pattern FIRST_TS_RE         = string_pattern(FIRST_TS);

--- a/src/main/java/io/nats/client/support/NatsJetStreamConstants.java
+++ b/src/main/java/io/nats/client/support/NatsJetStreamConstants.java
@@ -64,4 +64,6 @@ public interface NatsJetStreamConstants {
     String EXPECTED_STREAM_HDR = "Nats-Expected-Stream";
     String EXPECTED_LAST_SEQ_HDR = "Nats-Expected-Last-Sequence";
     String EXPECTED_LAST_MSG_ID_HDR = "Nats-Expected-Last-Msg-Id";
+
+    int JS_CONSUMER_NOT_FOUND_ERR = 10014;
 }

--- a/src/test/java/io/nats/client/api/ApiResponseTests.java
+++ b/src/test/java/io/nats/client/api/ApiResponseTests.java
@@ -64,37 +64,35 @@ public class ApiResponseTests {
         assertTrue(jsApiResp.hasError());
         assertEquals("non_zero_code_only_response", jsApiResp.getType());
         assertEquals(500, jsApiResp.getErrorCode());
-        assertNull(jsApiResp.getDescription());
         assertEquals("Unknown JetStream Error (500)", jsApiResp.getError());
         jsApiEx = new JetStreamApiException(jsApiResp);
         assertEquals(500, jsApiEx.getErrorCode());
-        assertNull(jsApiEx.getErrorDescription());
 
         jsApiResp = new TestApiResponse(jsons[3]);
         assertTrue(jsApiResp.hasError());
         assertEquals("no_code_response", jsApiResp.getType());
         assertEquals(Error.NOT_SET, jsApiResp.getErrorCode());
         assertEquals("no code", jsApiResp.getDescription());
-        assertEquals("no code (-1)", jsApiResp.getError());
+        assertEquals("no code", jsApiResp.getError());
         jsApiEx = new JetStreamApiException(jsApiResp);
         assertEquals(-1, jsApiEx.getErrorCode());
+        assertEquals(-1, jsApiEx.getApiErrorCode());
         assertEquals("no code", jsApiEx.getErrorDescription());
 
         jsApiResp = new TestApiResponse(jsons[4]);
         assertTrue(jsApiResp.hasError());
         assertEquals("empty_response", jsApiResp.getType());
         assertEquals(Error.NOT_SET, jsApiResp.getErrorCode());
-        assertNull(jsApiResp.getDescription());
-        assertTrue(jsApiResp.getError().startsWith("Unknown JetStream Error:"));
         jsApiEx = new JetStreamApiException(jsApiResp);
         assertEquals(-1, jsApiEx.getErrorCode());
-        assertNull(jsApiEx.getErrorDescription());
+        assertEquals(-1, jsApiEx.getApiErrorCode());
 
         jsApiResp = new TestApiResponse(jsons[5]);
         assertFalse(jsApiResp.hasError());
         assertEquals("not_error_response", jsApiResp.getType());
         jsApiEx = new JetStreamApiException(jsApiResp);
         assertEquals(-1, jsApiEx.getErrorCode());
+        assertEquals(-1, jsApiEx.getApiErrorCode());
         assertNull(jsApiEx.getErrorDescription());
 
         jsApiResp = new TestApiResponse(jsons[6]);

--- a/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
@@ -256,12 +256,20 @@ public class JetStreamManagementTests extends JetStreamTestBase {
     public void testDeleteStream() throws Exception {
         runInJsServer(nc -> {
             JetStreamManagement jsm = nc.jetStreamManagement();
-            assertThrows(JetStreamApiException.class, () -> jsm.deleteStream(STREAM));
+            JetStreamApiException jsapiEx =
+                    assertThrows(JetStreamApiException.class, () -> jsm.deleteStream(STREAM));
+            assertEquals(10059, jsapiEx.getApiErrorCode());
+
             createMemoryStream(nc, STREAM, SUBJECT);
-            assertNotNull(getStreamInfo(jsm, STREAM));
+            assertNotNull(jsm.getStreamInfo(STREAM));
             assertTrue(jsm.deleteStream(STREAM));
-            assertNull(getStreamInfo(jsm, STREAM));
-            assertThrows(JetStreamApiException.class, () -> jsm.deleteStream(STREAM));
+
+
+            jsapiEx = assertThrows(JetStreamApiException.class, () -> jsm.getStreamInfo(STREAM));
+            assertEquals(10059, jsapiEx.getApiErrorCode());
+
+            jsapiEx = assertThrows(JetStreamApiException.class, () -> jsm.deleteStream(STREAM));
+            assertEquals(10059, jsapiEx.getApiErrorCode());
         });
     }
 
@@ -375,8 +383,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
 
     private void invalidThenOrUpdate(JetStreamManagement jsm, ConsumerConfiguration cc) {
         JetStreamApiException e = assertThrows(JetStreamApiException.class, () -> jsm.addOrUpdateConsumer(STREAM, cc));
-        assertEquals("consumer already exists", e.getErrorDescription());
-        assertEquals(500, e.getErrorCode());
+        assertEquals(10013, e.getApiErrorCode());
     }
 
     private void validAddThenUpdate(JetStreamManagement jsm, ConsumerConfiguration cc) throws IOException, JetStreamApiException {

--- a/src/test/java/io/nats/client/impl/JetStreamTestBase.java
+++ b/src/test/java/io/nats/client/impl/JetStreamTestBase.java
@@ -64,18 +64,6 @@ public class JetStreamTestBase extends TestBase {
         return createMemoryStream(jsm, STREAM, SUBJECT);
     }
 
-    public static StreamInfo getStreamInfo(JetStreamManagement jsm, String streamName) throws IOException, JetStreamApiException {
-        try {
-            return jsm.getStreamInfo(streamName);
-        }
-        catch (JetStreamApiException jsae) {
-            if (jsae.getErrorCode() == 404) {
-                return null;
-            }
-            throw jsae;
-        }
-    }
-
     public static void debug(JetStreamManagement jsm, int n) throws IOException, JetStreamApiException {
         System.out.println("\n" + n + ". -------------------------------");
         printStreamInfo(jsm.getStreamInfo(STREAM));


### PR DESCRIPTION
A unit test failed on the nightly because the server changed the text of an error. This fix is to use the new err_code field supplied in the json of api error response, instead of using the text.