### PR TITLE
Websocket support

### DIFF
--- a/src/main/java/io/nats/client/HttpRequest.java
+++ b/src/main/java/io/nats/client/HttpRequest.java
@@ -1,0 +1,129 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client;
+
+import io.nats.client.impl.Headers;
+
+/**
+ * Encapsulate an HttpRequest, in Java 11 we could use this class:
+ * https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html
+ * 
+ * ...but we want to support older JVMs.
+ */
+public class HttpRequest {
+    private String method = "GET";
+    private String uri = "/";
+    private String version = "1.0";
+    private Headers headers = new Headers();
+
+    /**
+     * @return the attached http headers, defaults to GET
+     */
+    public Headers getHeaders() {
+        return headers;
+    }
+
+    /**
+     * @return the request method (GET, POST, etc)
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Note that no validation is performed, but the method is trimmed of whitespace
+     * and converted to all upper case.
+     * 
+     * @param method is the new request method to use.
+     * @return this for method chaining.
+     */
+    public HttpRequest method(String method) {
+        if (null == method) {
+            throw new IllegalArgumentException("HttpRequest method must be non-null");
+        }
+        this.method = method.trim().toUpperCase();
+        return this;
+    }
+
+    /**
+     * This is the RAW URI, you may need to perform URL decoding the result.
+     * 
+     * @return the "path" of the URI (in the RFC this is the request-URI)
+     */
+    public String getURI() {
+        return uri;
+    }
+
+    /**
+     * This sets the RAW URI, you may need to perform URL encoding before passing
+     * into this method.
+     * 
+     * @param uri is the new "path" of the URI to use.
+     * @return this for method chaining.
+     */
+    public HttpRequest uri(String uri) {
+        if (null == uri) {
+            throw new IllegalArgumentException("HttpRequest uri must be non-null");
+        }
+        this.uri = uri;
+        return this;
+    }
+
+    /**
+     * @return the HTTP version to use for this request. Defaults to "1.0"
+     */
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * Note that no validation is performed on the version. Probably only makes
+     * sense to use "0.9", "1.0", "1.1", or "2".
+     * 
+     * @param version is the new HTTP version to use.
+     * @return this for method chaining.
+     */
+    public HttpRequest version(String version) {
+        if (null == version) {
+            throw new IllegalArgumentException("HttpRequest version must be non-null");
+        }
+        this.version = version;
+        return this;
+    }
+
+    /**
+     * @return the textual representation of the HTTP request line + headers (no
+     *         body)
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(method);
+        sb.append(" ");
+        sb.append(uri);
+        sb.append(" HTTP/");
+        sb.append(version);
+        sb.append("\r\n");
+        headers.forEach((key, values) -> {
+            values.stream().forEach(value -> {
+                sb.append(key);
+                sb.append(": ");
+                sb.append(value);
+                sb.append("\r\n");
+            });
+        });
+        sb.append("\r\n");
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/nats/client/impl/DataPort.java
+++ b/src/main/java/io/nats/client/impl/DataPort.java
@@ -33,6 +33,10 @@ public interface DataPort {
 
     int read(byte[] dst, int off, int len) throws IOException;
 
+    /**
+     * NOTE: the buffer will be modified if communicating over websockets and
+     * the toWrite is greater than 1432.
+     */
     void write(byte[] src, int toWrite) throws IOException;
 
     void shutdownInput() throws IOException;

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -41,6 +41,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.nats.client.Options.isWebsocket;
 import static io.nats.client.support.NatsConstants.*;
 import static io.nats.client.support.Validator.validateNotNull;
 
@@ -403,7 +404,7 @@ class NatsConnection implements Connection {
                 readInitialInfo();
                 checkVersionRequirements();
                 long start = System.nanoTime();
-                upgradeToSecureIfNeeded();
+                upgradeToSecureIfNeeded(serverURI);
                 if (trace && options.isTLSRequired()) {
                     // If the time appears too long it might be related to
                     // https://github.com/nats-io/nats.java#linux-platform-note
@@ -511,17 +512,23 @@ class NatsConnection implements Connection {
         }
     }
 
-    void upgradeToSecureIfNeeded() throws IOException {
+    void upgradeToSecureIfNeeded(String serverURI) throws IOException {
         Options opts = getOptions();
         ServerInfo info = getInfo();
 
-        if (opts.isTLSRequired() && !info.isTLSRequired()) {
+        boolean isTLSRequired = opts.isTLSRequired();
+        if (isTLSRequired && isWebsocket(serverURI)) {
+            // We are already communicating over "https" websocket, so
+            // do NOT try to upgrade to secure.
+            isTLSRequired = false;
+        }
+        if (isTLSRequired && !info.isTLSRequired()) {
             throw new IOException("SSL connection wanted by client.");
-        } else if (!opts.isTLSRequired() && info.isTLSRequired()) {
+        } else if (!isTLSRequired && info.isTLSRequired()) {
             throw new IOException("SSL required by server.");
         }
 
-        if (opts.isTLSRequired()) {
+        if (isTLSRequired) {
             this.dataPort.upgradeToSecure();
         }
     }
@@ -1556,7 +1563,7 @@ class NatsConnection implements Connection {
             for (String uri : info.getConnectURLs()) {
                 try {
                     // call to createURIForServer is to parse (normalize)
-                    addNoDupes(servers, options.createURIForServer(uri).toString());
+                    addNoDupes(servers, options.createURIForServer(uri, isWebsocket(this.currentServer)).toString());
                 }
                 catch (URISyntaxException e) {
                     // this should never happen since this list comes from the server

--- a/src/main/java/io/nats/client/support/NatsConstants.java
+++ b/src/main/java/io/nats/client/support/NatsConstants.java
@@ -24,7 +24,9 @@ public interface NatsConstants {
     String NATS_PROTOCOL = "nats";
     String TLS_PROTOCOL = "tls";
     String OPENTLS_PROTOCOL = "opentls";
-    List<String> KNOWN_PROTOCOLS = Arrays.asList(NATS_PROTOCOL, TLS_PROTOCOL, OPENTLS_PROTOCOL);
+    String WEBSOCKET_PROTOCOL = "ws";
+    String SECURE_WEBSOCKET_PROTOCOL = "wss";
+    List<String> KNOWN_PROTOCOLS = Arrays.asList(NATS_PROTOCOL, TLS_PROTOCOL, OPENTLS_PROTOCOL, WEBSOCKET_PROTOCOL, SECURE_WEBSOCKET_PROTOCOL);
     String NATS_PROTOCOL_SLASH_SLASH = "nats://";
 
     String SPACE = " ";

--- a/src/main/java/io/nats/client/support/WebSocket.java
+++ b/src/main/java/io/nats/client/support/WebSocket.java
@@ -1,0 +1,367 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import io.nats.client.HttpRequest;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class WebSocket extends Socket {
+    private static final int MAX_LINE_LEN = 8192;
+    private static final int MAX_HTTP_HEADERS = 100;
+    private static final String WEBSOCKET_RESPONSE_LINE =
+        "HTTP/1.1 101 Switching Protocols";
+
+    private Socket wrap;
+    private WebsocketInputStream in;
+    private WebsocketOutputStream out;
+
+    public WebSocket(Socket wrap, String host, List<Consumer<HttpRequest>> interceptors) throws IOException {
+        this.wrap = wrap;
+        handshake(wrap, host, interceptors);
+        this.in = new WebsocketInputStream(wrap.getInputStream());
+        this.out = new WebsocketOutputStream(wrap.getOutputStream(), true);
+    }
+
+    private static void handshake(Socket socket, String host, List<Consumer<HttpRequest>> interceptors) throws IOException {
+        InputStream in = socket.getInputStream();
+        OutputStream out = socket.getOutputStream();
+        HttpRequest request = new HttpRequest();
+
+        // The value of this header field MUST be a
+        // nonce consisting of a randomly selected 16-byte value that has
+        // been base64-encoded
+        byte[] keyBytes = new byte[16];
+        new SecureRandom().nextBytes(keyBytes);
+        String key = Base64.getEncoder().encodeToString(keyBytes);
+
+        request.getHeaders()
+            .add("Host", host)
+            .add("Upgrade", "websocket")
+            .add("Connection", "Upgrade")
+            .add("Sec-WebSocket-Key", key)
+            .add("Sec-WebSocket-Protocol", "nats")
+            .add("Sec-WebSocket-Version", "13");
+            // TODO: Support Sec-WebSocket-Extensions: permessage-deflate
+            // TODO: Support Nats-No-Masking: TRUE
+
+        for (Consumer<HttpRequest> interceptor : interceptors) {
+            interceptor.accept(request);
+        }
+        out.write(request.toString().getBytes(UTF_8));
+
+        // rfc6455 4.1 "The client MUST validate the server's response as follows:"
+        byte[] buffer = new byte[MAX_LINE_LEN];
+        String responseLine = readLine(buffer, in);
+        if (null == responseLine) {
+            throw new IllegalStateException("Expected HTTP response line not to exceed " + MAX_LINE_LEN);
+        }
+        // 1. expect 101:
+        if (!responseLine.toLowerCase().startsWith(WEBSOCKET_RESPONSE_LINE.toLowerCase())) {
+            throw new IllegalStateException("Expected " + WEBSOCKET_RESPONSE_LINE + ", but got " + responseLine);
+        }
+        Map<String, String> headers = new HashMap<>();
+        while (true) {
+            String line = readLine(buffer, in);
+            if (null == line) {
+                throw new IllegalStateException("Expected HTTP header to not exceed " + MAX_LINE_LEN);
+            }
+            if ("".equals(line)) {
+                break;
+            }
+            int colon = line.indexOf(':');
+            if (colon >= 0) {
+                if (headers.size() >= MAX_HTTP_HEADERS) {
+                    throw new IllegalStateException("Exceeded max HTTP headers=" + MAX_HTTP_HEADERS);
+                }
+                headers.put(
+                    line.substring(0, colon).trim().toLowerCase(),
+                    line.substring(colon + 1).trim());
+            } else {
+                throw new IllegalStateException("Expected HTTP header to contain ':', but got " + line);
+            }
+        }
+        // 2. Expect `Upgrade: websocket`
+        if (!"websocket".equalsIgnoreCase(headers.get("upgrade"))) {
+            throw new IllegalStateException(
+                "Expected HTTP `Upgrade: websocket` header");
+        }
+        // 3. Expect `Connection: Upgrade`
+        if (!"upgrade".equalsIgnoreCase(headers.get("connection"))) {
+            throw new IllegalStateException(
+                "Expected HTTP `Connection: Upgrade` header");
+        }
+        // 4. Sec-WebSocket-Accept: base64(sha1(key + "258EAF..."))
+        MessageDigest sha1;
+        try {
+            sha1 = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException(ex);
+        }
+        sha1.update(key.getBytes(UTF_8));
+        sha1.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11".getBytes(UTF_8));
+        String acceptKey = Base64.getEncoder().encodeToString(
+            sha1.digest());
+        String gotAcceptKey = headers.get("sec-websocket-accept");
+        if (!acceptKey.equals(gotAcceptKey)) {
+            throw new IllegalStateException(
+                "Expected HTTP `Sec-WebSocket-Accept: " + acceptKey + ", but got " + gotAcceptKey);
+        }
+        // 5 & 6 are not valid, since nats-server doesn't
+        // implement extensions or protocols.
+    }
+
+    private static String readLine(byte[] buffer, InputStream in) throws IOException {
+        int offset = 0;
+        int lastCh = -1;
+        while (true) {
+            int ch = in.read();
+            switch (ch) {
+            case -1:
+                // Premature EOF (everything should be terminated with \n)
+                return new String(buffer, 0, offset);
+            case '\n':
+                // Found \n, remove \r if it is there:
+                return new String(
+                    buffer,
+                    0,
+                    '\r' == lastCh ? offset - 1 : offset);
+            }
+            // Line length exceeded:
+            if (offset >= buffer.length) {
+                return null;
+            }
+            buffer[offset++] = (byte)ch;
+            lastCh = ch;
+        }
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return in;
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return out;
+    }
+
+    @Override
+    public void connect(SocketAddress addr) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void connect(SocketAddress addr, int port) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void bind(SocketAddress addr) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SocketChannel getChannel() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        return wrap.getInetAddress();
+    }
+
+    @Override
+    public InetAddress getLocalAddress() {
+        return wrap.getLocalAddress();
+    }
+
+    @Override
+    public int getPort() {
+        return wrap.getPort();
+    }
+
+    @Override
+    public int getLocalPort() {
+        return wrap.getLocalPort();
+    }
+
+    @Override
+    public SocketAddress getRemoteSocketAddress() {
+        return wrap.getRemoteSocketAddress();
+    }
+
+    @Override
+    public SocketAddress getLocalSocketAddress() {
+        return wrap.getLocalSocketAddress();
+    }
+
+    @Override
+    public void setTcpNoDelay(boolean on) throws SocketException {
+        wrap.setTcpNoDelay(on);
+    }
+
+    @Override
+    public boolean getTcpNoDelay() throws SocketException {
+        return wrap.getTcpNoDelay();
+    }
+
+    @Override
+    public void setSoLinger(boolean on, int linger) throws SocketException {
+        wrap.setSoLinger(on, linger);
+    }
+
+    @Override
+    public int getSoLinger() throws SocketException {
+        return wrap.getSoLinger();
+    }
+
+    @Override
+    public void sendUrgentData(int data) throws IOException {
+        wrap.sendUrgentData(data);
+    }
+
+    @Override
+    public void setOOBInline(boolean on) throws SocketException {
+        wrap.setOOBInline(on);
+    }
+
+    @Override
+    public boolean getOOBInline() throws SocketException {
+        return wrap.getOOBInline();
+    }
+
+    @Override
+    public void setSoTimeout(int timeout) throws SocketException {
+        wrap.setSoTimeout(timeout);
+    }
+
+    @Override
+    public int getSoTimeout() throws SocketException {
+        return wrap.getSoTimeout();
+    }
+
+    @Override
+    public void setSendBufferSize(int size) throws SocketException {
+        wrap.setSendBufferSize(size);
+    }
+
+    @Override
+    public int getSendBufferSize() throws SocketException {
+        return wrap.getSendBufferSize();
+    }
+
+    @Override
+    public void setReceiveBufferSize(int size) throws SocketException {
+        wrap.setReceiveBufferSize(size);
+    }
+
+    @Override
+    public int getReceiveBufferSize() throws SocketException {
+        return wrap.getReceiveBufferSize();
+    }
+
+    @Override
+    public void setKeepAlive(boolean on) throws SocketException {
+        wrap.setKeepAlive(on);
+    }
+
+    @Override
+    public boolean getKeepAlive() throws SocketException {
+        return wrap.getKeepAlive();
+    }
+
+    @Override
+    public void setTrafficClass(int tc) throws SocketException {
+        wrap.setTrafficClass(tc);
+    }
+
+    @Override
+    public int getTrafficClass() throws SocketException {
+        return wrap.getTrafficClass();
+    }
+
+    @Override
+    public void setReuseAddress(boolean on) throws SocketException {
+        wrap.setReuseAddress(on);
+    }
+
+    @Override
+    public boolean getReuseAddress() throws SocketException {
+        return wrap.getReuseAddress();
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        // TODO: send websocket close:
+        wrap.close();
+    }
+
+    @Override
+    public void shutdownInput() throws IOException {
+        wrap.shutdownInput();
+    }
+
+    @Override
+    public void shutdownOutput() throws IOException {
+        wrap.shutdownOutput();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return wrap.isConnected();
+    }
+
+    @Override
+    public boolean isBound() {
+        return wrap.isBound();
+    }
+
+    @Override
+    public boolean isClosed() {
+        return wrap.isClosed();
+    }
+
+    @Override
+    public boolean isInputShutdown() {
+        return wrap.isInputShutdown();
+    }
+
+    @Override
+    public boolean isOutputShutdown() {
+        return wrap.isOutputShutdown();
+    }
+
+    @Override
+    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+        wrap.setPerformancePreferences(connectionTime, latency, bandwidth);
+    }
+}

--- a/src/main/java/io/nats/client/support/WebsocketFrameHeader.java
+++ b/src/main/java/io/nats/client/support/WebsocketFrameHeader.java
@@ -1,0 +1,271 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+public class WebsocketFrameHeader {
+    public static int MAX_FRAME_HEADER_SIZE = 14;
+
+    public enum OpCode {
+        CONTINUATION(0),
+        TEXT(1),
+        BINARY(2),
+        CLOSE(8),
+        PING(9),
+        PONG(10),
+        UNKNOWN(0x10);
+
+        private int code;
+
+        OpCode(int code) {
+            this.code = code;
+        }
+
+        public int getCode() {
+            return this.code;
+        }
+
+        public static OpCode of(int code) {
+            switch (code) {
+                case 0: return CONTINUATION;
+                case 1: return TEXT;
+                case 2: return BINARY;
+                case 8: return CLOSE;
+                case 9: return PING;
+                case 10: return PONG;
+            }
+            return UNKNOWN;
+        }
+    }
+
+    // Fields of header:
+    private byte byte0;
+    private boolean mask;
+    private long payloadLength;
+    private int maskingKey;
+    private int maskingKeyOffset = 0;
+
+    public WebsocketFrameHeader withOp(OpCode op, boolean isFinal) {
+        this.byte0 = (byte)(op.getCode() | (isFinal ? 0x80 : 0));
+        return this;
+    }
+
+    public WebsocketFrameHeader withNoMask() {
+        this.mask = false;
+        return this;
+    }
+
+    public WebsocketFrameHeader withMask(int maskingKey) {
+        this.mask = true;
+        this.maskingKey = maskingKey;
+        this.maskingKeyOffset = 0;
+        return this;
+    }
+
+    public WebsocketFrameHeader withPayloadLength(long payloadLength) {
+        this.payloadLength = payloadLength;
+        return this;
+    }
+
+    public boolean isFinal() {
+        return (byte0 & 0x80) != 0;
+    }
+
+    public boolean isMasked() {
+        return mask;
+    }
+
+    public int getMaskingKey() {
+        return maskingKey;
+    }
+
+    public long getPayloadLength() {
+        return payloadLength;
+    }
+
+    public OpCode getOpCode() {
+        return OpCode.of(byte0 & 0xF);
+    }
+
+    public boolean isPayloadEmpty() {
+        return 0 == payloadLength;
+    }
+
+    /**
+     * Decrement the payloadLength by at most maxSize such that payloadLength is non-negative,
+     * returning the amount decremented.
+     * 
+     * @param buffer is the buffer to filter.
+     * @param offset is the start offset within buffer to filter.
+     * @param length is the number of bytes to filter.
+     * 
+     * @return min(payloadLength, maxSize), decrementing the internal payloadLength by this amount.
+     */
+    public int filterPayload(byte[] buffer, int offset, int length) {
+        length = Math.min(length, payloadLength > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int)payloadLength);
+        payloadLength -= length;
+        if (mask) {
+            for (int i=0; i < length; i++) {
+                int key = 0xFF & (maskingKey >> (8 * (7 - maskingKeyOffset)));
+                buffer[offset + i] ^= key;
+                maskingKeyOffset = (maskingKeyOffset + 1) % 8;
+            }
+        }
+        return length;
+    }
+
+    public int size() {
+        int size = 2;
+        if (payloadLength > 0xFFFF) {
+            size += 8;
+        } else if (payloadLength > 125) {
+            size += 2;
+        }
+        if (mask) {
+            size += 4;
+        }
+        return size;
+    }
+
+    /**
+     * Introspects the first 2 bytes of buffer at the specified offset to
+     * determine how large the entire header is.
+     * 
+     * @param buffer is the buffer to introspect
+     * @param offset is the offset within the buffer where the websocket
+     *     header begins.
+     * @return the number of bytes used by the full websocket header.
+     */
+    public static int size(byte[] buffer, int offset) {
+        int size = 2;
+        if (0 != (buffer[offset + 1] & 0x80)) {
+            // mask adds 4 required bytes.
+            size += 4;
+        }
+
+        switch (buffer[offset + 1] & 0x7F) {
+        case 126:
+            size += 2;
+            break;
+        case 127:
+            size += 8;
+            break;
+        }
+        return size;
+    }
+
+    /**
+     * Serializes this WebsocketFrameHeader into a buffer.
+     * 
+     * @param buffer where the serialized header will be placed.
+     * 
+     * @param offset is the start offset into the buffer.
+     * 
+     * @param length is the max bytes that can be placed in the buffer.
+     * 
+     * @return 0 if there is insufficient remainder in the buffer, otherwise
+     *    returns the number of bytes placed into the buffer.
+     */
+    public int read(byte[] buffer, int offset, int length) {
+        if (length < size()) {
+            return 0;
+        }
+
+        int startOffset = offset;
+
+        buffer[offset++] = byte0;
+        if (payloadLength > 0xFFFF) {
+            buffer[offset++] = (byte)(127 | (mask ? 0x80 : 0));
+            // 64 bit length
+            buffer[offset++] = (byte)((payloadLength >> 56) & 0xFF);
+            buffer[offset++] = (byte)((payloadLength >> 48) & 0xFF);
+            buffer[offset++] = (byte)((payloadLength >> 40) & 0xFF);
+            buffer[offset++] = (byte)((payloadLength >> 32) & 0xFF);
+            buffer[offset++] = (byte)((payloadLength >> 24) & 0xFF);
+            buffer[offset++] = (byte)((payloadLength >> 16) & 0xFF);
+            buffer[offset++] = (byte)((payloadLength >> 8) & 0xFF);
+            buffer[offset++] = (byte)(payloadLength & 0xFF);
+        } else if (payloadLength > 125) {
+            buffer[offset++] = (byte)(126 | (mask ? 0x80 : 0));
+            // 16 bit length
+            buffer[offset++] = (byte)(payloadLength >> 8);
+            buffer[offset++] = (byte)(payloadLength & 0xFF);
+        } else {
+            buffer[offset++] = (byte)(payloadLength | (mask ? 0x80 : 0));
+        }
+        if (mask) {
+            buffer[offset++] = (byte)((maskingKey >> 24) & 0xFF);
+            buffer[offset++] = (byte)((maskingKey >> 16) & 0xFF);
+            buffer[offset++] = (byte)((maskingKey >> 8) & 0xFF);
+            buffer[offset++] = (byte)(maskingKey & 0xFF);
+        }
+        return offset - startOffset;
+    }
+
+    /**
+     * Overwrite internal frame header content with input buffer.
+     * 
+     * <pre>
+     * WebsocketFrameHeader header = new WebsocketFrameHeader();
+     * int consumedLength = header.write(buffer, offset, length);
+     * offset += consumedLength;
+     * length -= consumedLength;
+     * </pre>
+     * 
+     * @param buffer containing the serialized header.
+     * 
+     * @param offset is the start offset into the buffer.
+     * 
+     * @param length is the max bytes to consume.
+     * 
+     * @return 0 if there is insufficient remainder in the buffer, otherwise
+     *     returns the number of bytes consumed from the buffer.
+     */
+    public int write(byte[] buffer, int offset, int length) {
+        // Sufficient remainder?
+        if (length < 2) {
+            return 0;
+        }
+        int size = size(buffer, offset);
+        if (size > length) {
+            return 0;
+        }
+
+        byte0 = buffer[offset++];
+        mask = 0 != (buffer[offset] & 0x80);
+        payloadLength = buffer[offset] & 0x7F;
+        offset++;
+        if (126 == payloadLength) {
+            payloadLength = 0;
+            for (int i=0; i < 2; i++) {
+                payloadLength <<= 8;
+                payloadLength |= buffer[offset++] & 0xFF;
+            }
+        } else if (127 == payloadLength) {
+            payloadLength = 0;
+            for (int i=0; i < 8; i++) {
+                payloadLength <<= 8;
+                payloadLength |= buffer[offset++] & 0xFF;
+            }
+        }
+        if (mask) {
+            maskingKey = 0;
+            maskingKeyOffset = 0;
+            for (int i=0; i < 4; i++) {
+                maskingKey <<= 8;
+                maskingKey |= buffer[offset++] & 0xFF;
+            }
+        }
+        return size;
+    }
+}

--- a/src/main/java/io/nats/client/support/WebsocketInputStream.java
+++ b/src/main/java/io/nats/client/support/WebsocketInputStream.java
@@ -1,0 +1,100 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class WebsocketInputStream extends InputStream {
+    private byte[] buffer = new byte[WebsocketFrameHeader.MAX_FRAME_HEADER_SIZE];
+    private WebsocketFrameHeader header = new WebsocketFrameHeader();
+    private InputStream in;
+    private byte[] oneByte = new byte[1];
+
+    public WebsocketInputStream(InputStream in) {
+        this.in = in;
+    }
+
+    @Override
+    public int available() throws IOException {
+        return in.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+    }
+
+    @Override
+    public void mark(int readLimit) {
+
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public int read(byte[] buffer) throws IOException {
+        return read(buffer, 0, buffer.length);
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+        // Just in case we get headers with empty payloads:
+        while (0 == header.getPayloadLength()) {
+            if (!readHeader()) {
+                return -1;
+            }
+        }
+        length = in.read(buffer, offset, length);
+        if (-1 == length) {
+            return length;
+        }
+        return header.filterPayload(buffer, offset, length);
+    }
+
+    @Override
+    public int read() throws IOException {
+        int result = read(oneByte, 0, 1);
+        if (-1 == result) {
+            return result;
+        }
+        return oneByte[0];
+    }
+
+    private boolean readHeader() throws IOException {
+        int len = 0;
+        while (len < 2) {
+            int result = in.read(buffer, len, 2 - len);
+            if (result < 0) {
+                return false;
+            }
+            len += result;
+        }
+        int headerSize = WebsocketFrameHeader.size(buffer, 0);
+        if (headerSize > 2) {
+            while (len < headerSize) {
+                int result = in.read(buffer, len, headerSize - len);
+                if (result < 0) {
+                    return false;
+                }
+                len += result;
+            }
+        }
+        header.write(buffer, 0, headerSize);
+        return true;
+    }
+}

--- a/src/main/java/io/nats/client/support/WebsocketInputStream.java
+++ b/src/main/java/io/nats/client/support/WebsocketInputStream.java
@@ -16,6 +16,8 @@ package io.nats.client.support;
 import java.io.IOException;
 import java.io.InputStream;
 
+import io.nats.client.support.WebsocketFrameHeader.OpCode;
+
 public class WebsocketInputStream extends InputStream {
     private byte[] buffer = new byte[WebsocketFrameHeader.MAX_FRAME_HEADER_SIZE];
     private WebsocketFrameHeader header = new WebsocketFrameHeader();
@@ -58,6 +60,11 @@ public class WebsocketInputStream extends InputStream {
             if (!readHeader()) {
                 return -1;
             }
+        }
+        if (header.getOpCode() == OpCode.CLOSE) {
+            // Ignore the websocket close message body:
+            in.skip(header.getPayloadLength());
+            return -1;
         }
         length = in.read(buffer, offset, length);
         if (-1 == length) {

--- a/src/main/java/io/nats/client/support/WebsocketOutputStream.java
+++ b/src/main/java/io/nats/client/support/WebsocketOutputStream.java
@@ -1,0 +1,115 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.SecureRandom;
+import java.util.Random;
+
+import io.nats.client.support.WebsocketFrameHeader.OpCode;
+
+public class WebsocketOutputStream extends OutputStream {
+    private OutputStream wrap;
+    private boolean masked;
+    private byte[] oneByte = new byte[1];
+    /**
+     * Minimize fragmenting, by using a 1440 buffer size. This buffer is used to
+     * store the websocket header + payload for the first write.
+     *
+     * We are using this size since a typical MTU for ethernet is 1500 and the
+     * TCP/IPv6 header consumes 60 bytes, thus by using 1440 we should minimize
+     * the need for further fragmentation at the lower layers and yet minimize
+     * the overhead associated with the fact that a write to the Socket (which
+     * has NO_DELAY set on it) results in a single TCP/IPv6 datagram which has
+     * a 60 byte overhead.
+     *
+     * Note that the effective payload is less due to the websocket frame overhead:
+     * 4 bytes header/length + 4 bytes masking. Which would be a payload
+     * size of 1432. This means any write which is larger than 1432 will be
+     * fragmented into two socket writes and will thus have another 60 bytes
+     * of TCP/IPv6 datagram header overhead.
+     */
+    private byte[] headerBuffer = new byte[1440];
+    private WebsocketFrameHeader header = new WebsocketFrameHeader()
+        .withOp(OpCode.BINARY, true)
+        .withNoMask();
+    private Random random = new SecureRandom();
+
+    public WebsocketOutputStream(OutputStream wrap, boolean masked) {
+        this.wrap = wrap;
+        this.masked = masked;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // NOTE: Per spec, we should technically wait to receive the close frame,
+        // but we are not in control of the InputStream here...
+        WebsocketFrameHeader header = new WebsocketFrameHeader()
+            .withOp(OpCode.CLOSE, true)
+            .withNoMask()
+            .withPayloadLength(0);
+        int length = header.read(headerBuffer, 0, headerBuffer.length);
+        wrap.write(headerBuffer, 0, length);
+        wrap.close();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        wrap.flush();
+    }
+
+    @Override
+    public void write(byte[] buffer) throws IOException {
+        write(buffer, 0, buffer.length);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        oneByte[0] = (byte)(b & 0xFF);
+        write(oneByte, 0, 1);
+    }
+
+    /**
+     * NOTE: the buffer will be modified if masking is enabled and the length is greater
+     * than 1432. Regardless of if masking is enabled or not, any writes of length &gt; 1432
+     * will be split into two writes to the underlying OutputStream which is being wrapped.
+     */
+    @Override
+    public void write(byte[] buffer, int offset, int length) throws IOException {
+        header.withPayloadLength(length);
+        if (masked) {
+            header.withMask(random.nextInt());
+        }
+        int headerBufferOffset = header.read(headerBuffer, 0, headerBuffer.length);
+        int consumed = Math.min(length, headerBuffer.length - headerBufferOffset);
+        System.arraycopy(buffer, offset, headerBuffer, headerBufferOffset, consumed);
+
+        header.filterPayload(headerBuffer, headerBufferOffset, consumed);
+        wrap.write(headerBuffer, 0, headerBufferOffset + consumed);
+        if (consumed < length) {
+            // NOTE: We could perform a "mark" operation before filtering the
+            // payload which saves the payloadLength and maskingKeyOffset, then
+            // perform a "resetMark" operation after writing the masked buffer
+            // and finally re-applying the filter in order to preserve the
+            // original values of the bytes. However, there appears to be no
+            // code which relies on the bytes in the buffer to be preserved,
+            // so we are keeping things efficient by not performing these
+            // operations.
+            header.filterPayload(buffer, offset + consumed, length - consumed);
+            wrap.write(buffer, offset + consumed, length - consumed);
+        }
+    }
+
+}

--- a/src/test/java/io/nats/client/HttpRequestTests.java
+++ b/src/test/java/io/nats/client/HttpRequestTests.java
@@ -1,0 +1,69 @@
+// Copyright 2015-2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.nats.client.impl.Headers;
+
+public class HttpRequestTests {
+    @Test
+    public void testDefaults() {
+        HttpRequest request = new HttpRequest();
+        assertEquals("GET", request.getMethod());
+        assertEquals("/", request.getURI());
+        assertEquals("1.0", request.getVersion());
+        assertEquals(new Headers(), request.getHeaders());
+        assertEquals(
+            "GET / HTTP/1.0\r\n" +
+            "\r\n",
+            request.toString());
+    }
+
+    @Test
+    public void testSetters() {
+        HttpRequest request = new HttpRequest()
+            .method("PUT")
+            .uri("/fun")
+            .version("1.1");
+        request.getHeaders()
+            .add("One", "1")
+            .add("Two", "2");
+        assertEquals("PUT", request.getMethod());
+        assertEquals("/fun", request.getURI());
+        assertEquals("1.1", request.getVersion());
+        assertEquals(
+            "PUT /fun HTTP/1.1\r\n" +
+            "One: 1\r\n" +
+            "Two: 2\r\n" +
+            "\r\n",
+            request.toString());
+    }
+
+    @Test
+    public void testNulls() {
+        HttpRequest request = new HttpRequest();
+        assertThrows(IllegalArgumentException.class, () -> {
+            request.method(null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            request.uri(null);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            request.version(null);
+        });
+    }
+}

--- a/src/test/java/io/nats/client/NatsTestServer.java
+++ b/src/test/java/io/nats/client/NatsTestServer.java
@@ -71,7 +71,11 @@ public class NatsTestServer extends NatsServerRunner {
         return NatsRunnerUtils.nextPort();
     }
 
-    public static String getURIForPort(int port) {
-        return NatsRunnerUtils.getURIForPort(port);
+    public String getURI(String schema) {
+        return getURIForPort(schema, getPort());
+    }
+
+    public static String getURIForPort(String schema, int port) {
+        return schema + "://localhost:" + port;
     }
 }

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -24,8 +24,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -42,6 +44,7 @@ public class OptionsTests {
         assertEquals(1, o.getServers().size(), "default one server");
         assertEquals(Options.DEFAULT_URL, o.getServers().toArray()[0].toString(), "default url");
 
+        assertEquals(Collections.emptyList(), o.getHttpRequestInterceptors(), "default http request interceptors");
         assertEquals(Options.DEFAULT_DATA_PORT_TYPE, o.getDataPortType(), "default data port type");
 
         assertFalse(o.isVerbose(), "default verbose");
@@ -154,6 +157,26 @@ public class OptionsTests {
         assertEquals(Duration.ofMillis(404), o.getRequestCleanupInterval(), "chained cleanup interval");
         assertEquals(Duration.ofMillis(505), o.getReconnectJitter(), "chained reconnect jitter");
         assertEquals(Duration.ofMillis(606), o.getReconnectJitterTls(), "chained cleanup jitter tls");
+    }
+
+    @Test
+    public void testHttpRequestInterceptors() {
+        java.util.function.Consumer<HttpRequest> interceptor1 = req -> {
+            req.getHeaders().add("Test1", "Header");
+        };
+        java.util.function.Consumer<HttpRequest> interceptor2 = req -> {
+            req.getHeaders().add("Test2", "Header");
+        };
+        Options o = new Options.Builder()
+            .httpRequestInterceptor(interceptor1)
+            .httpRequestInterceptor(interceptor2)
+            .build();
+        assertEquals(o.getHttpRequestInterceptors(), Arrays.asList(interceptor1, interceptor2));
+
+        o = new Options.Builder()
+            .httpRequestInterceptors(Arrays.asList(interceptor2, interceptor1))
+            .build();
+        assertEquals(o.getHttpRequestInterceptors(), Arrays.asList(interceptor2, interceptor1));
     }
 
     @Test
@@ -631,11 +654,14 @@ public class OptionsTests {
         };
 
         for (String[] strings : test) {
-            URI actual = Options.parseURIForServer(strings[0]);
+            URI actual = Options.parseURIForServer(strings[0], false);
             URI expected = new URI(strings[1]);
             assertEquals(expected.toASCIIString(), actual.toASCIIString());
         }
-    }
+        URI actual = Options.parseURIForServer("connect.nats.io", true);
+        URI expected = new URI("wss://connect.nats.io:4222");
+        assertEquals(expected.toASCIIString(), actual.toASCIIString());
+}
 
     @Test
     public void testParseBadURIForServer() {
@@ -647,7 +673,7 @@ public class OptionsTests {
         };
 
         for (String string : strings) {
-            assertThrows(URISyntaxException.class, () -> Options.parseURIForServer(string));
+            assertThrows(URISyntaxException.class, () -> Options.parseURIForServer(string, false));
         }
     }
 

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -214,7 +214,7 @@ public class TLSConnectTests {
             SSLContext ctx = TestSSLUtils.createTestSSLContext();
             Options options = new Options.Builder().
                     server(ts.getURI()).
-                    server(NatsTestServer.getURIForPort(newPort)).
+                    server(NatsTestServer.getURIForPort("nats", newPort)).
                     maxReconnects(-1).
                     sslContext(ctx).
                     connectionListener(handler).

--- a/src/test/java/io/nats/client/impl/WebsocketConnectTests.java
+++ b/src/test/java/io/nats/client/impl/WebsocketConnectTests.java
@@ -1,0 +1,326 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.impl;
+
+import io.nats.client.*;
+import io.nats.client.ConnectionListener.Events;
+import io.nats.client.utils.CloseOnUpgradeAttempt;
+import io.nats.client.utils.RunProxy;
+
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static io.nats.client.utils.TestBase.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WebsocketConnectTests {
+    @Test
+    public void testRequestReply() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/ws.conf", false)) {
+            Options options = new Options.Builder().
+                                server(ts.getURI("ws")).
+                                maxReconnects(0).
+                                build();
+            try (Connection connection = standardConnection(options)) {
+                Dispatcher dispatcher = connection.createDispatcher(msg -> {
+                    connection.publish(msg.getReplyTo(), (new String(msg.getData()) + ":REPLY").getBytes());
+                });
+                try {
+                    dispatcher.subscribe("TEST");
+                    Message response = connection.request("TEST", "REQUEST".getBytes()).join();
+                    assertEquals("REQUEST:REPLY", new String(response.getData()));
+                } finally {
+                    dispatcher.drain(Duration.ZERO);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testTLSRequestReply() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wss.conf", false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder().
+                                httpRequestInterceptor(req -> {
+                                    // Ideally we could validate that this header was sent to NATS server 
+                                    req.getHeaders().add("X-Ignored", "VALUE");
+                                }).
+                                server(ts.getURI("wss")).
+                                maxReconnects(0).
+                                sslContext(ctx).
+                                build();
+            try (Connection connection = standardConnection(options)) {
+                Dispatcher dispatcher = connection.createDispatcher(msg -> {
+                    connection.publish(msg.getReplyTo(), (new String(msg.getData()) + ":REPLY").getBytes());
+                });
+                try {
+                    dispatcher.subscribe("TEST");
+                    Message response = connection.request("TEST", "REQUEST".getBytes()).join();
+                    assertEquals("REQUEST:REPLY", new String(response.getData()));
+                } finally {
+                    dispatcher.drain(Duration.ZERO);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testProxyRequestReply() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        RunProxy proxy = new RunProxy(new InetSocketAddress("localhost", 0), null, executor);
+        executor.submit(proxy);
+
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/ws.conf", false)) {
+            Options options = new Options.Builder()
+                .server(ts.getURI("ws"))
+                .maxReconnects(0)
+                .proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", proxy.getPort())))
+                .build();
+            try (Connection connection = standardConnection(options)) {
+                Dispatcher dispatcher = connection.createDispatcher(msg -> {
+                    connection.publish(msg.getReplyTo(), (new String(msg.getData()) + ":REPLY").getBytes());
+                });
+                try {
+                    dispatcher.subscribe("TEST");
+                    Message response = connection.request("TEST", "REQUEST".getBytes()).join();
+                    assertEquals("REQUEST:REPLY", new String(response.getData()));
+                } finally {
+                    dispatcher.drain(Duration.ZERO);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSimpleTLSConnection() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wss.conf", false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder().
+                                server(ts.getURI("wss")).
+                                maxReconnects(0).
+                                sslContext(ctx).
+                                build();
+            assertCanConnect(options);
+        }
+    }
+
+    @Test
+    public void testSimpleWSSIPConnection() throws Exception {
+        //System.setProperty("javax.net.debug", "all");
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wss.conf", false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder().
+                                server("wss://127.0.0.1:" + ts.getPort()).
+                                maxReconnects(0).
+                                sslContext(ctx).
+                                build();
+            assertCanConnect(options);
+        }
+    }
+
+    @Test
+    public void testVerifiedTLSConnection() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder().
+                                server(ts.getURI("wss")).
+                                maxReconnects(0).
+                                sslContext(ctx).
+                                build();
+            assertCanConnect(options);
+        }
+    }
+
+    @Test
+    public void testOpenTLSConnection() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wss.conf", false)) {
+            Options options = new Options.Builder().
+                                server(ts.getURI("wss")).
+                                maxReconnects(0).
+                                opentls().
+                                build();
+            assertCanConnect(options);
+        }
+    }
+
+    @Test
+    public void testURIWSSHostConnection() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+            Options options = new Options.Builder().
+                                server("wss://localhost:"+ts.getPort()).
+                                sslContext(TestSSLUtils.createTestSSLContext()). // override the custom one
+                                maxReconnects(0).
+                                build();
+            assertCanConnect(options);
+        }
+    }
+
+    @Test
+    public void testURIWSSIPConnection() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+            Options options = new Options.Builder().
+                                server("wss://127.0.0.1:"+ts.getPort()).
+                                sslContext(TestSSLUtils.createTestSSLContext()). // override the custom one
+                                maxReconnects(0).
+                                build();
+            assertCanConnect(options);
+        }
+    }
+
+    @Test
+    public void testURISchemeWSSConnection() throws Exception {
+        SSLContext originalDefault = SSLContext.getDefault();
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wss.conf", false)) {
+            SSLContext.setDefault(TestSSLUtils.createTestSSLContext());
+            Options options = new Options.Builder().
+                                server("wss://localhost:"+ts.getPort()).
+                                maxReconnects(0).
+                                build();
+            assertCanConnect(options);
+        } finally {
+            SSLContext.setDefault(originalDefault);
+        }
+    }
+
+    @Test
+    public void testTLSMessageFlow() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            int msgCount = 100;
+            Options options = new Options.Builder().
+                                server(ts.getURI("wss")).
+                                maxReconnects(0).
+                                sslContext(ctx).
+                                build();
+            Connection nc = standardConnection(options);
+            Dispatcher d = nc.createDispatcher((msg) -> {
+                nc.publish(msg.getReplyTo(), new byte[16]);
+            });
+            d.subscribe("subject");
+
+            for (int i=0;i<msgCount;i++) {
+                Future<Message> incoming = nc.request("subject", null);
+                Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
+                assertNotNull(msg);
+                assertEquals(16, msg.getData().length);
+            }
+
+            standardCloseConnection(nc);
+        }
+    }
+
+    @Test
+    public void testTLSOnReconnect() throws InterruptedException, Exception {
+        Connection nc = null;
+        TestHandler handler = new TestHandler();
+        int port = NatsTestServer.nextPort();
+        int newPort = NatsTestServer.nextPort();
+
+        // Use two server ports to avoid port release timing issues
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", port, false)) {
+            SSLContext ctx = TestSSLUtils.createTestSSLContext();
+            Options options = new Options.Builder().
+                    server(ts.getURI("wss")).
+                    server(NatsTestServer.getURIForPort("wss", newPort)).
+                    maxReconnects(-1).
+                    sslContext(ctx).
+                    connectionListener(handler).
+                    reconnectWait(Duration.ofMillis(10)).
+                    build();
+            nc = standardConnection(options);
+            assertTrue(((NatsConnection)nc).getDataPort() instanceof SocketDataPort, "Correct data port class");
+            handler.prepForStatusChange(Events.DISCONNECTED);
+        }
+
+        flushAndWaitLong(nc, handler);
+        handler.prepForStatusChange(Events.RESUBSCRIBED);
+
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", newPort, false)) {
+            standardConnectionWait(nc, handler, 10000);
+        }
+
+        standardCloseConnection(nc);
+    }
+
+    @Test
+    public void testDisconnectOnUpgrade() {
+        assertThrows(IOException.class, () -> {
+            try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+                SSLContext ctx = TestSSLUtils.createTestSSLContext();
+                Options options = new Options.Builder().
+                                    server(ts.getURI("wss")).
+                                    maxReconnects(0).
+                                    dataPortType(CloseOnUpgradeAttempt.class.getCanonicalName()).
+                                    sslContext(ctx).
+                                    build();
+                Nats.connect(options);
+            }
+        });
+    }
+
+    @Test
+    public void testServerSecureClientNotMismatch() {
+        assertThrows(IOException.class, () -> {
+            try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+                Options options = new Options.Builder().
+                                    server(ts.getURI("ws")).
+                                    maxReconnects(0).
+                                    build();
+                Nats.connect(options);
+            }
+        });
+    }
+
+    @Test
+    public void testClientSecureServerNotMismatch() {
+        assertThrows(IOException.class, () -> {
+            try (NatsTestServer ts = new NatsTestServer()) {
+                SSLContext ctx = TestSSLUtils.createTestSSLContext();
+                Options options = new Options.Builder().
+                                    server(ts.getURI("wss")).
+                                    maxReconnects(0).
+                                    sslContext(ctx).
+                                    build();
+                Nats.connect(options);
+            }
+        });
+    }
+
+    @Test
+    public void testClientServerCertMismatch() {
+        assertThrows(IOException.class, () -> {
+            try (NatsTestServer ts = new NatsTestServer("src/test/resources/wssverify.conf", false)) {
+                SSLContext ctx = TestSSLUtils.createEmptySSLContext();
+                Options options = new Options.Builder().
+                                    server(ts.getURI("wss")).
+                                    maxReconnects(0).
+                                    sslContext(ctx).
+                                    build();
+                Nats.connect(options);
+            }
+        });
+    }
+}

