### PR TITLE
Support for timeout propagation in async requests

### DIFF
--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -194,6 +194,20 @@ public interface Connection extends AutoCloseable {
     CompletableFuture<Message> request(Message message);
 
     /**
+     * Send a request. The returned future will be completed when the
+     * response comes back.
+     *
+     * <p>The Message object allows you to set a replyTo, but in requests,
+     * the replyTo is reserved for internal use as the address for the
+     * server to respond to the client with the consumer's reply.</p>
+     *
+     * @param message the message
+     * @param timeout the time to wait for a response
+     * @return a Future for the response, which may be cancelled on error or timed out
+     */
+    CompletableFuture<Message> requestWithTimeout(Message message, Duration timeout);
+    
+    /**
      * Send a request and returns the reply or null. This version of request is equivalent
      * to calling get on the future returned from {@link #request(String, byte[]) request()} with
      * the timeout and handling the ExecutionException and TimeoutException.

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1021,6 +1021,12 @@ class NatsConnection implements Connection {
     }
 
     @Override
+    public CompletableFuture<Message> requestWithTimeout(Message message, Duration timeout) {
+        validateNotNull(message, "Message");
+        return requestFutureInternal(message.getSubject(), message.getHeaders(), message.getData(), message.isUtf8mode(), timeout, true);
+    }
+
+    @Override
     public CompletableFuture<Message> request(Message message) {
         validateNotNull(message, "Message");
         return requestFutureInternal(message.getSubject(), message.getHeaders(), message.getData(), message.isUtf8mode(), null, true);


### PR DESCRIPTION
Give the possibility to clients to specify a timeout while performing async requests.
More details in [#616](https://github.com/nats-io/nats.java/issues/616)