### PR TITLE
increase default max (pending) messages, ability to set pending limits in subscribe options

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ In addition to some generic validation messages for values in builders, there ar
 | JsSubOrderedNotAllowOnQueues                 | SUB   | 90018 | Ordered consumer not allowed on queues.                                                             |
 | JsSubPushCantHaveMaxBatch                    | SUB   | 90019 | Push subscriptions cannot supply max batch.                                                         |
 | JsSubPushCantHaveMaxBytes                    | SUB   | 90020 | Push subscriptions cannot supply max bytes.                                                         |
+| JsSubPushAsyncCantSetPending                 | SUB   | 90021 | Pending limits must be set directly on the dispatcher.                                              |
 | JsConsumerCreate290NotAvailable              | CON   | 90301 | Name field not valid when v2.9.0 consumer create api is not available.                              |
 | JsConsumerNameDurableMismatch                | CON   | 90302 | Name must match durable if both are supplied.                                                       |
 | OsObjectNotFound                             | OS    | 90201 | The object was not found.                                                                           |

--- a/src/main/java/io/nats/client/Consumer.java
+++ b/src/main/java/io/nats/client/Consumer.java
@@ -35,7 +35,7 @@ public interface Consumer {
     /**
      * The default number of messages a consumer will hold before it starts to drop them.
      */
-    public static final long DEFAULT_MAX_MESSAGES = 64 * 1024;
+    public static final long DEFAULT_MAX_MESSAGES = 512 * 1024;
 
     /**
      * The default number of bytes a consumer will hold before it starts to drop messages.

--- a/src/main/java/io/nats/client/PullSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PullSubscribeOptions.java
@@ -20,7 +20,7 @@ package io.nats.client;
 public class PullSubscribeOptions extends SubscribeOptions {
 
     private PullSubscribeOptions(Builder builder) {
-        super(builder, true, false, null, null);
+        super(builder, true, false, null, null, -1, -1);
     }
 
     /**

--- a/src/main/java/io/nats/client/PushSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PushSubscribeOptions.java
@@ -136,11 +136,23 @@ public class PushSubscribeOptions extends SubscribeOptions {
             return this;
         }
 
+        /**
+         * Set the maximum number of messages that non-dispatched push subscriptions can hold
+         * in the internal (pending) message queue. Defaults to 512 * 1024  (Consumer.DEFAULT_MAX_MESSAGES)
+         * @param pendingMessageLimit the number of messages.
+         * @return the builder
+         */
         public Builder pendingMessageLimit(long pendingMessageLimit) {
             this.pendingMessageLimit = pendingMessageLimit;
             return this;
         }
 
+        /**
+         * Set the maximum number of bytes that non-dispatched push subscriptions can hold
+         * in the internal (pending) message queue. Defaults to 64 * 1024 * 1024 (Consumer.DEFAULT_MAX_BYTES)
+         * @param pendingByteLimit the number of bytes.
+         * @return the builder
+         */
         public Builder pendingByteLimit(long pendingByteLimit) {
             this.pendingByteLimit = pendingByteLimit;
             return this;

--- a/src/main/java/io/nats/client/PushSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PushSubscribeOptions.java
@@ -21,8 +21,9 @@ import static io.nats.client.support.Validator.emptyAsNull;
  */
 public class PushSubscribeOptions extends SubscribeOptions {
 
-    private PushSubscribeOptions(Builder builder, boolean ordered, String deliverSubject, String deliverGroup) {
-        super(builder, false, ordered, deliverSubject, deliverGroup);
+    private PushSubscribeOptions(Builder builder, boolean ordered, String deliverSubject, String deliverGroup,
+                                 long pendingMessageLimit, long pendingByteLimit) {
+        super(builder, false, ordered, deliverSubject, deliverGroup, pendingMessageLimit, pendingByteLimit);
     }
 
     /**
@@ -95,6 +96,8 @@ public class PushSubscribeOptions extends SubscribeOptions {
         private boolean ordered;
         private String deliverSubject;
         private String deliverGroup;
+        private long pendingMessageLimit = -1;
+        private long pendingByteLimit = -1;
 
         @Override
         protected Builder getThis() {
@@ -133,13 +136,24 @@ public class PushSubscribeOptions extends SubscribeOptions {
             return this;
         }
 
+        public Builder pendingMessageLimit(long pendingMessageLimit) {
+            this.pendingMessageLimit = pendingMessageLimit;
+            return this;
+        }
+
+        public Builder pendingByteLimit(long pendingByteLimit) {
+            this.pendingByteLimit = pendingByteLimit;
+            return this;
+        }
+
         /**
          * Builds the push subscribe options.
          * @return push subscribe options
          */
         @Override
         public PushSubscribeOptions build() {
-            return new PushSubscribeOptions(this, ordered, deliverSubject, deliverGroup);
+            return new PushSubscribeOptions(this, ordered, deliverSubject, deliverGroup,
+                pendingMessageLimit, pendingByteLimit);
         }
     }
 }

--- a/src/main/java/io/nats/client/SubscribeOptions.java
+++ b/src/main/java/io/nats/client/SubscribeOptions.java
@@ -34,9 +34,13 @@ public abstract class SubscribeOptions {
     protected final boolean ordered;
     protected final long messageAlarmTime;
     protected final ConsumerConfiguration consumerConfig;
+    protected final long pendingMessageLimit; // Only applicable for non dispatched (sync) push consumers.
+    protected final long pendingByteLimit; // Only applicable for non dispatched (sync) push consumers.
 
     @SuppressWarnings("rawtypes") // Don't need the type of the builder to get its vars
-    protected SubscribeOptions(Builder builder, boolean isPull, boolean isOrdered, String deliverSubject, String deliverGroup) {
+    protected SubscribeOptions(Builder builder, boolean isPull, boolean isOrdered,
+                               String deliverSubject, String deliverGroup,
+                               long pendingMessageLimit, long pendingByteLimit) {
 
         pull = isPull;
         bind = builder.bind;
@@ -59,6 +63,9 @@ public abstract class SubscribeOptions {
         deliverGroup = validateMustMatchIfBothSupplied(deliverGroup, builder.cc == null ? null : builder.cc.getDeliverGroup(), JsSoDeliverGroupMismatch);
 
         deliverSubject = validateMustMatchIfBothSupplied(deliverSubject, builder.cc == null ? null : builder.cc.getDeliverSubject(), JsSoDeliverSubjectMismatch);
+
+        this.pendingMessageLimit = pendingMessageLimit;
+        this.pendingByteLimit = pendingByteLimit;
 
         if (isOrdered) {
             validateNotSupplied(deliverGroup, JsSoOrderedNotAllowedWithDeliverGroup);
@@ -159,6 +166,22 @@ public abstract class SubscribeOptions {
      */
     public ConsumerConfiguration getConsumerConfiguration() {
         return consumerConfig;
+    }
+
+    /**
+     * Gets the pending message limit. Only applicable for non dispatched (sync) push consumers.
+     * @return the message limit
+     */
+    public long getPendingMessageLimit() {
+        return pendingMessageLimit;
+    }
+
+    /**
+     * Gets the pending byte limit. Only applicable for non dispatched (sync) push consumers.
+     * @return the byte limit
+     */
+    public long getPendingByteLimit() {
+        return pendingByteLimit;
     }
 
     @Override

--- a/src/main/java/io/nats/client/support/NatsJetStreamClientError.java
+++ b/src/main/java/io/nats/client/support/NatsJetStreamClientError.java
@@ -40,6 +40,7 @@ public class NatsJetStreamClientError {
     public static final NatsJetStreamClientError JsSubOrderedNotAllowOnQueues = new NatsJetStreamClientError(SUB, 90018, "Ordered consumer not allowed on queues.");
     public static final NatsJetStreamClientError JsSubPushCantHaveMaxBatch = new NatsJetStreamClientError(SUB, 90019, "Push subscriptions cannot supply max batch.");
     public static final NatsJetStreamClientError JsSubPushCantHaveMaxBytes = new NatsJetStreamClientError(SUB, 90020, "Push subscriptions cannot supply max bytes.");
+    public static final NatsJetStreamClientError JsSubPushAsyncCantSetPending = new NatsJetStreamClientError(SUB, 90021, "Pending limits must be set directly on the dispatcher.");
 
     public static final NatsJetStreamClientError JsSoDurableMismatch = new NatsJetStreamClientError(SO, 90101, "Builder durable must match the consumer configuration durable if both are provided.");
     public static final NatsJetStreamClientError JsSoDeliverGroupMismatch = new NatsJetStreamClientError(SO, 90102, "Builder deliver group must match the consumer configuration deliver group if both are provided.");

--- a/src/test/java/io/nats/client/impl/JetStreamPushTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamPushTests.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.nats.client.support.NatsJetStreamClientError.JsSubPushAsyncCantSetPending;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class JetStreamPushTests extends JetStreamTestBase {
@@ -713,8 +714,8 @@ public class JetStreamPushTests extends JetStreamTestBase {
 
             js.subscribe(SUBJECT, d, m ->{}, false, psoAsyncLtZero);
 
-            assertThrows(IllegalArgumentException.class, () -> js.subscribe(SUBJECT, d, m ->{}, false, psoAsyncNopeMessages));
-            assertThrows(IllegalArgumentException.class, () -> js.subscribe(SUBJECT, d, m ->{}, false, psoAsyncNopeBytes));
+            assertClientError(JsSubPushAsyncCantSetPending, () -> js.subscribe(SUBJECT, d, m ->{}, false, psoAsyncNopeMessages));
+            assertClientError(JsSubPushAsyncCantSetPending, () -> js.subscribe(SUBJECT, d, m ->{}, false, psoAsyncNopeBytes));
         });
     }
 }

--- a/src/test/java/io/nats/client/impl/SlowConsumerTests.java
+++ b/src/test/java/io/nats/client/impl/SlowConsumerTests.java
@@ -52,7 +52,7 @@ public class SlowConsumerTests {
             sub.setPendingLimits(1, -1);
 
             assertEquals(1, sub.getPendingMessageLimit());
-            assertEquals(-1, sub.getPendingByteLimit());
+            assertEquals(Consumer.DEFAULT_MAX_BYTES, sub.getPendingByteLimit());
             assertEquals(0, sub.getDroppedCount());
 
             nc.publish("subject", null);
@@ -85,7 +85,7 @@ public class SlowConsumerTests {
             sub.setPendingLimits(-1, 10); // will take the first, not the second
 
             assertEquals(10, sub.getPendingByteLimit());
-            assertEquals(-1, sub.getPendingMessageLimit());
+            assertEquals(Consumer.DEFAULT_MAX_MESSAGES, sub.getPendingMessageLimit());
             assertEquals(0, sub.getDroppedCount());
 
             nc.publish("subject", null);
@@ -122,7 +122,7 @@ public class SlowConsumerTests {
             d.subscribe("subject");
 
             assertEquals(1, d.getPendingMessageLimit());
-            assertEquals(-1, d.getPendingByteLimit());
+            assertEquals(Consumer.DEFAULT_MAX_BYTES, d.getPendingByteLimit());
             assertEquals(0, d.getDroppedCount());
 
             nc.publish("subject", null);
@@ -162,7 +162,7 @@ public class SlowConsumerTests {
             d.setPendingLimits(-1, 10);
             d.subscribe("subject");
 
-            assertEquals(-1, d.getPendingMessageLimit());
+            assertEquals(Consumer.DEFAULT_MAX_MESSAGES, d.getPendingMessageLimit());
             assertEquals(10, d.getPendingByteLimit());
             assertEquals(0, d.getDroppedCount());
 


### PR DESCRIPTION
* from 64K to 512K to match GO.
helps reduce client side slow consumer

see https://github.com/nats-io/nats-architecture-and-design/issues/172