### PR TITLE
Sync NatsMessage.getSizeInBytes() with usage in NatsConnectionWriter

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsMessage.java
@@ -166,13 +166,15 @@ public class NatsMessage implements Message {
             if (protocolBytes != null) {
                 sizeInBytes += protocolBytes.length;
             }
-            if (hdrLen > 0) {
-                sizeInBytes += hdrLen + 2; // CRLF
-            }
-            if (data.length == 0) {
+            sizeInBytes += 2; // CRLF
+            if (!isProtocol()) {
+                if (hdrLen > 0) {
+                    sizeInBytes += hdrLen;
+                }
+                if (dataLen > 0) {
+                    sizeInBytes += dataLen;
+                }
                 sizeInBytes += 2; // CRLF
-            } else {
-                sizeInBytes += dataLen + 4; // CRLF
             }
         }
         return sizeInBytes;

--- a/src/test/java/io/nats/client/impl/MessageQueueTests.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueTests.java
@@ -455,6 +455,34 @@ public class MessageQueueTests {
     }
 
     @Test
+    public void testSizeInBytesWithData() throws InterruptedException {
+        MessageQueue q = new MessageQueue(true);
+
+        String subject = "subj";
+        String replyTo = "reply";
+        Headers h = new Headers().add("Content-Type", "text/plain");
+        NatsMessage msg1 = new NatsMessage(subject, null, h, new byte[8]);
+        NatsMessage msg2 = new NatsMessage(subject, null, h, new byte[16]);
+        NatsMessage msg3 = new NatsMessage(subject, replyTo, h, new byte[16]);
+        long expected = 0;
+
+        assertEquals(64, msg1.getSizeInBytes());
+        assertEquals(72, msg2.getSizeInBytes());
+        assertEquals(78, msg3.getSizeInBytes());
+
+        q.push(msg1);    expected += msg1.getSizeInBytes();
+        assertEquals(expected, q.sizeInBytes());
+        q.push(msg2);    expected += msg2.getSizeInBytes();
+        assertEquals(expected, q.sizeInBytes());
+        q.push(msg3);    expected += msg3.getSizeInBytes();
+        assertEquals(expected, q.sizeInBytes());
+        q.popNow();      expected -= msg1.getSizeInBytes();
+        assertEquals(expected, q.sizeInBytes());
+        q.accumulate(1000,100, null); expected = 0;
+        assertEquals(expected, q.sizeInBytes());
+    }
+
+    @Test
     public void testFilterTail() throws InterruptedException, UnsupportedEncodingException {
         MessageQueue q = new MessageQueue(true);
         NatsMessage msg1 = new ProtocolMessage(ONE);

--- a/src/test/java/io/nats/client/impl/NatsMessageTests.java
+++ b/src/test/java/io/nats/client/impl/NatsMessageTests.java
@@ -55,6 +55,60 @@ public class NatsMessageTests {
     }
 
     @Test
+    public void testSizeOnPublishMessageWithHeaders() {
+        Headers headers = new Headers().add("Content-Type", "text/plain");
+        byte[] body = new byte[10];
+        String subject = "subj";
+        String replyTo = "reply";
+        String protocol = "HPUB " + subject + " " + replyTo + " " + headers.serializedLength() + " " + (headers.serializedLength() + body.length);
+
+        NatsMessage msg = new NatsMessage(subject, replyTo, headers, body);
+
+        assertEquals(msg.getProtocolBytes().length + headers.serializedLength() + body.length + 4, msg.getSizeInBytes(), "Size is set, with CRLF");
+        assertEquals(protocol.getBytes(StandardCharsets.US_ASCII).length + headers.serializedLength() + body.length + 4, msg.getSizeInBytes(), "Size is correct");
+
+        msg = new NatsMessage(subject, replyTo, headers, body);
+
+        assertEquals(msg.getProtocolBytes().length + headers.serializedLength() + body.length + 4, msg.getSizeInBytes(), "Size is set, with CRLF");
+        assertEquals(protocol.getBytes(StandardCharsets.UTF_8).length + headers.serializedLength() + body.length + 4, msg.getSizeInBytes(), "Size is correct");
+    }
+
+    @Test
+    public void testSizeOnPublishMessageOnlyHeaders() {
+        Headers headers = new Headers().add("Content-Type", "text/plain");
+        String subject = "subj";
+        String replyTo = "reply";
+        String protocol = "HPUB " + subject + " " + replyTo + " " + headers.serializedLength() + " " + headers.serializedLength();
+
+        NatsMessage msg = new NatsMessage(subject, replyTo, headers, null);
+
+        assertEquals(msg.getProtocolBytes().length + headers.serializedLength() + 4, msg.getSizeInBytes(), "Size is set, with CRLF");
+        assertEquals(protocol.getBytes(StandardCharsets.US_ASCII).length + headers.serializedLength() + 4, msg.getSizeInBytes(), "Size is correct");
+
+        msg = new NatsMessage(subject, replyTo, headers, null);
+
+        assertEquals(msg.getProtocolBytes().length + headers.serializedLength() + 4, msg.getSizeInBytes(), "Size is set, with CRLF");
+        assertEquals(protocol.getBytes(StandardCharsets.UTF_8).length + headers.serializedLength() + 4, msg.getSizeInBytes(), "Size is correct");
+    }
+
+    @Test
+    public void testSizeOnPublishMessageOnlySubject() {
+        String subject = "subj";
+        String replyTo = "reply";
+        String protocol = "PUB " + subject + " " + replyTo + " " + 0;
+
+        NatsMessage msg = new NatsMessage(subject, replyTo, null, null);
+
+        assertEquals(msg.getProtocolBytes().length + 4, msg.getSizeInBytes(), "Size is set, with CRLF");
+        assertEquals(protocol.getBytes(StandardCharsets.US_ASCII).length + 4, msg.getSizeInBytes(), "Size is correct");
+
+        msg = new NatsMessage(subject, replyTo, null, null);
+
+        assertEquals(msg.getProtocolBytes().length + 4, msg.getSizeInBytes(), "Size is set, with CRLF");
+        assertEquals(protocol.getBytes(StandardCharsets.UTF_8).length + 4, msg.getSizeInBytes(), "Size is correct");
+    }
+
+    @Test
     public void testCustomMaxControlLine() {
         assertThrows(IllegalArgumentException.class, () -> {
             byte[] body = new byte[10];

--- a/src/test/java/io/nats/client/impl/SlowConsumerTests.java
+++ b/src/test/java/io/nats/client/impl/SlowConsumerTests.java
@@ -63,7 +63,7 @@ public class SlowConsumerTests {
 
             assertEquals(3, sub.getDroppedCount());
             assertEquals(1, sub.getPendingMessageCount());
-            assertEquals(17, sub.getPendingByteCount()); // "msg 1 subject 0" + crlf
+            assertEquals(19, sub.getPendingByteCount()); // "msg 1 subject 0" + crlf + crlf
 
             sub.clearDroppedCount();
             
@@ -94,7 +94,7 @@ public class SlowConsumerTests {
 
             assertEquals(1, sub.getDroppedCount());
             assertEquals(1, sub.getPendingMessageCount());
-            assertEquals(17, sub.getPendingByteCount()); // "msg 1 subject 0" + crlf
+            assertEquals(19, sub.getPendingByteCount()); // "msg 1 subject 0" + crlf + crlf
 
             sub.clearDroppedCount();
             
@@ -135,7 +135,7 @@ public class SlowConsumerTests {
 
             assertEquals(1, d.getDroppedCount());
             assertEquals(1, d.getPendingMessageCount());
-            assertEquals(17, d.getPendingByteCount()); // "msg 1 subject 0" + crlf
+            assertEquals(19, d.getPendingByteCount()); // "msg 1 subject 0" + crlf + crlf
 
             d.clearDroppedCount();
             
@@ -176,7 +176,7 @@ public class SlowConsumerTests {
 
             assertEquals(1, d.getDroppedCount());
             assertEquals(1, d.getPendingMessageCount());
-            assertEquals(17, d.getPendingByteCount()); // "msg 1 subject 0" + crlf + crlf
+            assertEquals(19, d.getPendingByteCount()); // "msg 1 subject 0" + crlf + crlf
 
             d.clearDroppedCount();
             


### PR DESCRIPTION
The calculation of `getSizeInBytes()` was off, when looking at the usage in `NatsConnectionWriter.sendMessageBatch(...)`.

The following would happen:
| Message | Previously | Comment |
|:--|:--|:--|
| only subject | calculation off by -2 | When `accumulate` was called on the `MessageQueue` it would return more messages. `sendMessageBatch(...)` would write more bytes than was indicated by the msg size, so it would more easily trigger re-sizing of the `sendBuffer`. (Which I believe is the root cause of: https://github.com/nats-io/nats.java/issues/644)  |
| subject+headers | correct calculation | |
| subject+data | correct calculation | |
| subject+headers+data | calculation off by +2 | `MessageQueue.accumulate` would return less messages than would fit in the `sendBuffer`. Shouldn't be as much of an issue for the `NatsConnectionWriter` to handle, nonetheless the sizes aren't the same. |

This PR corrects these by ensuring the calculation of the `getSizeInBytes()` matches with the construction of the `sendBuffer` in `NatsConnectionWriter.sendMessageBatch(...)`.

@scottf, mentioning you since you've also reviewed my previous PR (https://github.com/nats-io/nats.java/pull/746) and I believe it's related to https://github.com/nats-io/nats.java/issues/644 as well.