### PR TITLE
bw compatibility restored on checking consumer not found

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -408,7 +408,8 @@ public class NatsJetStream extends NatsJetStreamImplBase implements JetStream {
             return getConsumerInfo(stream, consumer);
         }
         catch (JetStreamApiException e) {
-            if (e.getApiErrorCode() == JS_CONSUMER_NOT_FOUND_ERR) {
+            // the right side of this condition...  ( starting here \/ ) is for backward compatibility with server versions that did not provide api error codes
+            if (e.getApiErrorCode() == JS_CONSUMER_NOT_FOUND_ERR || (e.getErrorCode() == 404 && e.getErrorDescription().contains("consumer"))) {
                 return null;
             }
             throw e;


### PR DESCRIPTION
Fixing this change that was not backward compatible: https://github.com/nats-io/nats.java/commit/d3e2c0e675c4843ed259212f36024574a133954d#diff-7bae7dec65886ecd48115d9367d773a51255027e6f885b882dba2f915960241b