### PR TITLE
New connection option reportNoResponders

### DIFF
--- a/src/examples/java/io/nats/examples/DontCancelOnNoResponders.java
+++ b/src/examples/java/io/nats/examples/DontCancelOnNoResponders.java
@@ -41,7 +41,7 @@ public class DontCancelOnNoResponders {
 
         // new option
         options = new Options.Builder().server(Options.DEFAULT_URL)
-            .dontCancelNoResponders()
+            .reportNoResponders()
             .build();
 
         try (Connection nc = Nats.connect(options)) {

--- a/src/examples/java/io/nats/examples/DontCancelOnNoResponders.java
+++ b/src/examples/java/io/nats/examples/DontCancelOnNoResponders.java
@@ -1,0 +1,60 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.examples;
+
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+public class DontCancelOnNoResponders {
+    public static void main(String[] args) throws IOException {
+
+        // without new option
+        Options options = new Options.Builder().server(Options.DEFAULT_URL).build();
+        try (Connection nc = Nats.connect(options)) {
+            CompletableFuture<Message> future = nc.request("no-one-is-listening", null);
+            try {
+                future.get();
+            }
+            catch (Exception e) {
+                System.out.println(e);
+            }
+        }
+        catch (Exception e) {
+            System.out.println(e);
+        }
+
+        // new option
+        options = new Options.Builder().server(Options.DEFAULT_URL)
+            .dontCancelNoResponders()
+            .build();
+
+        try (Connection nc = Nats.connect(options)) {
+            CompletableFuture<Message> future = nc.request("no-one-is-listening", null);
+            try {
+                future.get();
+            }
+            catch (Exception e) {
+                System.out.println(e);
+            }
+        }
+        catch (Exception e) {
+            System.out.println(e);
+        }
+    }
+}

--- a/src/examples/java/io/nats/examples/ReportNoResponders.java
+++ b/src/examples/java/io/nats/examples/ReportNoResponders.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The NATS Authors
+// Copyright 2023 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -21,7 +21,7 @@ import io.nats.client.Options;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
-public class DontCancelOnNoResponders {
+public class ReportNoResponders {
     public static void main(String[] args) throws IOException {
 
         // without new option

--- a/src/main/java/io/nats/client/JetStreamStatusException.java
+++ b/src/main/java/io/nats/client/JetStreamStatusException.java
@@ -52,7 +52,7 @@ public class JetStreamStatusException extends IllegalStateException {
      * @param status the status
      */
     public JetStreamStatusException(Status status) {
-        super(status.getStatus());
+        super(status.getMessageWithCode());
         this.sub = null;
         this.description = status.toString();
         this.status = status;

--- a/src/main/java/io/nats/client/JetStreamStatusException.java
+++ b/src/main/java/io/nats/client/JetStreamStatusException.java
@@ -48,6 +48,17 @@ public class JetStreamStatusException extends IllegalStateException {
     }
 
     /**
+     * Construct an exception with a status message
+     * @param status the status
+     */
+    public JetStreamStatusException(Status status) {
+        super(status.getStatus());
+        this.sub = null;
+        this.description = status.toString();
+        this.status = status;
+    }
+
+    /**
      * Get the subscription this issue occurred on
      *
      * @return the subscription

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -329,9 +329,9 @@ public class Options {
      */
     public static final String PROP_NO_RESOLVE_HOSTNAMES = PFX + "noResolveHostnames";
     /**
-     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#dontCancelNoResponders() dontCancelNoResponders}.
+     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#reportNoResponders() reportNoResponders}.
      */
-    public static final String PROP_DONT_CANCEL_NO_RESPONDERS = PFX + "dontCancelNoResponders";
+    public static final String PROP_REPORT_NO_RESPONDERS = PFX + "reportNoResponders";
     /**
      * Property used to configure a builder from a Properties object. {@value},
      * see {@link Builder#servers(String[]) servers}. The value can be a comma-separated list of server URLs.
@@ -511,7 +511,7 @@ public class Options {
     private final List<String> unprocessedServers;
     private final boolean noRandomize;
     private final boolean noResolveHostnames;
-    private final boolean dontCancelNoResponders;
+    private final boolean reportNoResponders;
     private final String connectionName;
     private final boolean verbose;
     private final boolean pedantic;
@@ -605,7 +605,7 @@ public class Options {
         private final List<String> unprocessedServers = new ArrayList<>();
         private boolean noRandomize = false;
         private boolean noResolveHostnames = false;
-        private boolean dontCancelNoResponders = false;
+        private boolean reportNoResponders = false;
         private String connectionName = null; // Useful for debugging -> "test: " + NatsTestServer.currentPort();
         private boolean verbose = false;
         private boolean pedantic = false;
@@ -711,8 +711,8 @@ public class Options {
                 noResolveHostnames = Boolean.parseBoolean(props.getProperty(PROP_NO_RESOLVE_HOSTNAMES));
             }
 
-            if (props.containsKey(PROP_DONT_CANCEL_NO_RESPONDERS)) {
-                dontCancelNoResponders = Boolean.parseBoolean(props.getProperty(PROP_DONT_CANCEL_NO_RESPONDERS));
+            if (props.containsKey(PROP_REPORT_NO_RESPONDERS)) {
+                reportNoResponders = Boolean.parseBoolean(props.getProperty(PROP_REPORT_NO_RESPONDERS));
             }
 
             if (props.containsKey(PROP_SECURE)) {
@@ -949,8 +949,8 @@ public class Options {
             return this;
         }
 
-        public Builder dontCancelNoResponders() {
-            this.dontCancelNoResponders = true;
+        public Builder reportNoResponders() {
+            this.reportNoResponders = true;
             return this;
         }
 
@@ -1559,7 +1559,7 @@ public class Options {
             this.unprocessedServers.addAll(o.unprocessedServers);
             this.noRandomize = o.noRandomize;
             this.noResolveHostnames = o.noResolveHostnames;
-            this.dontCancelNoResponders = o.dontCancelNoResponders;
+            this.reportNoResponders = o.reportNoResponders;
             this.connectionName = o.connectionName;
             this.verbose = o.verbose;
             this.pedantic = o.pedantic;
@@ -1619,7 +1619,7 @@ public class Options {
         this.unprocessedServers = b.unprocessedServers;  // exactly how the user gave them
         this.noRandomize = b.noRandomize;
         this.noResolveHostnames = b.noResolveHostnames;
-        this.dontCancelNoResponders = b.dontCancelNoResponders;
+        this.reportNoResponders = b.reportNoResponders;
         this.connectionName = b.connectionName;
         this.verbose = b.verbose;
         this.pedantic = b.pedantic;
@@ -1773,10 +1773,10 @@ public class Options {
     }
 
     /**
-     * @return should complete with exception futures for requests that get no responders instead of cancelling the future, see {@link Builder#dontCancelNoResponders() dontCancelNoResponders()} in the builder doc
+     * @return should complete with exception futures for requests that get no responders instead of cancelling the future, see {@link Builder#reportNoResponders() reportNoResponders()} in the builder doc
      */
-    public boolean isDontCancelNoResponders() {
-        return dontCancelNoResponders;
+    public boolean isReportNoResponders() {
+        return reportNoResponders;
     }
 
     /**

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -329,6 +329,10 @@ public class Options {
      */
     public static final String PROP_NO_RESOLVE_HOSTNAMES = PFX + "noResolveHostnames";
     /**
+     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#dontCancelNoResponders() dontCancelNoResponders}.
+     */
+    public static final String PROP_DONT_CANCEL_NO_RESPONDERS = PFX + "dontCancelNoResponders";
+    /**
      * Property used to configure a builder from a Properties object. {@value},
      * see {@link Builder#servers(String[]) servers}. The value can be a comma-separated list of server URLs.
      */
@@ -489,7 +493,7 @@ public class Options {
     static final String OPTION_NORESPONDERS = "no_responders";
 
     /**
-     * Property used to set the whether to ignore discovered servers when connecting
+     * Property used to set whether to ignore discovered servers when connecting
      */
     public static final String PROP_IGNORE_DISCOVERED_SERVERS = "ignore_discovered_servers";
 
@@ -507,6 +511,7 @@ public class Options {
     private final List<String> unprocessedServers;
     private final boolean noRandomize;
     private final boolean noResolveHostnames;
+    private final boolean dontCancelNoResponders;
     private final String connectionName;
     private final boolean verbose;
     private final boolean pedantic;
@@ -600,6 +605,7 @@ public class Options {
         private final List<String> unprocessedServers = new ArrayList<>();
         private boolean noRandomize = false;
         private boolean noResolveHostnames = false;
+        private boolean dontCancelNoResponders = false;
         private String connectionName = null; // Useful for debugging -> "test: " + NatsTestServer.currentPort();
         private boolean verbose = false;
         private boolean pedantic = false;
@@ -703,6 +709,10 @@ public class Options {
 
             if (props.containsKey(PROP_NO_RESOLVE_HOSTNAMES)) {
                 noResolveHostnames = Boolean.parseBoolean(props.getProperty(PROP_NO_RESOLVE_HOSTNAMES));
+            }
+
+            if (props.containsKey(PROP_DONT_CANCEL_NO_RESPONDERS)) {
+                dontCancelNoResponders = Boolean.parseBoolean(props.getProperty(PROP_DONT_CANCEL_NO_RESPONDERS));
             }
 
             if (props.containsKey(PROP_SECURE)) {
@@ -936,6 +946,11 @@ public class Options {
          */
         public Builder noResolveHostnames() {
             this.noResolveHostnames = true;
+            return this;
+        }
+
+        public Builder dontCancelNoResponders() {
+            this.dontCancelNoResponders = true;
             return this;
         }
 
@@ -1544,6 +1559,7 @@ public class Options {
             this.unprocessedServers.addAll(o.unprocessedServers);
             this.noRandomize = o.noRandomize;
             this.noResolveHostnames = o.noResolveHostnames;
+            this.dontCancelNoResponders = o.dontCancelNoResponders;
             this.connectionName = o.connectionName;
             this.verbose = o.verbose;
             this.pedantic = o.pedantic;
@@ -1603,6 +1619,7 @@ public class Options {
         this.unprocessedServers = b.unprocessedServers;  // exactly how the user gave them
         this.noRandomize = b.noRandomize;
         this.noResolveHostnames = b.noResolveHostnames;
+        this.dontCancelNoResponders = b.dontCancelNoResponders;
         this.connectionName = b.connectionName;
         this.verbose = b.verbose;
         this.pedantic = b.pedantic;
@@ -1753,6 +1770,13 @@ public class Options {
      */
     public boolean isNoResolveHostnames() {
         return noResolveHostnames;
+    }
+
+    /**
+     * @return should complete with exception futures for requests that get no responders instead of cancelling the future, see {@link Builder#dontCancelNoResponders() dontCancelNoResponders()} in the builder doc
+     */
+    public boolean isDontCancelNoResponders() {
+        return dontCancelNoResponders;
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static io.nats.client.support.NatsJetStreamClientError.JsConsumerCreate290NotAvailable;
+import static io.nats.client.support.NatsRequestCompletableFuture.CancelAction;
 
 class NatsJetStreamImpl implements NatsJetStreamConstants {
 
@@ -175,9 +176,9 @@ class NatsJetStreamImpl implements NatsJetStreamConstants {
         }
     }
 
-    Message makeInternalRequestResponseRequired(String subject, Headers headers, byte[] data, Duration timeout, boolean cancelOn503) throws IOException {
+    Message makeInternalRequestResponseRequired(String subject, Headers headers, byte[] data, Duration timeout, CancelAction cancelAction) throws IOException {
         try {
-            return responseRequired(conn.requestInternal(subject, headers, data, timeout, cancelOn503));
+            return responseRequired(conn.requestInternal(subject, headers, data, timeout, cancelAction));
         } catch (InterruptedException e) {
             throw new IOException(e);
         }

--- a/src/main/java/io/nats/client/support/NatsRequestCompletableFuture.java
+++ b/src/main/java/io/nats/client/support/NatsRequestCompletableFuture.java
@@ -7,16 +7,20 @@ import java.time.Duration;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * This is an internal class and is only public for access.
+ */
 public class NatsRequestCompletableFuture extends CompletableFuture<Message> {
+    public enum CancelAction { CANCEL, REPORT, COMPLETE }
     private static final long DEFAULT_TIMEOUT = Options.DEFAULT_REQUEST_CLEANUP_INTERVAL.toMillis(); // currently 5 seconds
 
-    private final boolean cancelOn503;
+    private final CancelAction cancelAction;
     private final long timeOutAfter;
     private boolean wasCancelledClosing;
     private boolean wasCancelledTimedOut;
 
-    public NatsRequestCompletableFuture(boolean cancelOn503, Duration timeout) {
-        this.cancelOn503 = cancelOn503;
+    public NatsRequestCompletableFuture(CancelAction cancelAction, Duration timeout) {
+        this.cancelAction = cancelAction;
         timeOutAfter = System.currentTimeMillis() + 10 + (timeout == null ? DEFAULT_TIMEOUT : timeout.toMillis());
         // 10 extra millis allows for communication time, probably more than needed but...
     }
@@ -31,8 +35,8 @@ public class NatsRequestCompletableFuture extends CompletableFuture<Message> {
         completeExceptionally(new CancellationException("Future cancelled, response not registered in time, likely due to server disconnect."));
     }
 
-    public boolean isCancelOn503() {
-        return cancelOn503;
+    public CancelAction getCancelAction() {
+        return cancelAction;
     }
 
     public boolean hasExceededTimeout() {

--- a/src/main/java/io/nats/client/support/Status.java
+++ b/src/main/java/io/nats/client/support/Status.java
@@ -68,8 +68,8 @@ public class Status {
         return message;
     }
 
-    public String getStatus() {
-        return "(" + code + ") " + message;
+    public String getMessageWithCode() {
+        return code + " " + message;
     }
 
     private static String extractMessage(Token messageToken) {

--- a/src/main/java/io/nats/client/support/Status.java
+++ b/src/main/java/io/nats/client/support/Status.java
@@ -68,6 +68,10 @@ public class Status {
         return message;
     }
 
+    public String getStatus() {
+        return "(" + code + ") " + message;
+    }
+
     private static String extractMessage(Token messageToken) {
         return messageToken.hasValue() ? messageToken.getValue() : null;
     }

--- a/src/test/java/io/nats/client/impl/RequestTests.java
+++ b/src/test/java/io/nats/client/impl/RequestTests.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.nats.client.support.NatsRequestCompletableFuture.CancelAction;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RequestTests extends TestBase {
@@ -693,7 +694,8 @@ public class RequestTests extends TestBase {
 
     @Test
     public void testNatsRequestCompletableFuture() throws InterruptedException {
-        NatsRequestCompletableFuture f = new NatsRequestCompletableFuture(true, Duration.ofHours(-1));
+        // todo test all cancel actions
+        NatsRequestCompletableFuture f = new NatsRequestCompletableFuture(CancelAction.CANCEL, Duration.ofHours(-1));
         assertTrue(f.hasExceededTimeout());
         assertFalse(f.wasCancelledClosing());
         assertFalse(f.wasCancelledTimedOut());
@@ -703,7 +705,7 @@ public class RequestTests extends TestBase {
         assertTrue(f.wasCancelledTimedOut());
 
         // coverage for null timeout
-        f = new NatsRequestCompletableFuture(true, null);
+        f = new NatsRequestCompletableFuture(CancelAction.CANCEL, null);
         Thread.sleep(Options.DEFAULT_REQUEST_CLEANUP_INTERVAL.toMillis() + 100);
         assertTrue(f.hasExceededTimeout());
     }

--- a/src/test/java/io/nats/client/impl/RequestTests.java
+++ b/src/test/java/io/nats/client/impl/RequestTests.java
@@ -694,8 +694,8 @@ public class RequestTests extends TestBase {
 
     @Test
     public void testNatsRequestCompletableFuture() throws InterruptedException {
-        // todo test all cancel actions
         NatsRequestCompletableFuture f = new NatsRequestCompletableFuture(CancelAction.CANCEL, Duration.ofHours(-1));
+        assertEquals(CancelAction.CANCEL, f.getCancelAction());
         assertTrue(f.hasExceededTimeout());
         assertFalse(f.wasCancelledClosing());
         assertFalse(f.wasCancelledTimedOut());
@@ -703,6 +703,12 @@ public class RequestTests extends TestBase {
         f.cancelTimedOut(); // not real use, just testing flags
         assertTrue(f.wasCancelledClosing());
         assertTrue(f.wasCancelledTimedOut());
+
+        f = new NatsRequestCompletableFuture(CancelAction.COMPLETE, Duration.ofHours(-1));
+        assertEquals(CancelAction.COMPLETE, f.getCancelAction());
+
+        f = new NatsRequestCompletableFuture(CancelAction.REPORT, Duration.ofHours(-1));
+        assertEquals(CancelAction.REPORT, f.getCancelAction());
 
         // coverage for null timeout
         f = new NatsRequestCompletableFuture(CancelAction.CANCEL, null);

--- a/src/test/java/io/nats/client/utils/TestBase.java
+++ b/src/test/java/io/nats/client/utils/TestBase.java
@@ -428,11 +428,19 @@ public class TestBase {
             .build();
     }
 
+    public static Options.Builder standardOptionsBuilder() {
+        return Options.builder().errorListener(new TestHandler());
+    }
+
     public static Options standardOptions(String serverURL) {
         return Options.builder()
             .server(serverURL)
             .errorListener(new TestHandler())
             .build();
+    }
+
+    public static Options.Builder standardOptionsBuilder(String serverURL) {
+        return Options.builder().server(serverURL).errorListener(new TestHandler());
     }
 
     public static Connection standardConnection() throws IOException, InterruptedException {


### PR DESCRIPTION
Adding a `reportNoResponders` connection option flag. Will make core no responders exception differently when core-publishing to a subject.

This should really be the default behavior, but it would be a breaking change.

```
java.util.concurrent.CancellationException
```
to this
```
java.util.concurrent.ExecutionException: io.nats.client.JetStreamStatusException: 503 No Responders Available For Request
```