### PR TITLE
Time used fetching should never be negative

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsJetStreamPullSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamPullSubscription.java
@@ -149,7 +149,7 @@ public class NatsJetStreamPullSubscription extends NatsJetStreamSubscription {
                     batchLeft--;
                 }
                 // try again while we have time
-                timeLeft = maxWaitMillis - (System.currentTimeMillis() - start);
+                timeLeft = maxWaitMillis - Math.max(0, System.currentTimeMillis() - start);
             }
         }
         catch (InterruptedException e) {


### PR DESCRIPTION
If device system time changes into the past while fetching from nats, we should not allow the difference in time to be negative. This would cause the call to nextMessageInternal to hang for a long time.