### PR TITLE
max_ack_pending set by server if not provided

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -14,7 +14,6 @@
 package io.nats.client.impl;
 
 import io.nats.client.*;
-import io.nats.client.api.AckPolicy;
 import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.ConsumerInfo;
 import io.nats.client.api.PublishAck;
@@ -291,15 +290,6 @@ public class NatsJetStream extends NatsJetStreamImplBase implements JetStream {
 
         // 5-Consumer didn't exist. It's either ephemeral or a durable that didn't already exist.
         if (createConsumer) {
-            // Defaults should set the right ack pending.
-            // if we have acks and the maxAckPending is not set, set it
-            // to the internal Max.
-            // TODO: too high value?
-            if (ccBuilder.getMaxAckPending() == 0
-                    && ccBuilder.getAckPolicy() != AckPolicy.None) {
-                ccBuilder.maxAckPending(sub.getPendingMessageLimit());
-            }
-
             // Pull mode doesn't maintain a deliver subject. It's actually an error if we send it.
             if (!isPullMode) {
                 ccBuilder.deliverSubject(inbox);


### PR DESCRIPTION
during subscribe, we used to set max_ack_pending if it was not supplied, but we set it to pendingMessageLimit which defaults to 64k. The server default for max_ack_pending is 20K. Seems like the right behavior to let the server set this value.