### PR TITLE
consumer info change to sequence_info from sequence_pair

### DIFF
--- a/src/main/java/io/nats/client/api/ConsumerInfo.java
+++ b/src/main/java/io/nats/client/api/ConsumerInfo.java
@@ -31,8 +31,8 @@ public class ConsumerInfo extends ApiResponse<ConsumerInfo> {
     private final String name;
     private final ConsumerConfiguration configuration;
     private final ZonedDateTime created;
-    private final SequencePair delivered;
-    private final SequencePair ackFloor;
+    private final SequenceInfo delivered;
+    private final SequenceInfo ackFloor;
     private final long numPending;
     private final long numWaiting;
     private final long numAckPending;
@@ -54,10 +54,10 @@ public class ConsumerInfo extends ApiResponse<ConsumerInfo> {
         this.configuration = new ConsumerConfiguration(jsonObject);
 
         jsonObject = JsonUtils.getJsonObject(DELIVERED, json);
-        this.delivered = new SequencePair(jsonObject);
+        this.delivered = new SequenceInfo(jsonObject);
 
         jsonObject = JsonUtils.getJsonObject(ACK_FLOOR, json);
-        this.ackFloor = new SequencePair(jsonObject);
+        this.ackFloor = new SequenceInfo(jsonObject);
 
         numAckPending = JsonUtils.readLong(json, NUM_ACK_PENDING_RE, 0);
         numRedelivered = JsonUtils.readLong(json, NUM_REDELIVERED_RE, 0);
@@ -84,11 +84,11 @@ public class ConsumerInfo extends ApiResponse<ConsumerInfo> {
         return created;
     }
 
-    public SequencePair getDelivered() {
+    public SequenceInfo getDelivered() {
         return delivered;
     }
 
-    public SequencePair getAckFloor() {
+    public SequenceInfo getAckFloor() {
         return ackFloor;
     }
 

--- a/src/main/java/io/nats/client/api/SequenceInfo.java
+++ b/src/main/java/io/nats/client/api/SequenceInfo.java
@@ -33,7 +33,7 @@ public class SequenceInfo extends SequencePair {
     }
 
     /**
-     * "The last time a message was delivered or acknowledged (for ack_floor)
+     * The last time a message was delivered or acknowledged (for ack_floor)
      * @return the last active time
      */
     public ZonedDateTime getLastActive() {

--- a/src/main/java/io/nats/client/api/SequenceInfo.java
+++ b/src/main/java/io/nats/client/api/SequenceInfo.java
@@ -1,0 +1,51 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.api;
+
+import io.nats.client.support.JsonUtils;
+
+import java.time.ZonedDateTime;
+
+import static io.nats.client.support.ApiConstants.LAST_ACTIVE_RE;
+
+/**
+ * This class holds the sequence numbers for a consumer and
+ * stream and .
+ */
+public class SequenceInfo extends SequencePair {
+
+    private final ZonedDateTime lastActive;
+
+    SequenceInfo(String json) {
+        super(json);
+        lastActive = JsonUtils.readDate(json, LAST_ACTIVE_RE);
+    }
+
+    /**
+     * "The last time a message was delivered or acknowledged (for ack_floor)
+     * @return the last active time
+     */
+    public ZonedDateTime getLastActive() {
+        return lastActive;
+    }
+
+    @Override
+    public String toString() {
+        return "SequenceInfo{" +
+            "consumerSeq=" + consumerSeq +
+            ", streamSeq=" + streamSeq +
+            ", lastActive=" + lastActive +
+            '}';
+    }
+}

--- a/src/main/java/io/nats/client/api/SequencePair.java
+++ b/src/main/java/io/nats/client/api/SequencePair.java
@@ -23,8 +23,8 @@ import static io.nats.client.support.ApiConstants.STREAM_SEQ_RE;
  * stream.
  */
 public class SequencePair {
-    private final long consumerSeq;
-    private final long streamSeq;
+    protected final long consumerSeq;
+    protected final long streamSeq;
 
     SequencePair(String json) {
         consumerSeq = JsonUtils.readLong(json, CONSUMER_SEQ_RE, 0);

--- a/src/main/java/io/nats/client/support/ApiConstants.java
+++ b/src/main/java/io/nats/client/support/ApiConstants.java
@@ -76,6 +76,7 @@ public interface ApiConstants {
     String KEEP              = "keep";
     String LAG               = "lag";
     String LAME_DUCK_MODE    = "ldm";
+    String LAST_ACTIVE       = "last_active";
     String LAST_BY_SUBJECT   = "last_by_subj";
     String LAST_SEQ          = "last_seq";
     String LAST_TS           = "last_ts";
@@ -199,6 +200,7 @@ public interface ApiConstants {
     Pattern JET_STREAM_RE         = boolean_pattern(JETSTREAM);
     Pattern LAG_RE                = integer_pattern(LAG);
     Pattern LAME_DUCK_MODE_RE     = boolean_pattern(LAME_DUCK_MODE);
+    Pattern LAST_ACTIVE_RE        = string_pattern(LAST_ACTIVE);
     Pattern LAST_SEQ_RE           = integer_pattern(LAST_SEQ);
     Pattern LAST_TS_RE            = string_pattern(LAST_TS);
     Pattern LEADER_RE             = string_pattern(LEADER);

--- a/src/test/java/io/nats/client/api/ConsumerInfoTests.java
+++ b/src/test/java/io/nats/client/api/ConsumerInfoTests.java
@@ -13,6 +13,7 @@
 
 package io.nats.client.api;
 
+import io.nats.client.support.DateTimeUtils;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -31,10 +32,25 @@ public class ConsumerInfoTests {
         assertEquals("foo-stream", ci.getStreamName());
         assertEquals("foo-consumer", ci.getName());
 
-        assertEquals(1, ci.getDelivered().getConsumerSequence());
-        assertEquals(2, ci.getDelivered().getStreamSequence());
-        assertEquals(3, ci.getAckFloor().getConsumerSequence());
-        assertEquals(4, ci.getAckFloor().getStreamSequence());
+        SequencePair sp = ci.getDelivered();
+        assertEquals(1, sp.getConsumerSequence());
+        assertEquals(2, sp.getStreamSequence());
+
+        //noinspection CastCanBeRemovedNarrowingVariableType
+        SequenceInfo sinfo = (SequenceInfo)sp;
+        assertEquals(1, sinfo.getConsumerSequence());
+        assertEquals(2, sinfo.getStreamSequence());
+        assertEquals(DateTimeUtils.parseDateTime("2022-06-29T19:33:21.163377Z"), sinfo.getLastActive());
+
+        sp = ci.getAckFloor();
+        assertEquals(3, sp.getConsumerSequence());
+        assertEquals(4, sp.getStreamSequence());
+
+        //noinspection CastCanBeRemovedNarrowingVariableType
+        sinfo = (SequenceInfo)sp;
+        assertEquals(3, sinfo.getConsumerSequence());
+        assertEquals(4, sinfo.getStreamSequence());
+        assertEquals(DateTimeUtils.parseDateTime("2022-06-29T20:33:21.163377Z"), sinfo.getLastActive());
 
         assertEquals(24, ci.getNumPending());
         assertEquals(42, ci.getNumAckPending());

--- a/src/test/java/io/nats/client/impl/ListRequestsTests.java
+++ b/src/test/java/io/nats/client/impl/ListRequestsTests.java
@@ -17,7 +17,6 @@ import io.nats.client.JetStreamApiException;
 import io.nats.client.Message;
 import io.nats.client.api.*;
 import io.nats.client.support.DateTimeUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -39,7 +38,7 @@ public class ListRequestsTests extends JetStreamTestBase {
         ConsumerInfo ci = clr.getConsumers().get(0);
         assertEquals("stream-1", ci.getStreamName());
         assertEquals("cname1", ci.getName());
-        Assertions.assertEquals(DateTimeUtils.parseDateTime("2021-01-20T23:41:08.579594Z"), ci.getCreationTime());
+        assertEquals(DateTimeUtils.parseDateTime("2021-01-20T23:41:08.579594Z"), ci.getCreationTime());
         assertEquals(5, ci.getNumAckPending());
         assertEquals(6, ci.getRedelivered());
         assertEquals(7, ci.getNumWaiting());
@@ -58,9 +57,21 @@ public class ListRequestsTests extends JetStreamTestBase {
         assertEquals(1, sp.getConsumerSequence());
         assertEquals(2, sp.getStreamSequence());
 
+        //noinspection CastCanBeRemovedNarrowingVariableType
+        SequenceInfo sinfo = (SequenceInfo)sp;
+        assertEquals(1, sinfo.getConsumerSequence());
+        assertEquals(2, sinfo.getStreamSequence());
+        assertEquals(DateTimeUtils.parseDateTime("2022-06-29T19:33:21.163377Z"), sinfo.getLastActive());
+
         sp = ci.getAckFloor();
         assertEquals(3, sp.getConsumerSequence());
         assertEquals(4, sp.getStreamSequence());
+
+        //noinspection CastCanBeRemovedNarrowingVariableType
+        sinfo = (SequenceInfo)sp;
+        assertEquals(3, sinfo.getConsumerSequence());
+        assertEquals(4, sinfo.getStreamSequence());
+        assertEquals(DateTimeUtils.parseDateTime("2022-06-29T20:33:21.163377Z"), sinfo.getLastActive());
 
         clr = new ConsumerListReader();
         clr.process(getDataMessage(EMPTY_JSON));

--- a/src/test/resources/data/ConsumerInfo.json
+++ b/src/test/resources/data/ConsumerInfo.json
@@ -14,11 +14,13 @@
   },
   "delivered": {
     "consumer_seq": 1,
-    "stream_seq": 2
+    "stream_seq": 2,
+    "last_active": "2022-06-29T19:33:21.163377Z"
   },
   "ack_floor": {
     "consumer_seq": 3,
-    "stream_seq": 4
+    "stream_seq": 4,
+    "last_active": "2022-06-29T20:33:21.163377Z"
   },
   "num_pending": 24,
   "num_ack_pending": 42,

--- a/src/test/resources/data/ConsumerListResponse.json
+++ b/src/test/resources/data/ConsumerListResponse.json
@@ -19,11 +19,13 @@
       },
       "delivered": {
         "consumer_seq": 1,
-        "stream_seq": 2
+        "stream_seq": 2,
+        "last_active": "2022-06-29T19:33:21.163377Z"
       },
       "ack_floor": {
         "consumer_seq": 3,
-        "stream_seq": 4
+        "stream_seq": 4,
+        "last_active": "2022-06-29T20:33:21.163377Z"
       },
       "num_ack_pending": 5,
       "num_redelivered": 6,


### PR DESCRIPTION
https://github.com/nats-io/nats.java/issues/671

* A new object was created, `SequenceInfo` which extends `SequencePair`
* The `ConsumerInfo.delivered` and `ConsumerInfo.ackFloor` fields where changed to this type.

Backward compile compatibility was ensured by the subclass, meaning if you assigned `getDelivered()` to a SequencePair, this is fine, it still is a SequencePair.
