### PR TITLE
don't increment delivered count if no message was retrieved

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsSubscription.java
@@ -181,7 +181,9 @@ class NatsSubscription extends NatsConsumer implements Subscription {
             throw new IllegalStateException("This subscription became inactive.");
         }
 
-        this.incrementDeliveredCount();
+        if (msg != null) {
+            this.incrementDeliveredCount();
+        }
 
         if (this.reachedUnsubLimit()) {
             this.connection.invalidate(this);


### PR DESCRIPTION
The next message implementation tries to retrieve a message from the internal buffer and increments the delivered count whether or not there was a message. This seems like a bug, and the PR fixes it. Need confirmation that it should only increment the delivered count when a message is actually found.