### PR TITLE
Add test for NKey.clear

### DIFF
--- a/src/test/java/io/nats/client/NKeyTests.java
+++ b/src/test/java/io/nats/client/NKeyTests.java
@@ -587,4 +587,14 @@ public class NKeyTests {
         assertNotEquals(key, NKey.createServer(null));
         assertNotEquals(key, NKey.createAccount(null));
     }
+
+    @Test
+    public void testClear() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> {
+            NKey key = NKey.createServer(null);
+            key.clear();
+            key.getPrivateKey();
+
+        }, "Invalid encoding");
+    }
 }


### PR DESCRIPTION
Test that `key.getPrivateKey()` throws an `IllegalArgumentException` when `clear` is called. 
This tests the method [`NKey.clear`](https://github.com/nats-io/nats.java/blob/ddf96321702ff70d0b98d6e5c8d0b6b7987c312d/src/main/java/io/nats/client/NKey.java#L559). 
This test is based on the test [`testEquals`](https://github.com/nats-io/nats.java/blob/ddf96321702ff70d0b98d6e5c8d0b6b7987c312d/src/test/java/io/nats/client/NKeyTests.java#L582).


(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))