### PR TITLE
Add numReplicas field in ConsumerConfiguration

### DIFF
--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -29,6 +29,7 @@ import static io.nats.client.support.ApiConstants.*;
 import static io.nats.client.support.JsonUtils.beginJson;
 import static io.nats.client.support.JsonUtils.endJson;
 import static io.nats.client.support.Validator.emptyAsNull;
+import static io.nats.client.support.Validator.validateNumberOfReplicas;
 
 /**
  * The ConsumerConfiguration class specifies the configuration for creating a JetStream consumer on the client and
@@ -81,6 +82,7 @@ public class ConsumerConfiguration implements JsonSerializable {
     protected final Boolean flowControl;
     protected final Boolean headersOnly;
     protected final List<Duration> backoff;
+    protected final int numReplicas;
 
     protected ConsumerConfiguration(ConsumerConfiguration cc) {
         this.deliverPolicy = cc.deliverPolicy;
@@ -107,6 +109,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         this.flowControl = cc.flowControl;
         this.headersOnly = cc.headersOnly;
         this.backoff = new ArrayList<>(cc.backoff);
+        this.numReplicas = cc.numReplicas;
     }
 
     // for the response from the server
@@ -145,6 +148,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         headersOnly = JsonUtils.readBoolean(json, HEADERS_ONLY_RE, null);
 
         backoff = JsonUtils.getDurationList(BACKOFF, json);
+        numReplicas = JsonUtils.readInt(json, NUM_REPLICAS_RE, 1);
     }
 
     // For the builder
@@ -178,6 +182,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         this.headersOnly = b.headersOnly;
 
         this.backoff = b.backoff;
+        this.numReplicas = b.numReplicas;
     }
 
     /**
@@ -211,6 +216,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         JsonUtils.addFieldAsNanos(sb, MAX_EXPIRES, maxExpires);
         JsonUtils.addFieldAsNanos(sb, INACTIVE_THRESHOLD, inactiveThreshold);
         JsonUtils.addDurations(sb, BACKOFF, backoff);
+        JsonUtils.addField(sb, NUM_REPLICAS, numReplicas);
         return endJson(sb).toString();
     }
 
@@ -410,6 +416,12 @@ public class ConsumerConfiguration implements JsonSerializable {
     }
 
     /**
+     * Get the number of consumer replicas.
+     * @return the replicas count
+     */
+    public Integer getNumReplicas() { return numReplicas; }
+
+    /**
      * Gets whether deliver policy of this consumer configuration was set or left unset
      * @return true if the policy was set, false if the policy was not set
      */
@@ -559,6 +571,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         private Boolean headersOnly;
 
         private List<Duration> backoff = new ArrayList<>();
+        private int numReplicas = 1;
 
         public Builder() {}
 
@@ -593,6 +606,7 @@ public class ConsumerConfiguration implements JsonSerializable {
                 this.headersOnly = cc.headersOnly;
 
                 this.backoff = new ArrayList<>(cc.backoff);
+                this.numReplicas = cc.numReplicas;
             }
         }
 
@@ -1009,6 +1023,16 @@ public class ConsumerConfiguration implements JsonSerializable {
         }
 
         /**
+         * Set the number of replicas for the consumer.
+         * @param numReplicas number of replicas for the consumer
+         * @return Builder
+         */
+        public Builder numReplicas(Integer numReplicas) {
+            this.numReplicas = validateNumberOfReplicas(numReplicas);
+            return this;
+        }
+
+        /**
          * Builds the ConsumerConfiguration
          * @return The consumer configuration.
          */
@@ -1059,6 +1083,7 @@ public class ConsumerConfiguration implements JsonSerializable {
             ", maxExpires=" + maxExpires +
             ", inactiveThreshold=" + inactiveThreshold +
             ", backoff=" + backoff +
+            ", numReplicas=" + numReplicas +
             '}';
     }
 

