### PR TITLE
Bump GH Actions versions (Go; node12 deprecation)

### DIFF
--- a/.github/workflows/branch-snapshot.yml
+++ b/.github/workflows/branch-snapshot.yml
@@ -18,14 +18,14 @@ jobs:
       GODEBUG: x509sha1=1
     steps:
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -39,7 +39,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
       - name: Verify Javadoc

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -19,14 +19,14 @@ jobs:
       GODEBUG: x509sha1=1
     steps:
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -40,7 +40,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
       - name: Verify Javadoc

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -18,14 +18,14 @@ jobs:
       GODEBUG: x509sha1=1
     steps:
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -39,7 +39,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
       - name: Verify Javadoc

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,14 +19,14 @@ jobs:
       GODEBUG: x509sha1=1
     steps:
       - name: Setup JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '8'
           distribution: 'adopt'
       - name: Setup GO
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.19.1
+          go-version: '1.19.9'
       - name: Install Nats Server
         run: |
           cd $GITHUB_WORKSPACE
@@ -40,7 +40,7 @@ jobs:
           rm -rf nats-server
           nats-server -v
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and Test
         run: chmod +x gradlew && ./gradlew clean test
       - name: Verify, Sign and Publish Release


### PR DESCRIPTION
Bump various GitHub Actions versions to move away from those using the deprecated node.js 12 runtime, and so remove the warnings.

Bump Golang to the latest security fixed patch-level within the same minor, and quote the string for defensiveness against version number parsing and YAML string vs version numbers.  While we're unlikely to switch to patch-level-unspecified in future, protect against mistakes by quoting, as we're doing for all repos.
