### PR TITLE
JwtUtils: support subs, data, payload & default to no limit / -1

### DIFF
--- a/src/main/java/io/nats/client/support/JsonUtils.java
+++ b/src/main/java/io/nats/client/support/JsonUtils.java
@@ -225,8 +225,8 @@ public abstract class JsonUtils {
      * @param fname fieldname
      * @param value field value
      */
-    public static void addFieldAllowNegativeOne(StringBuilder sb, String fname, Long value) {
-        if (value != null && value >= -1) {
+    public static void addFieldWhenGtZero(StringBuilder sb, String fname, Long value) {
+        if (value != null && value > 0) {
             sb.append(Q);
             jsonEncode(sb, fname);
             sb.append(QCOLON).append(value).append(COMMA);
@@ -239,8 +239,8 @@ public abstract class JsonUtils {
      * @param fname fieldname
      * @param value field value
      */
-    public static void addFieldWhenGtZero(StringBuilder sb, String fname, Long value) {
-        if (value != null && value > 0) {
+    public static void addFieldWhenGteMinusOne(StringBuilder sb, String fname, Long value) {
+        if (value != null && value >= -1) {
             sb.append(Q);
             jsonEncode(sb, fname);
             sb.append(QCOLON).append(value).append(COMMA);

--- a/src/main/java/io/nats/client/support/JsonUtils.java
+++ b/src/main/java/io/nats/client/support/JsonUtils.java
@@ -225,6 +225,20 @@ public abstract class JsonUtils {
      * @param fname fieldname
      * @param value field value
      */
+    public static void addFieldAllowNegativeOne(StringBuilder sb, String fname, Long value) {
+        if (value != null && value >= -1) {
+            sb.append(Q);
+            jsonEncode(sb, fname);
+            sb.append(QCOLON).append(value).append(COMMA);
+        }
+    }
+
+    /**
+     * Appends a json field to a string builder.
+     * @param sb string builder
+     * @param fname fieldname
+     * @param value field value
+     */
     public static void addFieldWhenGtZero(StringBuilder sb, String fname, Long value) {
         if (value != null && value > 0) {
             sb.append(Q);

--- a/src/main/java/io/nats/client/support/JwtUtils.java
+++ b/src/main/java/io/nats/client/support/JwtUtils.java
@@ -36,6 +36,8 @@ public abstract class JwtUtils {
     private static final String ENCODED_CLAIM_HEADER =
             toBase64Url("{\"typ\":\"JWT\", \"alg\":\"ed25519-nkey\"}");
 
+    private static final long NO_LIMIT = -1;
+
     /**
      * Format string with `%s` placeholder for the JWT token followed
      * by the user NKey seed. This can be directly used as such:
@@ -216,6 +218,9 @@ public abstract class JwtUtils {
     public static class UserClaim extends NatsClaim<UserClaim> {
         public Permission pub;
         public Permission sub;
+        public long subs = NO_LIMIT;
+        public long data = NO_LIMIT;
+        public long payload = NO_LIMIT;
 
         public UserClaim(String issuerAccount) {
             super("user", issuerAccount);
@@ -231,6 +236,21 @@ public abstract class JwtUtils {
             return this;
         }
 
+        public UserClaim subs(long subs) {
+            this.subs = subs;
+            return this;
+        }
+
+        public UserClaim data(long data) {
+            this.data = data;
+            return this;
+        }
+
+        public UserClaim payload(long payload) {
+            this.payload = payload;
+            return this;
+        }
+
         @Override
         protected UserClaim getThis() {
             return this;
@@ -240,6 +260,9 @@ public abstract class JwtUtils {
         protected void subAppendJson(StringBuilder sb) {
             JsonUtils.addField(sb, "pub", pub);
             JsonUtils.addField(sb, "sub", sub);
+            JsonUtils.addFieldAllowNegativeOne(sb, "subs", subs);
+            JsonUtils.addFieldAllowNegativeOne(sb, "data", data);
+            JsonUtils.addFieldAllowNegativeOne(sb, "payload", payload);
         }
     }
 

--- a/src/main/java/io/nats/client/support/JwtUtils.java
+++ b/src/main/java/io/nats/client/support/JwtUtils.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.List;
 
 import static io.nats.client.support.Encoding.base32Encode;
 import static io.nats.client.support.Encoding.toBase64Url;
@@ -215,15 +216,51 @@ public abstract class JwtUtils {
         return ENCODED_CLAIM_HEADER + "." + encBody + "." + encSig;
     }
 
-    public static class UserClaim extends NatsClaim<UserClaim> {
-        public Permission pub;
-        public Permission sub;
-        public long subs = NO_LIMIT;
-        public long data = NO_LIMIT;
-        public long payload = NO_LIMIT;
+    public static class UserClaim implements JsonSerializable {
+        public String issuerAccount;            // User
+        public String[] tags;                   // User/GenericFields
+        public String type = "user";            // User/GenericFields
+        public int version = 2;                 // User/GenericFields
+        public Permission pub;                  // User/UserPermissionLimits/Permissions
+        public Permission sub;                  // User/UserPermissionLimits/Permissions
+        public ResponsePermission resp;         // User/UserPermissionLimits/Permissions
+        public String[] src;                    // User/UserPermissionLimits/Limits/UserLimits
+        public List<TimeRange> times;           // User/UserPermissionLimits/Limits/UserLimits
+        public String locale;                   // User/UserPermissionLimits/Limits/UserLimits
+        public long subs = NO_LIMIT;            // User/UserPermissionLimits/Limits/NatsLimits
+        public long data = NO_LIMIT;            // User/UserPermissionLimits/Limits/NatsLimits
+        public long payload = NO_LIMIT;         // User/UserPermissionLimits/Limits/NatsLimits
+        public boolean bearerToken;             // User/UserPermissionLimits
+        public String[] allowedConnectionTypes; // User/UserPermissionLimits
 
         public UserClaim(String issuerAccount) {
-            super("user", issuerAccount);
+            this.issuerAccount = issuerAccount;
+        }
+
+        @Override
+        public String toJson() {
+            StringBuilder sb = beginJson();
+            JsonUtils.addField(sb, "issuer_account", issuerAccount);
+            JsonUtils.addStrings(sb, "tags", tags);
+            JsonUtils.addField(sb, "type", type);
+            JsonUtils.addField(sb, "version", version);
+            JsonUtils.addField(sb, "pub", pub);
+            JsonUtils.addField(sb, "sub", sub);
+            JsonUtils.addField(sb, "resp", resp);
+            JsonUtils.addStrings(sb, "src", src);
+            JsonUtils.addJsons(sb, "times", times);
+            JsonUtils.addField(sb, "times_location", locale);
+            JsonUtils.addFieldWhenGteMinusOne(sb, "subs", subs);
+            JsonUtils.addFieldWhenGteMinusOne(sb, "data", data);
+            JsonUtils.addFieldWhenGteMinusOne(sb, "payload", payload);
+            JsonUtils.addFldWhenTrue(sb, "bearer_token", bearerToken);
+            JsonUtils.addStrings(sb, "allowed_connection_types", allowedConnectionTypes);
+            return endJson(sb).toString();
+        }
+
+        public UserClaim tags(String... tags) {
+            this.tags = tags;
+            return this;
         }
 
         public UserClaim pub(Permission pub) {
@@ -233,6 +270,26 @@ public abstract class JwtUtils {
 
         public UserClaim sub(Permission sub) {
             this.sub = sub;
+            return this;
+        }
+
+        public UserClaim resp(ResponsePermission resp) {
+            this.resp = resp;
+            return this;
+        }
+
+        public UserClaim src(String... src) {
+            this.src = src;
+            return this;
+        }
+
+        public UserClaim times(List<TimeRange> times) {
+            this.times = times;
+            return this;
+        }
+
+        public UserClaim locale(String locale) {
+            this.locale = locale;
             return this;
         }
 
@@ -251,49 +308,59 @@ public abstract class JwtUtils {
             return this;
         }
 
-        @Override
-        protected UserClaim getThis() {
+        public UserClaim bearerToken(boolean bearerToken) {
+            this.bearerToken = bearerToken;
             return this;
         }
 
-        @Override
-        protected void subAppendJson(StringBuilder sb) {
-            JsonUtils.addField(sb, "pub", pub);
-            JsonUtils.addField(sb, "sub", sub);
-            JsonUtils.addFieldAllowNegativeOne(sb, "subs", subs);
-            JsonUtils.addFieldAllowNegativeOne(sb, "data", data);
-            JsonUtils.addFieldAllowNegativeOne(sb, "payload", payload);
+        public UserClaim allowedConnectionTypes(String... allowedConnectionTypes) {
+            this.allowedConnectionTypes = allowedConnectionTypes;
+            return this;
         }
     }
 
-    protected abstract static class NatsClaim<T> implements JsonSerializable {
-        public int version = 2;
-        public String type;
-        public String issuerAccount;
-        public String[] tags;
+    public static class TimeRange implements JsonSerializable {
+        public String start;
+        public String end;
 
-        protected abstract T getThis();
-
-        protected NatsClaim(String type, String issuerAccount) {
-            this.type = type;
-            this.issuerAccount = issuerAccount;
+        public TimeRange(String start, String end) {
+            this.start = start;
+            this.end = end;
         }
-
-        public T tags(String[] tags) {
-            this.tags = tags;
-            return getThis();
-        }
-
-        protected abstract void subAppendJson(StringBuilder sb);
 
         @Override
         public String toJson() {
             StringBuilder sb = beginJson();
-            JsonUtils.addField(sb, "issuer_account", issuerAccount);
-            JsonUtils.addStrings(sb, "tags", tags);
-            JsonUtils.addField(sb, "type", type);
-            JsonUtils.addField(sb, "version", version);
-            subAppendJson(sb);
+            JsonUtils.addField(sb, "start", start);
+            JsonUtils.addField(sb, "end", end);
+            return endJson(sb).toString();
+        }
+    }
+
+    public static class ResponsePermission implements JsonSerializable {
+        public int maxMsgs;
+        public Duration expires;
+
+        public ResponsePermission maxMsgs(int maxMsgs) {
+            this.maxMsgs = maxMsgs;
+            return this;
+        }
+
+        public ResponsePermission expires(Duration expires) {
+            this.expires = expires;
+            return this;
+        }
+
+        public ResponsePermission expires(long expiresMillis) {
+            this.expires = Duration.ofMillis(expiresMillis);
+            return this;
+        }
+
+        @Override
+        public String toJson() {
+            StringBuilder sb = beginJson();
+            JsonUtils.addField(sb, "max", maxMsgs);
+            JsonUtils.addFieldAsNanos(sb, "ttl", expires);
             return endJson(sb).toString();
         }
     }

--- a/src/test/java/io/nats/client/support/JwtUtilsTests.java
+++ b/src/test/java/io/nats/client/support/JwtUtilsTests.java
@@ -28,13 +28,16 @@ public class JwtUtilsTests {
                 "nats": {
                     "issuer_account": "ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6",
                     "type": "user",
-                    "version": 2
+                    "version": 2,
+                    "subs": -1,
+                    "data": -1,
+                    "payload": -1
                 },
                 "sub": "UA6KOMQ67XOE3FHE37W4OXADVXVYISBNLTBUT2LSY5VFKAIJ7CRDR2RZ"
             }
          */
         assertEquals("-----BEGIN NATS USER JWT-----\n" +
-            "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJpYXQiOjE2MzMwNDMzNzgsImp0aSI6Ilg0VFdENEkzWUdDQVo0UFJLVUxPT1VBQ1I1VzVBSUtTTTZNWFZQSlpCTFhIWlpNTkZaQVEiLCJpc3MiOiJBRFE0QllNNUtJQ1I1T1hEU1AzUzNXVko1Q1lFT1JHUUtUNzJTVlJGMlpEVkE3TFRGS01DSVBHWSIsIm5hbWUiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiIsIm5hdHMiOnsiaXNzdWVyX2FjY291bnQiOiJBQ1haUkFMSUwyMldSRVREUlhZS09ZREI3WEMzRTdNQlNWVVNVTUZBQ082T001VlBSTkZNT09PNiIsInR5cGUiOiJ1c2VyIiwidmVyc2lvbiI6Mn0sInN1YiI6IlVBNktPTVE2N1hPRTNGSEUzN1c0T1hBRFZYVllJU0JOTFRCVVQyTFNZNVZGS0FJSjdDUkRSMlJaIn0.CUo-0aCxS1DvPpvZ3cZMXmLlQRMKYRfQjjXSFiCkmRrIJKX9crdkcIBuoYIgfczt5oTEDyR1ldS_ucipxCnoAQ\n" +
+            "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJpYXQiOjE2MzMwNDMzNzgsImp0aSI6IlROUUhFRzVMQllNVzVJM0lMVFBYSDRON0dHSEVGM0lLTURNSDRRSjROUUFVSUQ1MkZFM1EiLCJpc3MiOiJBRFE0QllNNUtJQ1I1T1hEU1AzUzNXVko1Q1lFT1JHUUtUNzJTVlJGMlpEVkE3TFRGS01DSVBHWSIsIm5hbWUiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiIsIm5hdHMiOnsiaXNzdWVyX2FjY291bnQiOiJBQ1haUkFMSUwyMldSRVREUlhZS09ZREI3WEMzRTdNQlNWVVNVTUZBQ082T001VlBSTkZNT09PNiIsInR5cGUiOiJ1c2VyIiwidmVyc2lvbiI6Miwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMX0sInN1YiI6IlVBNktPTVE2N1hPRTNGSEUzN1c0T1hBRFZYVllJU0JOTFRCVVQyTFNZNVZGS0FJSjdDUkRSMlJaIn0.9uzP8We3PCdR6G_50kvaKxLIOIwTlnc2eZe5249XFQj1JGgsHC0VJ3MSMerxIdNpWbSPQrgy1oKL2yU-xjr8Bw\n" +
             "------END NATS USER JWT------\n" +
             "\n" +
             "************************* IMPORTANT *************************\n" +
@@ -71,13 +74,16 @@ public class JwtUtilsTests {
                         "tag\\two"
                     ],
                     "type": "user",
-                    "version": 2
+                    "version": 2,
+                    "subs": -1,
+                    "data": -1,
+                    "payload": -1
                 },
                 "sub": "UA6KOMQ67XOE3FHE37W4OXADVXVYISBNLTBUT2LSY5VFKAIJ7CRDR2RZ"
             }
         */
         assertEquals("-----BEGIN NATS USER JWT-----\n" +
-            "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJleHAiOjE2MzMwNDM0NzgsImlhdCI6MTYzMzA0MzM3OCwianRpIjoiNDNGWEcyRktLN09ZMlFIN09KR1lPRDdCRjJVRlU0NDdFREpaRVBPM1ZTQk5KSlZBS0pDQSIsImlzcyI6IkFEUTRCWU01S0lDUjVPWERTUDNTM1dWSjVDWUVPUkdRS1Q3MlNWUkYyWkRWQTdMVEZLTUNJUEdZIiwibmFtZSI6Im5hbWUiLCJuYXRzIjp7Imlzc3Vlcl9hY2NvdW50IjoiQUNYWlJBTElMMjJXUkVURFJYWUtPWURCN1hDM0U3TUJTVlVTVU1GQUNPNk9NNVZQUk5GTU9PTzYiLCJ0YWdzIjpbInRhZzEiLCJ0YWdcXHR3byJdLCJ0eXBlIjoidXNlciIsInZlcnNpb24iOjJ9LCJzdWIiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiJ9.NdCdguIm89sg07PIlwdjkWesjHzKNQ2XYUd_t_Pfz7BFNz3gNbdcm5L-4mzvzH4l7NMI2Hbp0I7v_P26zU5cCQ\n" +
+            "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJleHAiOjE2MzMwNDM0NzgsImlhdCI6MTYzMzA0MzM3OCwianRpIjoiWk1ENEJCRkxTVklZVzNBRVNHVk5UNDdEQ1dSN0lPV1paUVk3NFBLQTNDWEhQV0NYMkFOUSIsImlzcyI6IkFEUTRCWU01S0lDUjVPWERTUDNTM1dWSjVDWUVPUkdRS1Q3MlNWUkYyWkRWQTdMVEZLTUNJUEdZIiwibmFtZSI6Im5hbWUiLCJuYXRzIjp7Imlzc3Vlcl9hY2NvdW50IjoiQUNYWlJBTElMMjJXUkVURFJYWUtPWURCN1hDM0U3TUJTVlVTVU1GQUNPNk9NNVZQUk5GTU9PTzYiLCJ0YWdzIjpbInRhZzEiLCJ0YWdcXHR3byJdLCJ0eXBlIjoidXNlciIsInZlcnNpb24iOjIsInN1YnMiOi0xLCJkYXRhIjotMSwicGF5bG9hZCI6LTF9LCJzdWIiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiJ9.5cUsiR0BTT1g6mbLeNRROvEfHFIG3m22Zt9q_xjozjEj_JREZsZHm84noE0Ec8xWN92bIrETmaX-qywOGBdcCg\n" +
             "------END NATS USER JWT------\n" +
             "\n" +
             "************************* IMPORTANT *************************\n" +
@@ -128,14 +134,65 @@ public class JwtUtilsTests {
                     "sub": {
                         "allow": ["sub-allow-subject"],
                         "deny": ["sub-deny-subject"]
-                    }
+                    },
+                    "subs": -1,
+                    "data": -1,
+                    "payload": -1
                 },
                 "sub": "UA6KOMQ67XOE3FHE37W4OXADVXVYISBNLTBUT2LSY5VFKAIJ7CRDR2RZ"
             }
          */
 
         assertEquals("-----BEGIN NATS USER JWT-----\n" +
-                "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJpYXQiOjE2MzMwNDMzNzgsImp0aSI6IkpVQjY1QU5ERUlST1dFR0VCT1ZSR0VKUlc2Rlg3NFBJSlgzTEpEWUhCS0tRSVRER0FUVEEiLCJpc3MiOiJBRFE0QllNNUtJQ1I1T1hEU1AzUzNXVko1Q1lFT1JHUUtUNzJTVlJGMlpEVkE3TFRGS01DSVBHWSIsIm5hbWUiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiIsIm5hdHMiOnsiaXNzdWVyX2FjY291bnQiOiJBQ1haUkFMSUwyMldSRVREUlhZS09ZREI3WEMzRTdNQlNWVVNVTUZBQ082T001VlBSTkZNT09PNiIsInRhZ3MiOlsidGFnMSIsInRhZ1xcdHdvIl0sInR5cGUiOiJ1c2VyIiwidmVyc2lvbiI6MiwicHViIjp7ImFsbG93IjpbInB1Yi1hbGxvdy1zdWJqZWN0Il0sImRlbnkiOlsicHViLWRlbnktc3ViamVjdCJdfSwic3ViIjp7ImFsbG93IjpbInN1Yi1hbGxvdy1zdWJqZWN0Il0sImRlbnkiOlsic3ViLWRlbnktc3ViamVjdCJdfX0sInN1YiI6IlVBNktPTVE2N1hPRTNGSEUzN1c0T1hBRFZYVllJU0JOTFRCVVQyTFNZNVZGS0FJSjdDUkRSMlJaIn0.bZAJPqeoBuwKYZHaWGNJlyejPmSRxhM_2lMlu6fx4UxsjUdMkJJLl1P5KpGl95cyjnxpShDz7aanGgtAPfnzDQ\n" +
+                "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJpYXQiOjE2MzMwNDMzNzgsImp0aSI6IldGMkJDR0VMRVVOTzJDWEYzUjZaN0w0RTNKS09PM0tCREVDRU5IUkVSSTczRzYzRUtZVlEiLCJpc3MiOiJBRFE0QllNNUtJQ1I1T1hEU1AzUzNXVko1Q1lFT1JHUUtUNzJTVlJGMlpEVkE3TFRGS01DSVBHWSIsIm5hbWUiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiIsIm5hdHMiOnsiaXNzdWVyX2FjY291bnQiOiJBQ1haUkFMSUwyMldSRVREUlhZS09ZREI3WEMzRTdNQlNWVVNVTUZBQ082T001VlBSTkZNT09PNiIsInRhZ3MiOlsidGFnMSIsInRhZ1xcdHdvIl0sInR5cGUiOiJ1c2VyIiwidmVyc2lvbiI6MiwicHViIjp7ImFsbG93IjpbInB1Yi1hbGxvdy1zdWJqZWN0Il0sImRlbnkiOlsicHViLWRlbnktc3ViamVjdCJdfSwic3ViIjp7ImFsbG93IjpbInN1Yi1hbGxvdy1zdWJqZWN0Il0sImRlbnkiOlsic3ViLWRlbnktc3ViamVjdCJdfSwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMX0sInN1YiI6IlVBNktPTVE2N1hPRTNGSEUzN1c0T1hBRFZYVllJU0JOTFRCVVQyTFNZNVZGS0FJSjdDUkRSMlJaIn0.kKExDG8HH5zWytrknE8XXKSnkUdWQYi3FgCfNks0IM9LlJyDbiQIadpJa4eyFh_ajCIXKGhMTKIULEwNbrPbAQ\n" +
+                "------END NATS USER JWT------\n" +
+                "\n" +
+                "************************* IMPORTANT *************************\n" +
+                "    NKEY Seed printed below can be used to sign and prove identity.\n" +
+                "    NKEYs are sensitive and should be treated as secrets.\n" +
+                "\n" +
+                "-----BEGIN USER NKEY SEED-----\n" +
+                "SUAGL3KX4ZBBD53BNNLSHGAAGCMXSEYZ6NTYUBUCPZQGHYNK3ZRQBUDPRY\n" +
+                "------END USER NKEY SEED------\n" +
+                "\n" +
+                "*************************************************************\n",
+            cred);
+    }
+
+    @Test
+    public void issueUserJWTSuccessCustomLimits() throws Exception {
+        NKey userKey = NKey.fromSeed("SUAGL3KX4ZBBD53BNNLSHGAAGCMXSEYZ6NTYUBUCPZQGHYNK3ZRQBUDPRY".toCharArray());
+        NKey signingKey = NKey.fromSeed("SAANJIBNEKGCRUWJCPIWUXFBFJLR36FJTFKGBGKAT7AQXH2LVFNQWZJMQU".toCharArray());
+
+        JwtUtils.UserClaim userClaim = new JwtUtils.UserClaim("ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6")
+                .subs(1)
+                .data(2)
+                .payload(3);
+
+        String jwt = issueUserJWT(signingKey, new String(userKey.getPublicKey()), null, null, 1633043378, userClaim);
+        String cred = String.format(JwtUtils.NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
+
+        /*
+            Generated JWT:
+            {
+                "iat": 1633043378,
+                "jti": "JUB65ANDEIROWEGEBOVRGEJRW6FX74PIJX3LJDYHBKKQITDGATTA",
+                "iss": "ADQ4BYM5KICR5OXDSP3S3WVJ5CYEORGQKT72SVRF2ZDVA7LTFKMCIPGY",
+                "name": "UA6KOMQ67XOE3FHE37W4OXADVXVYISBNLTBUT2LSY5VFKAIJ7CRDR2RZ",
+                "nats": {
+                    "issuer_account": "ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6",
+                    "type": "user",
+                    "version": 2,
+                    "subs": 1,
+                    "data": 2,
+                    "payload": 3
+                },
+                "sub": "UA6KOMQ67XOE3FHE37W4OXADVXVYISBNLTBUT2LSY5VFKAIJ7CRDR2RZ"
+            }
+         */
+
+        assertEquals("-----BEGIN NATS USER JWT-----\n" +
+                "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJpYXQiOjE2MzMwNDMzNzgsImp0aSI6IkVLNUpHR0VYVEhKWUZZM0VYSEZXSVVQTE5HWU82QjRaSUZETk43V1k2NVFYVEhMT0JPVUEiLCJpc3MiOiJBRFE0QllNNUtJQ1I1T1hEU1AzUzNXVko1Q1lFT1JHUUtUNzJTVlJGMlpEVkE3TFRGS01DSVBHWSIsIm5hbWUiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiIsIm5hdHMiOnsiaXNzdWVyX2FjY291bnQiOiJBQ1haUkFMSUwyMldSRVREUlhZS09ZREI3WEMzRTdNQlNWVVNVTUZBQ082T001VlBSTkZNT09PNiIsInR5cGUiOiJ1c2VyIiwidmVyc2lvbiI6Miwic3VicyI6MSwiZGF0YSI6MiwicGF5bG9hZCI6M30sInN1YiI6IlVBNktPTVE2N1hPRTNGSEUzN1c0T1hBRFZYVllJU0JOTFRCVVQyTFNZNVZGS0FJSjdDUkRSMlJaIn0.7nMNv_ugIM28U9va9cQR64LwbQZYEz7DZqJnD7Z-h49ZXp0PB96bHXfvzwgBgxNuTvlnWpnBmt5XtF33PlRMDw\n" +
                 "------END NATS USER JWT------\n" +
                 "\n" +
                 "************************* IMPORTANT *************************\n" +

--- a/src/test/java/io/nats/client/support/JwtUtilsTests.java
+++ b/src/test/java/io/nats/client/support/JwtUtilsTests.java
@@ -4,8 +4,10 @@ import io.nats.client.NKey;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
-import static io.nats.client.support.JwtUtils.issueUserJWT;
+import static io.nats.client.support.JwtUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -17,7 +19,7 @@ public class JwtUtilsTests {
         NKey signingKey = NKey.fromSeed("SAANJIBNEKGCRUWJCPIWUXFBFJLR36FJTFKGBGKAT7AQXH2LVFNQWZJMQU".toCharArray());
         String accountId = "ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6";
         String jwt = issueUserJWT(signingKey, accountId, new String(userKey.getPublicKey()), null, null, null, 1633043378);
-        String cred = String.format(JwtUtils.NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
+        String cred = String.format(NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
         /*
             Generated JWT:
             {
@@ -58,7 +60,7 @@ public class JwtUtilsTests {
         NKey signingKey = NKey.fromSeed("SAANJIBNEKGCRUWJCPIWUXFBFJLR36FJTFKGBGKAT7AQXH2LVFNQWZJMQU".toCharArray());
         String accountId = "ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6";
         String jwt = issueUserJWT(signingKey, accountId, new String(userKey.getPublicKey()), "name", Duration.ofSeconds(100), new String[]{"tag1", "tag\\two"}, 1633043378);
-        String cred = String.format(JwtUtils.NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
+        String cred = String.format(NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
         /*
             Generated JWT:
             {
@@ -103,17 +105,17 @@ public class JwtUtilsTests {
         NKey userKey = NKey.fromSeed("SUAGL3KX4ZBBD53BNNLSHGAAGCMXSEYZ6NTYUBUCPZQGHYNK3ZRQBUDPRY".toCharArray());
         NKey signingKey = NKey.fromSeed("SAANJIBNEKGCRUWJCPIWUXFBFJLR36FJTFKGBGKAT7AQXH2LVFNQWZJMQU".toCharArray());
 
-        JwtUtils.UserClaim userClaim = new JwtUtils.UserClaim("ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6")
-            .pub(new JwtUtils.Permission()
+        UserClaim userClaim = new UserClaim("ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6")
+            .pub(new Permission()
                 .allow(new String[] {"pub-allow-subject"})
                 .deny(new String[] {"pub-deny-subject"}))
-            .sub(new JwtUtils.Permission()
+            .sub(new Permission()
                 .allow(new String[] {"sub-allow-subject"})
                 .deny(new String[] {"sub-deny-subject"}))
             .tags(new String[]{"tag1", "tag\\two"});
 
         String jwt = issueUserJWT(signingKey, new String(userKey.getPublicKey()), null, null, 1633043378, userClaim);
-        String cred = String.format(JwtUtils.NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
+        String cred = String.format(NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
 
         /*
             Generated JWT:
@@ -164,13 +166,13 @@ public class JwtUtilsTests {
         NKey userKey = NKey.fromSeed("SUAGL3KX4ZBBD53BNNLSHGAAGCMXSEYZ6NTYUBUCPZQGHYNK3ZRQBUDPRY".toCharArray());
         NKey signingKey = NKey.fromSeed("SAANJIBNEKGCRUWJCPIWUXFBFJLR36FJTFKGBGKAT7AQXH2LVFNQWZJMQU".toCharArray());
 
-        JwtUtils.UserClaim userClaim = new JwtUtils.UserClaim("ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6")
+        UserClaim userClaim = new UserClaim("ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6")
                 .subs(1)
                 .data(2)
                 .payload(3);
 
         String jwt = issueUserJWT(signingKey, new String(userKey.getPublicKey()), null, null, 1633043378, userClaim);
-        String cred = String.format(JwtUtils.NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
+        String cred = String.format(NATS_USER_JWT_FORMAT, jwt, new String(userKey.getSeed()));
 
         /*
             Generated JWT:
@@ -189,7 +191,7 @@ public class JwtUtilsTests {
                 },
                 "sub": "UA6KOMQ67XOE3FHE37W4OXADVXVYISBNLTBUT2LSY5VFKAIJ7CRDR2RZ"
             }
-         */
+        */
 
         assertEquals("-----BEGIN NATS USER JWT-----\n" +
                 "eyJ0eXAiOiJKV1QiLCAiYWxnIjoiZWQyNTUxOS1ua2V5In0.eyJpYXQiOjE2MzMwNDMzNzgsImp0aSI6IkVLNUpHR0VYVEhKWUZZM0VYSEZXSVVQTE5HWU82QjRaSUZETk43V1k2NVFYVEhMT0JPVUEiLCJpc3MiOiJBRFE0QllNNUtJQ1I1T1hEU1AzUzNXVko1Q1lFT1JHUUtUNzJTVlJGMlpEVkE3TFRGS01DSVBHWSIsIm5hbWUiOiJVQTZLT01RNjdYT0UzRkhFMzdXNE9YQURWWFZZSVNCTkxUQlVUMkxTWTVWRktBSUo3Q1JEUjJSWiIsIm5hdHMiOnsiaXNzdWVyX2FjY291bnQiOiJBQ1haUkFMSUwyMldSRVREUlhZS09ZREI3WEMzRTdNQlNWVVNVTUZBQ082T001VlBSTkZNT09PNiIsInR5cGUiOiJ1c2VyIiwidmVyc2lvbiI6Miwic3VicyI6MSwiZGF0YSI6MiwicGF5bG9hZCI6M30sInN1YiI6IlVBNktPTVE2N1hPRTNGSEUzN1c0T1hBRFZYVllJU0JOTFRCVVQyTFNZNVZGS0FJSjdDUkRSMlJaIn0.7nMNv_ugIM28U9va9cQR64LwbQZYEz7DZqJnD7Z-h49ZXp0PB96bHXfvzwgBgxNuTvlnWpnBmt5XtF33PlRMDw\n" +
@@ -232,4 +234,74 @@ public class JwtUtilsTests {
         String accountId = "ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6";
         assertThrows(IllegalArgumentException.class, () -> issueUserJWT(signingKey, accountId, new String(userKey.getPublicKey()), null, null, null, 1633043378));
     }
+
+    @Test
+    public void userJwt() throws Exception {
+        UserClaim uc = new UserClaim("test-issuer-account");
+        assertEquals(DEFAULT_JSON, uc.toJson());
+        System.out.println(DEFAULT_JSON);
+
+        List<TimeRange> times = new ArrayList<>();
+        times.add(new TimeRange("01:15:00", "03:15:00"));
+
+        uc.tags("tag1", "tag2")
+            .pub(new Permission().allow("pa1", "pa2").deny("pd1", "pd2"))
+            .sub(new Permission().allow("sa1", "sa2").deny("sd1", "sd2"))
+            .resp(new ResponsePermission().maxMsgs(99).expires(999))
+            .src("src1", "src2")
+            .times(times)
+            .locale("US/Eastern")
+            .subs(42)
+            .data(43)
+            .payload(44)
+            .bearerToken(true)
+            .allowedConnectionTypes("nats", "tls");
+        assertEquals(FULL_JSON, uc.toJson());
+    }
+
+    private static final String DEFAULT_JSON = "{\"issuer_account\":\"test-issuer-account\",\"type\":\"user\",\"version\":2,\"subs\":-1,\"data\":-1,\"payload\":-1}";
+    private static final String FULL_JSON = "{\"issuer_account\":\"test-issuer-account\",\"tags\":[\"tag1\",\"tag2\"],\"type\":\"user\",\"version\":2,\"pub\":{\"allow\":[\"pa1\",\"pa2\"],\"deny\":[\"pd1\",\"pd2\"]},\"sub\":{\"allow\":[\"sa1\",\"sa2\"],\"deny\":[\"sd1\",\"sd2\"]},\"resp\":{\"max\":99,\"ttl\":999000000},\"src\":[\"src1\",\"src2\"],\"times\":[{\"start\":\"01:15:00\",\"end\":\"03:15:00\"}],\"times_location\":\"US\\/Eastern\",\"subs\":42,\"data\":43,\"payload\":44,\"bearer_token\":true,\"allowed_connection_types\":[\"nats\",\"tls\"]}";
+
+    /*
+        DEFAULT_JSON
+        {
+            "issuer_account": "test-issuer-account",
+            "type": "user",
+            "version": 2,
+            "subs": -1,
+            "data": -1,
+            "payload": -1
+        }
+
+        FULL_JSON
+        {
+            "issuer_account": "test-issuer-account",
+            "tags": ["tag1", "tag2"],
+            "type": "user",
+            "version": 2,
+            "pub": {
+                "allow": ["pa1", "pa2"],
+                "deny": ["pd1", "pd2"]
+            },
+            "sub": {
+                "allow": ["sa1", "sa2"],
+                "deny": ["sd1", "sd2"]
+            },
+            "resp": {
+                "max": 99,
+                "ttl": 999000000
+            },
+            "src": ["src1", "src2"],
+            "times": [{
+                "start": "01:15:00",
+                "end": "03:15:00"
+            }],
+            "times_location": "US\/Eastern",
+            "subs": 42,
+            "data": 43,
+            "payload": 44,
+            "bearer_token": true,
+            "allowed_connection_types": ["nats", "tls"]
+        }
+    */
 }


### PR DESCRIPTION
The `JwtUtils` didn't include the `subs`, `data` and `payload`. This made the server default those limits to 0, not allowing for any subs to be created, etc.

Looking at the NATS JWT Go implementation:
```go
// NewUserClaims creates a user JWT with the specific subject/public key
func NewUserClaims(subject string) *UserClaims {
	if subject == "" {
		return nil
	}
	c := &UserClaims{}
	c.Subject = subject
	c.Limits = Limits{
		UserLimits{CIDRList{}, nil, ""},
		NatsLimits{NoLimit, NoLimit, NoLimit},
	}
	return c
}
```

These fields are defaulted to `NoLimit`, so -1, in the `NatsLimits` (which contains the `subs`, `data`, `payload`).

To support the Java client I've added support for overwriting these fields in the `UserClaim`, as well as defaulting them to `NO_LIMIT = -1` to ensure these are set explicitly in the created JWT, instead of defaulted by the server to 0.

This fixes an issue when creating a JWT without these fields explicitly defined, and the server logging about it when trying to create subs and publishing data:
```
[115788] 2023/05/10 23:45:32.652619 [ERR] 127.0.0.1:48848 - cid:7 - maximum subscriptions exceeded
[115788] 2023/05/10 23:45:32.657450 [ERR] 127.0.0.1:48848 - cid:7 - maximum payload exceeded: 29 vs 0
```