--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -82,7 +82,7 @@ public class ConsumerConfiguration implements JsonSerializable {
     protected final Boolean flowControl;
     protected final Boolean headersOnly;
     protected final List<Duration> backoff;
-    protected final int numReplicas;
+    protected final Integer numReplicas;
 
     protected ConsumerConfiguration(ConsumerConfiguration cc) {
         this.deliverPolicy = cc.deliverPolicy;
@@ -148,7 +148,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         headersOnly = JsonUtils.readBoolean(json, HEADERS_ONLY_RE, null);
 
         backoff = JsonUtils.getDurationList(BACKOFF, json);
-        numReplicas = JsonUtils.readInt(json, NUM_REPLICAS_RE, 1);
+        numReplicas = JsonUtils.readInteger(json, NUM_REPLICAS_RE);
     }
 
     // For the builder
@@ -419,7 +419,7 @@ public class ConsumerConfiguration implements JsonSerializable {
      * Get the number of consumer replicas.
      * @return the replicas count
      */
-    public Integer getNumReplicas() { return numReplicas; }
+    public int getNumReplicas() { return numReplicas; }
 
     /**
      * Gets whether deliver policy of this consumer configuration was set or left unset
@@ -571,7 +571,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         private Boolean headersOnly;
 
         private List<Duration> backoff = new ArrayList<>();
-        private int numReplicas = 1;
+        private Integer numReplicas = 1;
 
         public Builder() {}
 

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -461,6 +461,8 @@ public class NatsJetStream extends NatsJetStreamImplBase implements JetStream {
 
             if (!backoff.equals(serverCcc.backoff)) { changes.add("backoff"); }; // backoff will never be null, but can be empty
 
+            if (numReplicas != null && !numReplicas.equals(serverCcc.numReplicas)) { changes.add("numReplicas"); };
+
             // do not need to check Durable because the original is retrieved by the durable name
 
             return changes;

--- a/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
@@ -419,10 +419,12 @@ public class JetStreamManagementTests extends JetStreamTestBase {
 
             final ConsumerConfiguration cc0 = ConsumerConfiguration.builder()
                     .durable(durable(0))
+                    .numReplicas(1)
                     .build();
             ConsumerInfo ci = jsm.addOrUpdateConsumer(STREAM, cc0);
             assertEquals(durable(0), ci.getName());
             assertEquals(durable(0), ci.getConsumerConfiguration().getDurable());
+            assertEquals(1, ci.getConsumerConfiguration().getNumReplicas());
             assertNull(ci.getConsumerConfiguration().getDeliverSubject());
 
             final ConsumerConfiguration cc1 = ConsumerConfiguration.builder()
@@ -583,13 +585,14 @@ public class JetStreamManagementTests extends JetStreamTestBase {
             JetStreamManagement jsm = nc.jetStreamManagement();
             createDefaultTestStream(jsm);
             assertThrows(JetStreamApiException.class, () -> jsm.getConsumerInfo(STREAM, DURABLE));
-            ConsumerConfiguration cc = ConsumerConfiguration.builder().durable(DURABLE).build();
+            ConsumerConfiguration cc = ConsumerConfiguration.builder().durable(DURABLE).numReplicas(1).build();
             ConsumerInfo ci = jsm.addOrUpdateConsumer(STREAM, cc);
             assertEquals(STREAM, ci.getStreamName());
             assertEquals(DURABLE, ci.getName());
             ci = jsm.getConsumerInfo(STREAM, DURABLE);
             assertEquals(STREAM, ci.getStreamName());
             assertEquals(DURABLE, ci.getName());
+            assertEquals(1, ci.getConsumerConfiguration().getNumReplicas());
             assertThrows(JetStreamApiException.class, () -> jsm.getConsumerInfo(STREAM, durable(999)));
         });
     }


### PR DESCRIPTION
This adds "numReplicas" field in the `ConsumerConfiguration` class to allow configuring the replicas count for a consumer.