### PR TITLE
Always send credentials when provided

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -1889,18 +1889,17 @@ public class Options {
         throw new URISyntaxException(serverURI, "unable to parse server URI");
     }
 
-    /**
-     * Create the options string sent with a connect message.
+   /**
+     * Create the options string sent with a connect message. For internal use; do not use.
      * 
      * If includeAuth is true the auth information is included:
      * If the server URIs have auth info it is used. Otherwise the userInfo is used.
      * 
      * @param serverURI the current server uri
-     * @param includeAuth tells the options to build a connection string that includes auth information
      * @param nonce if the client is supposed to sign the nonce for authentication
      * @return the options String, basically JSON
      */
-    public CharBuffer buildProtocolConnectOptionsString(String serverURI, boolean includeAuth, byte[] nonce) {
+    public CharBuffer buildProtocolConnectOptionsString(String serverURI, byte[] nonce) {
         CharBuffer connectString = CharBuffer.allocate(this.maxControlLine);
         connectString.append("{");
 
@@ -1920,7 +1919,7 @@ public class Options {
         appendOption(connectString, Options.OPTION_HEADERS, String.valueOf(!this.isNoHeaders()), false, true);
         appendOption(connectString, Options.OPTION_NORESPONDERS, String.valueOf(!this.isNoNoResponders()), false, true);
 
-        if (includeAuth && nonce != null && this.getAuthHandler() != null) {
+        if (nonce != null && this.getAuthHandler() != null) {
             char[] nkey = this.getAuthHandler().getID();
             byte[] sig = this.getAuthHandler().sign(nonce);
             char[] jwt = this.getAuthHandler().getJWT();
@@ -1942,7 +1941,7 @@ public class Options {
             appendOption(connectString, Options.OPTION_NKEY, nkey, true, true);
             appendOption(connectString, Options.OPTION_SIG, encodedSig, true, true);
             appendOption(connectString, Options.OPTION_JWT, jwt, true, true);
-        } else if (includeAuth) {
+        } else {
             String uriUser = null;
             String uriPass = null;
             String uriToken = null;
@@ -1988,6 +1987,21 @@ public class Options {
         connectString.append("}");
         connectString.flip();
         return connectString;
+    }
+     
+    /**
+     * Create the options string sent with a connect message.  For internal use; do not use.
+     * 
+     * If includeAuth is true the auth information is included:
+     * If the server URIs have auth info it is used. Otherwise the userInfo is used.
+     * 
+     * @param serverURI the current server uri
+     * @param includeAuth no longer used
+     * @param nonce if the client is supposed to sign the nonce for authentication
+     * @return the options String, basically JSON
+     */
+    public CharBuffer buildProtocolConnectOptionsString(String serverURI, boolean includeAuth, byte[] nonce) {
+        return buildProtocolConnectOptionsString(serverURI, nonce);
     }
 
     private void appendOption(CharBuffer builder, String key, String value, boolean quotes, boolean comma) {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1207,7 +1207,7 @@ class NatsConnection implements Connection {
     void sendConnect(String serverURI) throws IOException {
         try {
             ServerInfo info = this.serverInfo.get();
-            CharBuffer connectOptions = this.options.buildProtocolConnectOptionsString(serverURI, info.isAuthRequired(), info.getNonce());
+            CharBuffer connectOptions = this.options.buildProtocolConnectOptionsString(serverURI, info.getNonce());
             ByteArrayBuilder bab =
                 new ByteArrayBuilder(OP_CONNECT_SP_LEN + connectOptions.limit(), UTF_8)
                     .append(CONNECT_SP_BYTES).append(connectOptions);

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -391,7 +391,7 @@ public class OptionsTests {
         Options o = new Options.Builder().build();
         String expected = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
                 + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,\"headers\":true,\"no_responders\":true}";
-        assertEquals(expected, o.buildProtocolConnectOptionsString("nats://localhost:4222", false, null).toString(), "default connect options");
+        assertEquals(expected, o.buildProtocolConnectOptionsString("nats://localhost:4222", null).toString(), "default connect options");
     }
 
     @Test
@@ -399,7 +399,7 @@ public class OptionsTests {
         Options o = new Options.Builder().noNoResponders().noHeaders().noEcho().pedantic().verbose().build();
         String expected = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
                 + ",\"protocol\":1,\"verbose\":true,\"pedantic\":true,\"tls_required\":false,\"echo\":false,\"headers\":false,\"no_responders\":false}";
-        assertEquals(expected, o.buildProtocolConnectOptionsString("nats://localhost:4222", false, null).toString(), "non default connect options");
+        assertEquals(expected, o.buildProtocolConnectOptionsString("nats://localhost:4222", null).toString(), "non default connect options");
     }
 
     @Test
@@ -408,19 +408,16 @@ public class OptionsTests {
         Options o = new Options.Builder().sslContext(ctx).connectionName("c1").build();
         String expected = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\",\"name\":\"c1\""
                 + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":true,\"echo\":true,\"headers\":true,\"no_responders\":true}";
-        assertEquals(expected, o.buildProtocolConnectOptionsString("nats://localhost:4222", false, null).toString(), "default connect options");
+        assertEquals(expected, o.buildProtocolConnectOptionsString("nats://localhost:4222", null).toString(), "default connect options");
     }
 
     @Test
     public void testAuthConnectOptions() {
         Options o = new Options.Builder().userInfo("hello".toCharArray(), "world".toCharArray()).build();
-        String expectedNoAuth = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
-                + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,\"headers\":true,\"no_responders\":true}";
         String expectedWithAuth = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
                 + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,\"headers\":true,\"no_responders\":true"
                 + ",\"user\":\"hello\",\"pass\":\"world\"}";
-        assertEquals(expectedNoAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", false, null).toString(), "no auth connect options");
-        assertEquals(expectedWithAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", true, null).toString(), "auth connect options");
+           assertEquals(expectedWithAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", null).toString(), "auth connect options");
     }
     /*
     expected: <{"lang":"java","version":"2.8.0","protocol":1,"verbose":false,"pedantic":false,"tls_required":false,"echo":true}>
@@ -434,13 +431,10 @@ public class OptionsTests {
         String sig = Base64.getUrlEncoder().withoutPadding().encodeToString(th.sign(nonce));
 
         Options o = new Options.Builder().authHandler(th).build();
-        String expectedNoAuth = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
-                + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,\"headers\":true,\"no_responders\":true}";
         String expectedWithAuth = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
                 + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,\"headers\":true"
                 + ",\"no_responders\":true,\"nkey\":\""+new String(th.getID())+"\",\"sig\":\""+sig+"\",\"jwt\":\"\"}";
-        assertEquals(expectedNoAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", false, nonce).toString(), "no auth connect options");
-        assertEquals(expectedWithAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", true, nonce).toString(), "auth connect options");
+        assertEquals(expectedWithAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", nonce).toString(), "auth connect options");
     }
 
     @Test
@@ -481,7 +475,7 @@ public class OptionsTests {
         String serverURI = "nats://derek:password@localhost:2222";
         Options o = new Options.Builder().server(serverURI).build();
 
-        String connectString = o.buildProtocolConnectOptionsString(serverURI, true, null).toString();
+        String connectString = o.buildProtocolConnectOptionsString(serverURI, null).toString();
         assertTrue(connectString.contains("\"user\":\"derek\""));
         assertTrue(connectString.contains("\"pass\":\"password\""));
         assertFalse(connectString.contains("\"token\":"));
@@ -492,7 +486,7 @@ public class OptionsTests {
         String serverURI = "nats://alberto@localhost:2222";
         Options o = new Options.Builder().server(serverURI).build();
 
-        String connectString = o.buildProtocolConnectOptionsString(serverURI, true, null).toString();
+        String connectString = o.buildProtocolConnectOptionsString(serverURI, null).toString();
         assertTrue(connectString.contains("\"auth_token\":\"alberto\""));
         assertFalse(connectString.contains("\"user\":"));
         assertFalse(connectString.contains("\"pass\":"));


### PR DESCRIPTION
Do not use the server's auth-required flag to trim the connect protocol.  Always send credentials when specified in options.

I added a new function to avoid a major version bump as the method to build the connect protocol was public.

See: https://github.com/nats-io/nats-server/pull/3667
Resolves: https://github.com/nats-io/nats.java/issues/805

Signed-off-by: Colin Sullivan <colin@synadia.com>