### PR TITLE
kv get with revision

### DIFF
--- a/src/main/java/io/nats/client/KeyValue.java
+++ b/src/main/java/io/nats/client/KeyValue.java
@@ -46,6 +46,19 @@ public interface KeyValue {
     KeyValueEntry get(String key) throws IOException, JetStreamApiException;
 
     /**
+     * Get the specific revision of an entry for a key.
+     * THIS IS A BETA FEATURE AND SUBJECT TO CHANGE
+     * @param key the key
+     * @param revision the revision
+     * @return the KvEntry object or null if not found.
+     * @throws IOException covers various communication issues with the NATS
+     *         server such as timeout or interruption
+     * @throws JetStreamApiException the request had an error related to the data
+     * @throws IllegalArgumentException the server is not JetStream enabled
+     */
+    KeyValueEntry get(String key, long revision) throws IOException, JetStreamApiException;
+
+    /**
      * Put a byte[] as the value for a key
      * THIS IS A BETA FEATURE AND SUBJECT TO CHANGE
      * @param key the key

--- a/src/main/java/io/nats/client/impl/NatsJetStreamManagement.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamManagement.java
@@ -20,8 +20,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static io.nats.client.api.MessageGetRequest.lastBySubjectBytes;
-import static io.nats.client.api.MessageGetRequest.seqBytes;
 import static io.nats.client.support.ApiConstants.SEQ;
 import static io.nats.client.support.JsonUtils.simpleMessageBody;
 import static io.nats.client.support.Validator.*;
@@ -208,7 +206,7 @@ public class NatsJetStreamManagement extends NatsJetStreamImplBase implements Je
     public MessageInfo getMessage(String streamName, long seq) throws IOException, JetStreamApiException {
         validateNotNull(streamName, "Stream Name");
         String subj = String.format(JSAPI_MSG_GET, streamName);
-        Message resp = makeRequestResponseRequired(subj, seqBytes(seq), jso.getRequestTimeout());
+        Message resp = makeRequestResponseRequired(subj, MessageGetRequest.seqBytes(seq), jso.getRequestTimeout());
         return new MessageInfo(resp).throwOnHasError();
     }
 
@@ -220,8 +218,8 @@ public class NatsJetStreamManagement extends NatsJetStreamImplBase implements Je
         validateNotNull(streamName, "Stream Name");
         validateSubject(subject, true);
         String getSubject = String.format(JSAPI_MSG_GET, streamName);
-        Message resp = makeRequestResponseRequired(getSubject, lastBySubjectBytes(subject), jso.getRequestTimeout());
-        return new MessageInfo(resp);
+        Message resp = makeRequestResponseRequired(getSubject, MessageGetRequest.lastBySubjectBytes(subject), jso.getRequestTimeout());
+        return new MessageInfo(resp).throwOnHasError();
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/NatsKeyValue.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValue.java
@@ -84,18 +84,41 @@ public class NatsKeyValue implements KeyValue {
      */
     @Override
     public KeyValueEntry get(String key) throws IOException, JetStreamApiException {
-        return getLastMessage(validateNonWildcardKvKeyRequired(key));
+        return _kvGetLastMessage(validateNonWildcardKvKeyRequired(key));
     }
 
-    KeyValueEntry getLastMessage(String key) throws IOException, JetStreamApiException {
-        MessageInfo mi = jsm.getLastMessage(streamName, defaultKeySubject(key));
-        if (mi.hasError()) {
-            if (mi.getApiErrorCode() == JS_NO_MESSAGE_FOUND_ERR) {
-                return null; // run of the mill key not found
-            }
-            mi.throwOnHasError();
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public KeyValueEntry get(String key, long revision) throws IOException, JetStreamApiException {
+        return _kvGetMessage(validateNonWildcardKvKeyRequired(key), revision);
+    }
+
+    KeyValueEntry _kvGetLastMessage(String key) throws IOException, JetStreamApiException {
+        try {
+            return new KeyValueEntry(jsm.getLastMessage(streamName, defaultKeySubject(key)));
         }
-        return new KeyValueEntry(mi);
+        catch (JetStreamApiException jsae) {
+            if (jsae.getApiErrorCode() == JS_NO_MESSAGE_FOUND_ERR) {
+                return null;
+            }
+            throw jsae;
+        }
+    }
+
+    private KeyValueEntry _kvGetMessage(String key, long revision) throws IOException, JetStreamApiException {
+        try {
+            MessageInfo mi = jsm.getMessage(streamName, revision);
+            KeyValueEntry kve = new KeyValueEntry(mi);
+            return key.equals(kve.getKey()) ? kve : null;
+        }
+        catch (JetStreamApiException jsae) {
+            if (jsae.getApiErrorCode() == JS_NO_MESSAGE_FOUND_ERR) {
+                return null;
+            }
+            throw jsae;
+        }
     }
 
     /**
@@ -127,13 +150,14 @@ public class NatsKeyValue implements KeyValue {
      */
     @Override
     public long create(String key, byte[] value) throws IOException, JetStreamApiException {
+        validateNonWildcardKvKeyRequired(key);
         try {
             return update(key, value, 0);
         }
         catch (JetStreamApiException e) {
             if (e.getApiErrorCode() == JS_WRONG_LAST_SEQUENCE) {
                 // must check if the last message for this subject is a delete or purge
-                KeyValueEntry kve = getLastMessage(key);
+                KeyValueEntry kve = _kvGetLastMessage(key);
                 if (kve != null && kve.getOperation() != KeyValueOperation.PUT) {
                     return update(key, value, kve.getRevision());
                 }
@@ -147,6 +171,7 @@ public class NatsKeyValue implements KeyValue {
      */
     @Override
     public long update(String key, byte[] value, long expectedRevision) throws IOException, JetStreamApiException {
+        validateNonWildcardKvKeyRequired(key);
         Headers h = new Headers().add(EXPECTED_LAST_SUB_SEQ_HDR, Long.toString(expectedRevision));
         return _publishWithNonWildcardKey(key, value, h).getSeqno();
     }
@@ -156,6 +181,7 @@ public class NatsKeyValue implements KeyValue {
      */
     @Override
     public void delete(String key) throws IOException, JetStreamApiException {
+        validateNonWildcardKvKeyRequired(key);
         _publishWithNonWildcardKey(key, null, DELETE_HEADERS);
     }
 

--- a/src/main/java/io/nats/client/impl/NatsKeyValue.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValue.java
@@ -109,8 +109,7 @@ public class NatsKeyValue implements KeyValue {
 
     private KeyValueEntry _kvGetMessage(String key, long revision) throws IOException, JetStreamApiException {
         try {
-            MessageInfo mi = jsm.getMessage(streamName, revision);
-            KeyValueEntry kve = new KeyValueEntry(mi);
+            KeyValueEntry kve = new KeyValueEntry(jsm.getMessage(streamName, revision));
             return key.equals(kve.getKey()) ? kve : null;
         }
         catch (JetStreamApiException jsae) {

--- a/src/main/java/io/nats/client/impl/NatsKeyValueWatchSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValueWatchSubscription.java
@@ -49,7 +49,7 @@ public class NatsKeyValueWatchSubscription implements AutoCloseable {
             endOfDataSent = new AtomicBoolean(true);
         }
         else {
-            KeyValueEntry kveCheckPending = kv.getLastMessage(keyPattern);
+            KeyValueEntry kveCheckPending = kv._kvGetLastMessage(keyPattern);
             if (kveCheckPending == null) {
                 watcher.endOfData();
                 endOfDataSent = new AtomicBoolean(true);

--- a/src/test/java/io/nats/client/impl/KeyValueTests.java
+++ b/src/test/java/io/nats/client/impl/KeyValueTests.java
@@ -302,6 +302,42 @@ public class KeyValueTests extends JetStreamTestBase {
     }
 
     @Test
+    public void testGetRevision() throws Exception {
+        runInJsServer(nc -> {
+            KeyValueManagement kvm = nc.keyValueManagement();
+
+            kvm.create(KeyValueConfiguration.builder()
+                .name(BUCKET)
+                .storageType(StorageType.Memory)
+                .maxHistoryPerKey(2)
+                .build());
+
+            KeyValue kv = nc.keyValue(BUCKET);
+            long seq1 = kv.put(KEY, 1);
+            long seq2 = kv.put(KEY, 2);
+            long seq3 = kv.put(KEY, 3);
+
+            KeyValueEntry kve = kv.get(KEY);
+            assertNotNull(kve);
+            assertEquals(3, kve.getValueAsLong());
+
+            kve = kv.get(KEY, seq3);
+            assertNotNull(kve);
+            assertEquals(3, kve.getValueAsLong());
+
+            kve = kv.get(KEY, seq2);
+            assertNotNull(kve);
+            assertEquals(2, kve.getValueAsLong());
+
+            kve = kv.get(KEY, seq1);
+            assertNull(kve);
+
+            kve = kv.get("notkey", seq3);
+            assertNull(kve);
+        });
+    }
+
+    @Test
     public void testKeys() throws Exception {
         runInJsServer(nc -> {
             KeyValueManagement kvm = nc.keyValueManagement();


### PR DESCRIPTION
https://github.com/nats-io/nats-architecture-and-design/issues/93

**KeyValue.java** 
* Added interface method overload which takes a revision parameter

**NatsJetStreamManagement.java** 
* Changed imports for readability
* Underlying MessageInfo object changed to be consistent, so had to manually throw on error

**NatsKeyValue.java**
* Implemented get with revision with refactor to original get to share common code.

* NatsKeyValueWatchSubscription.java
* Use minor refactor 

**KeyValueTests.java**
* test the implementation