### PR TITLE
better request timeout management

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1056,7 +1056,7 @@ class NatsConnection implements Connection {
         String responseInbox = oldStyle ? createInbox() : createResponseInbox(this.mainInbox);
         String responseToken = getResponseToken(responseInbox);
         NatsRequestCompletableFuture future =
-            new NatsRequestCompletableFuture(cancelOn503, futureTimeout == null ? options.getConnectionTimeout() : futureTimeout);
+            new NatsRequestCompletableFuture(cancelOn503, futureTimeout == null ? options.getRequestCleanupInterval() : futureTimeout);
 
         if (!oldStyle) {
             responsesAwaiting.put(responseToken, future);

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1055,7 +1055,8 @@ class NatsConnection implements Connection {
         boolean oldStyle = options.isOldRequestStyle();
         String responseInbox = oldStyle ? createInbox() : createResponseInbox(this.mainInbox);
         String responseToken = getResponseToken(responseInbox);
-        NatsRequestCompletableFuture future = new NatsRequestCompletableFuture(cancelOn503, futureTimeout);
+        NatsRequestCompletableFuture future =
+            new NatsRequestCompletableFuture(cancelOn503, futureTimeout == null ? options.getConnectionTimeout() : futureTimeout);
 
         if (!oldStyle) {
             responsesAwaiting.put(responseToken, future);

--- a/src/main/java/io/nats/client/support/NatsRequestCompletableFuture.java
+++ b/src/main/java/io/nats/client/support/NatsRequestCompletableFuture.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 public class NatsRequestCompletableFuture extends CompletableFuture<Message> {
-    private static final long DEFAULT_TIMEOUT = Options.DEFAULT_CONNECTION_TIMEOUT.toMillis(); // currently 2 seconds
+    private static final long DEFAULT_TIMEOUT = Options.DEFAULT_REQUEST_CLEANUP_INTERVAL.toMillis(); // currently 5 seconds
 
     private final boolean cancelOn503;
     private final long timeOutAfter;

--- a/src/main/java/io/nats/client/support/NatsRequestCompletableFuture.java
+++ b/src/main/java/io/nats/client/support/NatsRequestCompletableFuture.java
@@ -17,7 +17,8 @@ public class NatsRequestCompletableFuture extends CompletableFuture<Message> {
 
     public NatsRequestCompletableFuture(boolean cancelOn503, Duration timeout) {
         this.cancelOn503 = cancelOn503;
-        timeOutAfter = System.currentTimeMillis() + (timeout == null ? DEFAULT_TIMEOUT : timeout.toMillis());
+        timeOutAfter = System.currentTimeMillis() + 10 + (timeout == null ? DEFAULT_TIMEOUT : timeout.toMillis());
+        // 10 extra millis allows for communication time, probably more than needed but...
     }
 
     public void cancelClosing() {


### PR DESCRIPTION
https://github.com/nats-io/nats.java/issues/687

Changed the code to use Options RequestCleanupInterval, which defaults to 5 seconds.