--- a/src/test/java/io/nats/client/support/WebsocketTests.java
+++ b/src/test/java/io/nats/client/support/WebsocketTests.java
@@ -1,0 +1,662 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.support;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.nats.client.NatsTestServer;
+import io.nats.client.Options;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static io.nats.client.support.WebsocketFrameHeader.OpCode;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class WebsocketTests {
+    private int[] testSizes = new int[] { 1, 2, 3, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 1432, // WebsocketOutputStream
+                                                                                                // buffer threshold,
+                                                                                                // will fragment after
+                                                                                                // this.
+            1433, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144 };
+
+    @Test
+    public void testInputStreamMaskedBinaryFin() throws IOException {
+        for (int i = 0; i < testSizes.length; i++) {
+            byte[] fuzz = getFuzz(testSizes[i]);
+            int maskingKey = new SecureRandom().nextInt();
+            InputStream in = websocketInputStream(
+                    new WebsocketFrameHeader().withMask(maskingKey).withOp(OpCode.BINARY, true), fuzz);
+            WebsocketInputStream win = new WebsocketInputStream(in);
+            byte[] got = new byte[testSizes[i]];
+            if (fuzz.length == 1) {
+                got[0] = (byte) (win.read() & 0xFF);
+            } else {
+                assertEquals(got.length, win.read(got));
+            }
+            assertArrayEquals(fuzz, got);
+            win.close();
+        }
+    }
+
+    @Test
+    public void testInputStreamUnMaskedBinaryFin() throws IOException {
+        for (int i = 0; i < testSizes.length; i++) {
+            byte[] fuzz = getFuzz(testSizes[i]);
+            InputStream in = websocketInputStream(new WebsocketFrameHeader().withNoMask().withOp(OpCode.BINARY, true),
+                    fuzz);
+            WebsocketInputStream win = new WebsocketInputStream(in);
+            byte[] got = new byte[testSizes[i]];
+            assertEquals(got.length, win.read(got));
+            assertArrayEquals(fuzz, got);
+            win.close();
+        }
+    }
+
+    @Test
+    public void testOutputStreamMaskedBinaryFin() throws IOException {
+        for (int i = 0; i < testSizes.length; i++) {
+            byte[] fuzz = getFuzz(testSizes[i]);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            WebsocketOutputStream wout = new WebsocketOutputStream(out, true);
+            if (1 == fuzz.length) {
+                wout.write(fuzz[0]);
+            } else {
+                // NOTE: this API will modify fuzz, so we need to take a copy:
+                wout.write(Arrays.copyOf(fuzz, fuzz.length));
+            }
+            byte[] got = out.toByteArray();
+
+            // Validate the header:
+            WebsocketFrameHeader header = new WebsocketFrameHeader();
+            int headerLength = header.write(got, 0, got.length);
+            assertEquals(OpCode.BINARY, header.getOpCode());
+            assertEquals(fuzz.length, header.getPayloadLength());
+            assertTrue(header.isMasked());
+
+            // Validate the payload:
+            byte[] gotPayload = Arrays.copyOfRange(got, headerLength, got.length);
+            // Must be masked!
+            assertFalse(Arrays.equals(gotPayload, fuzz));
+            assertEquals(gotPayload.length, header.filterPayload(gotPayload, 0, gotPayload.length));
+            assertArrayEquals(gotPayload, fuzz, "size=" + fuzz.length);
+
+            wout.close();
+        }
+    }
+
+    @Test
+    public void testOutputStreamUnMaskedBinaryFin() throws IOException {
+        for (int i = 0; i < testSizes.length; i++) {
+            byte[] fuzz = getFuzz(testSizes[i]);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            WebsocketOutputStream wout = new WebsocketOutputStream(out, false);
+            wout.write(fuzz);
+            byte[] got = out.toByteArray();
+
+            // Validate the header:
+            WebsocketFrameHeader header = new WebsocketFrameHeader();
+            int headerLength = header.write(got, 0, got.length);
+            assertEquals(OpCode.BINARY, header.getOpCode());
+            assertEquals(fuzz.length, header.getPayloadLength());
+            assertFalse(header.isMasked());
+
+            // Validate the payload:
+            byte[] gotPayload = Arrays.copyOfRange(got, headerLength, got.length);
+
+            // Must NOT be masked!
+            assertArrayEquals(gotPayload, fuzz);
+
+            wout.close();
+        }
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        WebsocketOutputStream wout = new WebsocketOutputStream(out, false);
+        wout.close();
+        byte[] got = out.toByteArray();
+
+        // Validate the header:
+        WebsocketFrameHeader header = new WebsocketFrameHeader();
+        assertEquals(2, header.write(got, 0, got.length));
+        assertEquals(OpCode.CLOSE, header.getOpCode());
+        assertEquals(0, header.getPayloadLength());
+        assertFalse(header.isMasked());
+        assertTrue(header.isFinal());
+        assertTrue(header.isPayloadEmpty());
+    }
+
+    @Test
+    public void testInputCoverage() throws IOException {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        WebsocketInputStream win = new WebsocketInputStream(in);
+        assertFalse(win.markSupported());
+        win.mark(0);
+        assertEquals(0, win.available());
+        win.close();
+    }
+
+    @Test
+    public void testFrameHeaderCoverage() throws IOException {
+        assertEquals(OpCode.CONTINUATION, OpCode.of(0));
+        assertEquals(OpCode.TEXT, OpCode.of(1));
+        assertEquals(OpCode.BINARY, OpCode.of(2));
+        assertEquals(OpCode.CLOSE, OpCode.of(8));
+        assertEquals(OpCode.PING, OpCode.of(9));
+        assertEquals(OpCode.PONG, OpCode.of(10));
+        assertEquals(OpCode.UNKNOWN, OpCode.of(11));
+
+        WebsocketFrameHeader header = new WebsocketFrameHeader();
+        assertEquals(0xFF, header.withMask(0xFF).getMaskingKey());
+        assertEquals(0, header.write(new byte[1], 0, 1));
+        assertEquals(0, header.write(new byte[] { 2, 127 }, 0, 2));
+    }
+
+    private byte[] getFuzz(int size) {
+        byte[] fuzz = new byte[size];
+        new SecureRandom().nextBytes(fuzz);
+        return fuzz;
+    }
+
+    @Test
+    public void testHandshakeFailures() throws Exception {
+        byte[] buffer = new byte[1024];
+        Arrays.fill(buffer, (byte) 'a');
+
+        testWithWriter(out -> {
+            for (int i = 0; i < 1000; i++) {
+                out.write(buffer, 0, buffer.length);
+            }
+            out.close();
+        }, "Expected HTTP response line not to exceed ");
+
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\r\n");
+            writer.flush();
+            for (int i = 0; i < 1000; i++) {
+                out.write(buffer, 0, buffer.length);
+            }
+            out.close();
+        }, "Expected HTTP header to not exceed ");
+
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\r\n");
+            writer.append("missing-colon\r\n");
+            writer.append("\r\n");
+            writer.close();
+        }, "Expected HTTP header to contain ':', but got missing-colon");
+
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\r\n");
+            for (int i = 0; i < 1000; i++) {
+                writer.append("a-" + i + ": Test\r\n");
+            }
+            writer.close();
+        }, "Exceeded max HTTP headers");
+
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\r\n");
+            writer.append("Connection: Upgrade\r\n");
+            writer.append("Sec-Websocket-Accept: DEADBEEF\r\n");
+            writer.append("\r\n");
+            writer.close();
+        }, "Expected HTTP `Upgrade: websocket` header");
+
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\n");
+            writer.append("Upgrade: Websocket\n");
+            writer.append("Sec-Websocket-Accept: DEADBEEF\n");
+            writer.append("\n");
+            writer.close();
+        }, "Expected HTTP `Connection: Upgrade` header");
+
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\r\n");
+            writer.append("Upgrade: Websocket\r\n");
+            writer.append("Connection: Upgrade\r\n");
+            writer.append("Sec-Websocket-Accept: DEADBEEF\r\n");
+            writer.append("\r\n");
+            writer.close();
+        }, "Expected HTTP `Sec-WebSocket-Accept: ");
+
+        // Premature EOF:
+        testWithWriter(out -> {
+            OutputStreamWriter writer = new OutputStreamWriter(out, UTF_8);
+            writer.append("HTTP/1.1 101 Switching Protocols\r\n");
+            writer.append("Upgrade: Websocket\r\n");
+            writer.append("Connection: Upgrade\r\n");
+            writer.append("Sec-Websocket-Accept: DEADBEEF");
+            writer.flush();
+        }, "Expected HTTP `Sec-WebSocket-Accept: ");
+    }
+
+    @FunctionalInterface
+    interface OutputStreamWrite {
+        public void write(OutputStream out) throws IOException;
+    }
+
+    private void testWithWriter(OutputStreamWrite writer, String msgStartsWith) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        try (ServerSocket serverSocket = new ServerSocket(0, 10, InetAddress.getByName("localhost"))) {
+            Future<?> serverFuture = executor.submit(() -> {
+                Socket client = serverSocket.accept();
+                InputStream in = client.getInputStream();
+                Future<?> readFuture = executor.submit(() -> {
+                    byte[] buffer = new byte[1024];
+                    try {
+                        while (in.read(buffer) >= 0) {
+                        }
+                    } catch (SocketException ex) {
+                        // Expect this failure:
+                        if (!"Connection reset".equals(ex.getMessage()) && !"Socket closed".equals(ex.getMessage())) {
+                            throw ex;
+                        }
+                    }
+                    return null;
+                });
+                try {
+                    writer.write(client.getOutputStream());
+                    if (!client.isClosed()) {
+                        client.shutdownOutput();
+                    }
+                } catch (SocketException ex) {
+                    // Expect this failure:
+                    if (!"Broken pipe (Write failed)".equals(ex.getMessage())) {
+                        throw ex;
+                    }
+                }
+                readFuture.get();
+                return null;
+            });
+            Socket client = new Socket("localhost", serverSocket.getLocalPort());
+            IllegalStateException ex = assertThrows(IllegalStateException.class,
+                    () -> new WebSocket(client, "localhost", Collections.emptyList()));
+            assertTrue(ex.getMessage().startsWith(msgStartsWith), ex.getMessage());
+            client.close();
+            serverFuture.get();
+        }
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testWebSocketCoverage() throws Exception {
+        AtomicReference<String> lastMethod = new AtomicReference<>();
+        try (NatsTestServer ts = new NatsTestServer("src/test/resources/ws.conf", false)) {
+            try (Socket tcpSocket = new Socket("localhost", ts.getPort())) {
+                WebSocket webSocket = new WebSocket(new Socket() {
+                    @Override
+                    public InputStream getInputStream() throws IOException {
+                        return tcpSocket.getInputStream();
+                    }
+
+                    @Override
+                    public OutputStream getOutputStream() throws IOException {
+                        return tcpSocket.getOutputStream();
+                    }
+
+                    @Override
+                    public synchronized void close() throws IOException {
+                        tcpSocket.close();
+                    }
+
+                    @Override
+                    public InetAddress getInetAddress() {
+                        lastMethod.set("getInetAddress");
+                        return null;
+                    }
+
+                    @Override
+                    public InetAddress getLocalAddress() {
+                        lastMethod.set("getLocalAddress");
+                        return null;
+                    }
+
+                    @Override
+                    public int getPort() {
+                        lastMethod.set("getPort");
+                        return 0;
+                    }
+
+                    @Override
+                    public int getLocalPort() {
+                        lastMethod.set("getLocalPort");
+                        return 0;
+                    }
+
+                    @Override
+                    public SocketAddress getRemoteSocketAddress() {
+                        lastMethod.set("getRemoteSocketAddress");
+                        return null;
+                    }
+
+                    @Override
+                    public SocketAddress getLocalSocketAddress() {
+                        lastMethod.set("getLocalSocketAddress");
+                        return null;
+                    }
+
+                    @Override
+                    public void setTcpNoDelay(boolean on) throws SocketException {
+                        lastMethod.set("setTcpNoDelay");
+                    }
+
+                    @Override
+                    public boolean getTcpNoDelay() throws SocketException {
+                        lastMethod.set("getTcpNoDelay");
+                        return true;
+                    }
+
+                    @Override
+                    public void setSoLinger(boolean on, int linger) throws SocketException {
+                        lastMethod.set("setSoLinger");
+                    }
+
+                    @Override
+                    public int getSoLinger() throws SocketException {
+                        lastMethod.set("getSoLinger");
+                        return 0;
+                    }
+
+                    @Override
+                    public void sendUrgentData(int data) throws IOException {
+                        lastMethod.set("sendUrgentData");
+                    }
+
+                    @Override
+                    public void setOOBInline(boolean on) throws SocketException {
+                        lastMethod.set("setOOBInline");
+                    }
+
+                    @Override
+                    public boolean getOOBInline() throws SocketException {
+                        lastMethod.set("getOOBInline");
+                        return false;
+                    }
+
+                    @Override
+                    public void setSoTimeout(int timeout) throws SocketException {
+                        lastMethod.set("setSoTimeout");
+                    }
+
+                    @Override
+                    public int getSoTimeout() throws SocketException {
+                        lastMethod.set("getSoTimeout");
+                        return 1000;
+                    }
+
+                    @Override
+                    public void setSendBufferSize(int size) throws SocketException {
+                        lastMethod.set("setSendBufferSize");
+                    }
+
+                    @Override
+                    public int getSendBufferSize() throws SocketException {
+                        lastMethod.set("getSendBufferSize");
+                        return 1024;
+                    }
+
+                    @Override
+                    public void setReceiveBufferSize(int size) throws SocketException {
+                        lastMethod.set("setReceiveBufferSize");
+                    }
+
+                    @Override
+                    public int getReceiveBufferSize() throws SocketException {
+                        lastMethod.set("getReceiveBufferSize");
+                        return 1024;
+                    }
+
+                    @Override
+                    public void setKeepAlive(boolean on) throws SocketException {
+                        lastMethod.set("setKeepAlive");
+                    }
+
+                    @Override
+                    public boolean getKeepAlive() throws SocketException {
+                        lastMethod.set("getKeepAlive");
+                        return false;
+                    }
+
+                    @Override
+                    public void setTrafficClass(int tc) throws SocketException {
+                        lastMethod.set("setTrafficClass");
+                    }
+
+                    @Override
+                    public int getTrafficClass() throws SocketException {
+                        lastMethod.set("getTrafficClass");
+                        return 0;
+                    }
+
+                    @Override
+                    public void setReuseAddress(boolean on) throws SocketException {
+                        lastMethod.set("setReuseAddress");
+                    }
+
+                    @Override
+                    public boolean getReuseAddress() throws SocketException {
+                        lastMethod.set("getReuseAddress");
+                        return false;
+                    }
+
+                    @Override
+                    public void shutdownInput() throws IOException {
+                        lastMethod.set("shutdownInput");
+                    }
+
+                    @Override
+                    public void shutdownOutput() throws IOException {
+                        lastMethod.set("shutdownOutput");
+                    }
+
+                    @Override
+                    public boolean isConnected() {
+                        lastMethod.set("isConnected");
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isBound() {
+                        lastMethod.set("isBound");
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isClosed() {
+                        lastMethod.set("isClosed");
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isInputShutdown() {
+                        lastMethod.set("isInputShutdown");
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isOutputShutdown() {
+                        lastMethod.set("isOutputShutdown");
+                        return false;
+                    }
+
+                    @Override
+                    public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+                        lastMethod.set("setPerformancePreferences");
+                    }
+                }, "host", Collections.emptyList());
+
+                // Unsupported methods:
+                assertThrows(UnsupportedOperationException.class, () -> webSocket.connect(null));
+                assertThrows(UnsupportedOperationException.class, () -> webSocket.connect(null, 0));
+                assertThrows(UnsupportedOperationException.class, () -> webSocket.bind(null));
+                assertThrows(UnsupportedOperationException.class, () -> webSocket.getChannel());
+
+                // Delegated methods:
+                webSocket.getInetAddress();
+                assertEquals("getInetAddress", lastMethod.get());
+
+                webSocket.getLocalAddress();
+                assertEquals("getLocalAddress", lastMethod.get());
+
+                webSocket.getPort();
+                assertEquals("getPort", lastMethod.get());
+
+                webSocket.getLocalPort();
+                assertEquals("getLocalPort", lastMethod.get());
+
+                webSocket.getRemoteSocketAddress();
+                assertEquals("getRemoteSocketAddress", lastMethod.get());
+
+                webSocket.getLocalSocketAddress();
+                assertEquals("getLocalSocketAddress", lastMethod.get());
+
+                webSocket.setTcpNoDelay(true);
+                assertEquals("setTcpNoDelay", lastMethod.get());
+
+                webSocket.getTcpNoDelay();
+                assertEquals("getTcpNoDelay", lastMethod.get());
+
+                webSocket.setSoLinger(true, 0);
+                assertEquals("setSoLinger", lastMethod.get());
+
+                webSocket.getSoLinger();
+                assertEquals("getSoLinger", lastMethod.get());
+
+                webSocket.sendUrgentData(1);
+                assertEquals("sendUrgentData", lastMethod.get());
+
+                webSocket.setOOBInline(true);
+                assertEquals("setOOBInline", lastMethod.get());
+
+                webSocket.getOOBInline();
+                assertEquals("getOOBInline", lastMethod.get());
+
+                webSocket.setSoTimeout(1);
+                assertEquals("setSoTimeout", lastMethod.get());
+
+                webSocket.getSoTimeout();
+                assertEquals("getSoTimeout", lastMethod.get());
+
+                webSocket.setSendBufferSize(1);
+                assertEquals("setSendBufferSize", lastMethod.get());
+
+                webSocket.getSendBufferSize();
+                assertEquals("getSendBufferSize", lastMethod.get());
+
+                webSocket.setReceiveBufferSize(1);
+                assertEquals("setReceiveBufferSize", lastMethod.get());
+
+                webSocket.getReceiveBufferSize();
+                assertEquals("getReceiveBufferSize", lastMethod.get());
+
+                webSocket.setKeepAlive(true);
+                assertEquals("setKeepAlive", lastMethod.get());
+
+                webSocket.getKeepAlive();
+                assertEquals("getKeepAlive", lastMethod.get());
+
+                webSocket.setTrafficClass(1);
+                assertEquals("setTrafficClass", lastMethod.get());
+
+                webSocket.getTrafficClass();
+                assertEquals("getTrafficClass", lastMethod.get());
+
+                webSocket.setReuseAddress(true);
+                assertEquals("setReuseAddress", lastMethod.get());
+
+                webSocket.getReuseAddress();
+                assertEquals("getReuseAddress", lastMethod.get());
+
+                webSocket.shutdownInput();
+                assertEquals("shutdownInput", lastMethod.get());
+
+                webSocket.shutdownOutput();
+                assertEquals("shutdownOutput", lastMethod.get());
+
+                webSocket.isConnected();
+                assertEquals("isConnected", lastMethod.get());
+
+                webSocket.isBound();
+                assertEquals("isBound", lastMethod.get());
+
+                webSocket.isClosed();
+                assertEquals("isClosed", lastMethod.get());
+
+                webSocket.isInputShutdown();
+                assertEquals("isInputShutdown", lastMethod.get());
+
+                webSocket.isOutputShutdown();
+                assertEquals("isOutputShutdown", lastMethod.get());
+
+                webSocket.setPerformancePreferences(1, 1, 1);
+                assertEquals("setPerformancePreferences", lastMethod.get());
+            }
+        }
+    }
+
+    /**
+     * Create a ByteArrayInputStream with a websocket frame header and payload.
+     * 
+     */
+    private InputStream websocketInputStream(WebsocketFrameHeader header, byte[] payload) {
+        ByteBuffer buffer = ByteBuffer.allocate(payload.length + WebsocketFrameHeader.MAX_FRAME_HEADER_SIZE);
+
+        // Set payload length:
+        header.withPayloadLength(payload.length);
+
+        // write the header into a buffer:
+        buffer.position(buffer.position() + header.read(buffer.array(), buffer.position(), buffer.limit()));
+
+        // write the payload:
+        int position = buffer.position();
+        buffer.put(payload);
+
+        // filter the payload:
+        int filterLength = header.filterPayload(buffer.array(), position, buffer.position() - position);
+
+        assertEquals(buffer.position() - position, filterLength);
+        return new ByteArrayInputStream(buffer.array(), 0, buffer.position());
+    }
+}

--- a/src/test/java/io/nats/client/utils/RunProxy.java
+++ b/src/test/java/io/nats/client/utils/RunProxy.java
@@ -1,0 +1,199 @@
+// Copyright 2021 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.net.ssl.SSLContext;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Quick proxy server implementation for testing against.
+ */
+public class RunProxy implements Runnable {
+    private static final Pattern REQUEST_LINE_PATTERN = Pattern.compile("^(\\S+)\\s+([^\\s:]+):(\\d+)\\s+HTTP/(\\S+)$");
+
+    private ServerSocket server;
+    private InetSocketAddress hostPort;
+    private ExecutorService executor;
+
+    /**
+     * Specify port=0 for ephemeral port. Specify null SSLContext to
+     * NOT make it a secure proxy.
+     * @throws IOException if we fail to bind to the host:port specified.
+     */
+    public RunProxy(InetSocketAddress hostPort, SSLContext sslContext, ExecutorService executor) throws IOException {
+        if (null == hostPort.getHostName()) {
+            throw new IllegalArgumentException("Expected URI with host defined, but got " + hostPort);
+        }
+        int port = hostPort.getPort();
+        if (port < 0) {
+            port = 0;
+        }
+        if (null != sslContext) {
+            server = sslContext.getServerSocketFactory().createServerSocket(
+                port,
+                10,
+                hostPort.getAddress());
+        } else {
+            server = new ServerSocket(
+                port,
+                10,
+                hostPort.getAddress());
+        }
+        this.hostPort = new InetSocketAddress(hostPort.getHostName(), server.getLocalPort());
+        this.executor = executor;
+    }
+
+    /**
+     * Runs the "accept" thread which delegates sockets out to the executor.
+     */
+	@Override
+	public void run() {
+        try {
+            runImpl();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+	}
+
+    public int getPort() {
+        return hostPort.getPort();
+    }
+
+    private void runImpl() throws IOException {
+        while (true) {
+            Socket client = server.accept();
+            executor.submit(() -> proxy(client));
+        }
+    }
+
+    private void proxy(Socket client) {
+        Socket remote;
+        try {
+            remote = handshake(client);
+            if (null == remote) {
+                return;
+            }
+        } catch (Exception ex) {
+            System.err.println("Failure to establish a proxy:");
+            ex.printStackTrace(System.err);
+            try {
+                client.close();
+            } catch (Exception ignored) {}
+            return;
+        }
+        executor.submit(() -> transferTo(remote, client, "remote -> client"));
+        executor.submit(() -> transferTo(client, remote, "client -> remote"));
+    }
+
+    private void transferTo(Socket from, Socket to, String description) {
+        try {
+            InputStream in = from.getInputStream();
+            OutputStream out = to.getOutputStream();
+            // Really inefficient!
+            while (true) {
+                int ch = in.read();
+                if (ch < 0) {
+                    return;
+                }
+                out.write(ch);
+            }
+        } catch (Exception ex) {
+            System.err.println("Failure to forward data (" + description + "):");
+            ex.printStackTrace(System.err);
+        }
+    }
+
+    private Socket handshake(Socket client) throws IOException {
+        String line = getLatin1Line(client.getInputStream());
+        Matcher matcher = REQUEST_LINE_PATTERN.matcher(line);
+        if (!matcher.matches()) {
+            System.err.println("proxy received unexpected request line=" + line);
+            return null;
+        }
+        if (!"CONNECT".equalsIgnoreCase(matcher.group(1))) {
+            System.err.println("Unsupported method='" + matcher.group(1) + "'");
+            client.getOutputStream().write(
+                "HTTP/1.0 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n".getBytes(UTF_8));
+            return null;
+        }
+        while (true) {
+            line = getLatin1Line(client.getInputStream());
+            if (null == line) {
+                System.err.println("Premature close...");
+                return null;
+            }
+            if ("".equals(line)) {
+                break;
+            }
+        }
+        String remoteHost = matcher.group(2);
+        int remotePort = Integer.parseInt(matcher.group(3));
+        Socket remote;
+        try {
+            remote = new Socket();
+            remote.setTcpNoDelay(true);
+            remote.setReceiveBufferSize(2 * 1024 * 1024);
+            remote.setSendBufferSize(2 * 1024 * 1024);
+            remote.connect(new InetSocketAddress(remoteHost, remotePort));
+            remote = new Socket(remoteHost, remotePort);
+        } catch (Exception ex) {
+            System.err.println("Remote connect to " + remoteHost + ":" + remotePort + " failed:");
+            ex.printStackTrace(System.err);
+            client.getOutputStream().write(
+                "HTTP/1.0 400 Bad Connection\r\nContent-Length: 0\r\n\r\n".getBytes(UTF_8));
+            return null;
+        }
+        client.getOutputStream().write(
+            "HTTP/1.0 200 OK\r\n\r\n".getBytes(UTF_8));
+        return remote;
+    }
+
+    /**
+     * Only handles \r\n, not robust!
+     */
+    private String getLatin1Line(InputStream in) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        boolean gotCR = false;
+        while (true) {
+            int ch = in.read();
+            if (ch < 1) {
+                // Got end of stream.
+                return sb.length() > 0 ? sb.toString() : null;
+            }
+            switch (ch) {
+            case '\r':
+                gotCR = true;
+                break;
+
+            case '\n':
+                if (gotCR) {
+                    return sb.deleteCharAt(sb.length() - 1).toString();
+                }
+            }
+            sb.append((char)(ch & 0xFF));
+        }
+    }
+}

--- a/src/test/resources/ws.conf
+++ b/src/test/resources/ws.conf
@@ -1,0 +1,9 @@
+
+# Simple TLS config file
+
+net: localhost
+
+ws {
+  port: 4443
+  no_tls: true
+}

--- a/src/test/resources/wss.conf
+++ b/src/test/resources/wss.conf
@@ -1,0 +1,16 @@
+
+# Simple TLS config file
+
+net: localhost
+
+ws {
+  port: 4443
+  tls {
+    cert_file:  "src/test/resources/certs/server.pem"
+    key_file:   "src/test/resources/certs/key.pem"
+    timeout:    2
+
+    # Optional certificate authority for clients
+    ca_file:   "src/test/resources/certs/ca.pem"
+  }
+}

--- a/src/test/resources/wssverify.conf
+++ b/src/test/resources/wssverify.conf
@@ -1,0 +1,18 @@
+
+# Simple TLS config file
+
+net: localhost
+ws {
+  port: 4443
+  tls {
+    cert_file:  "src/test/resources/certs/server.pem"
+    key_file:   "src/test/resources/certs/key.pem"
+    timeout:    2
+
+    # Optional certificate authority for clients
+    ca_file:   "src/test/resources/certs/ca.pem"
+  
+    # Require a client certificate
+    verify:    true
+  }
+}


### PR DESCRIPTION
This is the simplest possible implementation of websockets with a net increase in code coverage.
* No alterations to DataPort.
* Two new options, one to support httpInterceptors and another to support proxy requests.
* Websockets is supported via a new schema ("ws" or "wss").
* Copy writer headers are at the top of every new file added.
* All websocket implementation details are encapsulated by extending Socket and implementing WebSocket with a WebSocketInputStream and WebSocketOutputStream.

I'm planning to use these changes in our production environment within the next few weeks.

Being critical of myself, these are the points that are lacking:
* Proper websocket closure handshake is not implemented, close() simply forwards to the underlying socket.
* The http interceptors don't allow filtering HTTP responses and are very primitive. They work for my use case, but not sure if it works for all use-cases.
* The handling of upgradeToSecure is a little awkward since websockets is typically performed over a TLS channel and thus there is no need for double encryption. A better solution would involve delegating this to the DataPort... or more specifically, when the secure() option is set, we should NOT throw an error if "wss" transport is used.
* Create URI for server now takes in an "is websocket" parameter, again this is a little awkward. A better solution would involve delegating this to the DataPort.
* No support for `Sec-WebSocket-Extensions: permessage-deflate` (aka websocket level compression... which should really be combined with `Nats-No-Masking: TRUE` to really get the full benefits).
* The implementation of websocket framing strikes a balance between TCP fragmentation and extra buffer copying by using a 1440 sized buffer used for the initial frame header + the first ~1438 bytes. The channel based implementation mitigates this fragmentation by using the GatheringByteChannel and passing in an array of ByteBuffers.


Note that this PR replaces https://github.com/nats-io/nats.java/pull/426 which was posted before I had access to the `nats-io/nats.java` repository (and for some reason that other PR isn't working with coveralls).

For more information on websockets, I'd really recommend reading the RFC: https://datatracker.ietf.org/doc/html/rfc6455

A 4x more complex PR which involves a DataPort refactor was posted here:
* DataPort refactor: https://github.com/nats-io/nats.java/pull/494
* ByteBuffer based websocket support: https://github.com/nats-io/nats.java/pull/502

I've closed out the 4x more complex PRs, since the guiding principle that @scottf suggests is simplicity... and this is as simple as it gets.