### PR TITLE
[Patch] Change Temporary File Creation in unit test.

### DIFF
--- a/src/test/java/io/nats/client/AuthTests.java
+++ b/src/test/java/io/nats/client/AuthTests.java
@@ -22,6 +22,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -362,7 +363,7 @@ public class AuthTests {
     }
 
     String createNKeyConfigFile(char[] nkey) throws Exception {
-        File tmp = File.createTempFile("nats_java_test", ".conf");
+        File tmp = Files.createTempFile("nats_java_test", ".conf").toFile();
         BufferedWriter writer = new BufferedWriter(new FileWriter(tmp));
 
         writer.write("port: 8222"); // will get rewritten


### PR DESCRIPTION
## Overview

This pull request fixes a unit test that uses an insecure creation of a temporary file. It is not a library vulnerability because it is not part of the runtime library, therefore does not make the project vulnerable to local information disclosure.

## Issue

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

> If this code was found in the runtime library it would be considered a vulnerability, but it is located in a unit test; the files that are created contain no security or system information, only information that is already publicly available in this open source repo.

## The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.