### PR TITLE
Support for timeout propagation in async requests

### DIFF
--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -184,6 +184,18 @@ public interface Connection extends AutoCloseable {
      * Send a request. The returned future will be completed when the
      * response comes back.
      *
+     * @param subject the subject for the service that will handle the request
+     * @param body the content of the message
+     * @param timeout the time to wait for a response
+     * @return a Future for the response, which may be cancelled on error or timed out
+     */
+    CompletableFuture<Message> requestWithTimeout(String subject, byte[] body, Duration timeout);
+
+
+    /**
+     * Send a request. The returned future will be completed when the
+     * response comes back.
+     *
      * <p>The Message object allows you to set a replyTo, but in requests,
      * the replyTo is reserved for internal use as the address for the
      * server to respond to the client with the consumer's reply.</p>
@@ -193,6 +205,20 @@ public interface Connection extends AutoCloseable {
      */
     CompletableFuture<Message> request(Message message);
 
+    /**
+     * Send a request. The returned future will be completed when the
+     * response comes back.
+     *
+     * <p>The Message object allows you to set a replyTo, but in requests,
+     * the replyTo is reserved for internal use as the address for the
+     * server to respond to the client with the consumer's reply.</p>
+     *
+     * @param message the message
+     * @param timeout the time to wait for a response
+     * @return a Future for the response, which may be cancelled on error or timed out
+     */
+    CompletableFuture<Message> requestWithTimeout(Message message, Duration timeout);
+    
     /**
      * Send a request and returns the reply or null. This version of request is equivalent
      * to calling get on the future returned from {@link #request(String, byte[]) request()} with

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1021,6 +1021,17 @@ class NatsConnection implements Connection {
     }
 
     @Override
+    public CompletableFuture<Message> requestWithTimeout(String subject, byte[] body, Duration timeout) {
+        return requestFutureInternal(subject, null, body, options.supportUTF8Subjects(), timeout, true);
+    }
+
+    @Override
+    public CompletableFuture<Message> requestWithTimeout(Message message, Duration timeout) {
+        validateNotNull(message, "Message");
+        return requestFutureInternal(message.getSubject(), message.getHeaders(), message.getData(), message.isUtf8mode(), timeout, true);
+    }
+
+    @Override
     public CompletableFuture<Message> request(Message message) {
         validateNotNull(message, "Message");
         return requestFutureInternal(message.getSubject(), message.getHeaders(), message.getData(), message.isUtf8mode(), null, true);

--- a/src/test/java/io/nats/client/impl/RequestTests.java
+++ b/src/test/java/io/nats/client/impl/RequestTests.java
@@ -240,6 +240,105 @@ public class RequestTests extends TestBase {
     }
 
     @Test
+    public void testRequireCleanupOnTimeoutCleanCompletable() throws IOException, InterruptedException {
+        try (NatsTestServer ts = new NatsTestServer(false)) {
+
+            long cleanupInterval = 100;
+
+            Options options = new Options.Builder().server(ts.getURI())
+                    .requestCleanupInterval(Duration.ofMillis(cleanupInterval))
+                    .noNoResponders().build();
+
+            NatsConnection nc = (NatsConnection) Nats.connect(options);
+            try {
+                assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                NatsMessage nm = NatsMessage.builder().subject(SUBJECT).data(dataBytes(2)).build();
+                CompletableFuture<Message> future = nc.requestWithTimeout(nm, Duration.ofMillis(cleanupInterval));
+                
+                Thread.sleep(2 * cleanupInterval + Options.DEFAULT_CONNECTION_TIMEOUT.toMillis());
+
+                assertTrue(future.isCompletedExceptionally());
+                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+
+            } finally {
+                nc.close();
+                assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+            }
+        }
+    }
+
+    @Test
+    public void testSimpleRequestWithTimeout() throws IOException, ExecutionException, TimeoutException, InterruptedException {
+
+        try (NatsTestServer ts = new NatsTestServer(false))
+        {
+            Options options = new Options.Builder().server(ts.getURI()).requestCleanupInterval(Duration.ofHours(1)).build();
+            NatsConnection nc = (NatsConnection) Nats.connect(options);
+
+            try {
+
+                assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+
+                Dispatcher d = nc.createDispatcher((msg) -> {
+                    assertTrue(msg.getReplyTo().startsWith(Options.DEFAULT_INBOX_PREFIX));
+                    nc.publish(msg.getReplyTo(), null);
+                });
+                d.subscribe(SUBJECT);
+
+                NatsMessage nm = NatsMessage.builder().subject(SUBJECT).data(dataBytes(2)).build();
+                CompletableFuture<Message> incoming = nc.requestWithTimeout("subject", null, Duration.ofMillis(100));
+
+                Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
+
+                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertNotNull(msg);
+                assertEquals(0, msg.getData().length);
+                assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
+
+            }
+            finally {
+                nc.close();
+                assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+            }
+        }
+    }
+
+    @Test
+    public void testSimpleRequestWithTimeoutSlowProducer() throws IOException, ExecutionException, TimeoutException, InterruptedException {
+
+        try (NatsTestServer ts = new NatsTestServer(false))
+        {
+            long cleanupInterval = 10;
+            Options options = new Options.Builder().server(ts.getURI()).requestCleanupInterval(Duration.ofMillis(cleanupInterval)).build();
+            NatsConnection nc = (NatsConnection) Nats.connect(options);
+
+            try {
+
+                assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+
+                //slow responder
+                long delay = 2 * cleanupInterval + Options.DEFAULT_CONNECTION_TIMEOUT.toMillis();
+
+                Dispatcher d = nc.createDispatcher((msg) -> {
+                    assertTrue(msg.getReplyTo().startsWith(Options.DEFAULT_INBOX_PREFIX));
+                    Thread.sleep(delay);
+                    nc.publish(msg.getReplyTo(), null);
+                });
+                d.subscribe(SUBJECT);
+
+                NatsMessage nm = NatsMessage.builder().subject(SUBJECT).data(dataBytes(2)).build();
+                CompletableFuture<Message> incoming = nc.requestWithTimeout("subject", null, Duration.ofMillis(cleanupInterval));
+                assertThrows(CancellationException.class, () -> incoming.get(delay, TimeUnit.MILLISECONDS));
+
+            }
+            finally {
+                nc.close();
+                assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+            }
+        }
+    }
+
+    @Test
     public void testRequireCleanupOnCancelFromNoResponders() throws IOException, InterruptedException {
         try (NatsTestServer ts = new NatsTestServer(false)) {
             Options options = new Options.Builder().server(ts.getURI())
@@ -248,11 +347,51 @@ public class RequestTests extends TestBase {
             Connection nc = Nats.connect(options);
             try {
                 assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertThrows(CancellationException.class, () -> nc.request("subject", null).get(100, TimeUnit.MILLISECONDS));
 
-                assertThrows(CancellationException.class,
-                        () -> nc.request("subject", null).get(100, TimeUnit.MILLISECONDS));
+                assertEquals(0, ((NatsStatistics) nc.getStatistics()).getOutstandingRequests());
+            } finally {
+                nc.close();
+                assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+            }
 
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+        }
+    }
+
+    @Test
+    public void testRequireCleanupWithTimeoutNoResponders() throws IOException, InterruptedException {
+        try (NatsTestServer ts = new NatsTestServer(false)) {
+            Options options = new Options.Builder().server(ts.getURI())
+                    .requestCleanupInterval(Duration.ofHours(1)).build();
+
+            Connection nc = Nats.connect(options);
+            try {
+                assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertThrows(CancellationException.class, () -> nc.requestWithTimeout("subject", null, Duration.ofMillis(100)).get(100, TimeUnit.MILLISECONDS));
+                assertEquals(0, ((NatsStatistics) nc.getStatistics()).getOutstandingRequests());
+            } finally {
+                nc.close();
+                assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
+            }
+
+        }
+    }
+
+    @Test
+    public void testRequireCleanupWithTimeoutNoNoResponders() throws IOException, InterruptedException {
+        try (NatsTestServer ts = new NatsTestServer(false)) {
+            Options options = new Options.Builder().server(ts.getURI())
+                    .requestCleanupInterval(Duration.ofHours(1))
+                    .noNoResponders().build();
+
+            Connection nc = Nats.connect(options);
+            try {
+                assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+
+                assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
+                assertThrows(TimeoutException.class, () -> nc.requestWithTimeout("subject", null, Duration.ofMillis(100)).get(100, TimeUnit.MILLISECONDS));
+                assertEquals(1, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+
             } finally {
                 nc.close();
                 assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");


### PR DESCRIPTION
Give the possibility to clients to specify a timeout while performing async requests.
More details in [#616](https://github.com/nats-io/nats.java/issues/616)