### PR TITLE
Enable add/remove of multiple ConnectionListeners per Connection

### DIFF
--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -405,6 +405,24 @@ public interface Connection extends AutoCloseable {
     void closeDispatcher(Dispatcher dispatcher);
 
     /**
+     * Attach another ConnectionListener. 
+     * 
+     * <p>The ConnectionListener will only receive Connection events arriving after it has been attached.  When
+     * a Connection event is raised, the invocation order and parallelism of multiple ConnectionListeners is not 
+     * specified.
+     * 
+     * @param connectionListener the ConnectionListener to attach
+     */
+    void addConnectionListener(ConnectionListener connectionListener);
+
+    /**
+     * Detach a ConnectionListioner. This will cease delivery of any further Connection events to this instance.
+     * 
+     * @param connectionListener the ConnectionListener to detach
+     */
+    void removeConnectionListener(ConnectionListener connectionListener);
+
+    /**
      * Flush the connection's buffer of outgoing messages, including sending a
      * protocol message to and from the server. Passing null is equivalent to
      * passing 0, which will wait forever.


### PR DESCRIPTION
This patch addresses #860.

Late and multiple bindings of ConnectionListeners to Connections enable business logic to listen for events without needing to construct their own Connection object.

This benefits applications which separate their NATS Connection factory from their business logic, but whose business logic's resource's lifecycle are coupled to the state of NATS Connection's.  Eg: They wish to clean up on connection CLOSED events without polling or passing around a separate observable mechanism.