### PR TITLE
[BUG] Consumer Config fields are 32 bits (ints) not 64 bits (longs)

### DIFF
--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -53,7 +53,7 @@ public class ConsumerConfiguration implements JsonSerializable {
     public static final long DURATION_UNSET_LONG = 0;
     public static final long DURATION_MIN_LONG = 1;
     public static final int STANDARD_MIN = 0;
-    public static final long MAX_DELIVER_MIN = 1;
+    public static final int MAX_DELIVER_MIN = 1;
 
     public static final long MIN_IDLE_HEARTBEAT_NANOS = MIN_IDLE_HEARTBEAT.toNanos();
     public static final long MIN_IDLE_HEARTBEAT_MILLIS = MIN_IDLE_HEARTBEAT.toMillis();
@@ -74,12 +74,12 @@ public class ConsumerConfiguration implements JsonSerializable {
     protected final Duration maxExpires;
     protected final Duration inactiveThreshold;
     protected final Long startSeq; // server side this is unsigned
-    protected final Long maxDeliver;
+    protected final Integer maxDeliver;
     protected final Long rateLimit; // server side this is unsigned
-    protected final Long maxAckPending;
-    protected final Long maxPullWaiting;
-    protected final Long maxBatch;
-    protected final Long maxBytes;
+    protected final Integer maxAckPending;
+    protected final Integer maxPullWaiting;
+    protected final Integer maxBatch;
+    protected final Integer maxBytes;
     protected final Integer numReplicas;
     protected final Boolean flowControl;
     protected final Boolean headersOnly;
@@ -138,12 +138,12 @@ public class ConsumerConfiguration implements JsonSerializable {
         inactiveThreshold = readNanos(v, INACTIVE_THRESHOLD);
 
         startSeq = readLong(v, OPT_START_SEQ);
-        maxDeliver = readLong(v, MAX_DELIVER);
+        maxDeliver = readInteger(v, MAX_DELIVER);
         rateLimit = readLong(v, RATE_LIMIT_BPS);
-        maxAckPending = readLong(v, MAX_ACK_PENDING);
-        maxPullWaiting = readLong(v, MAX_WAITING);
-        maxBatch = readLong(v, MAX_BATCH);
-        maxBytes = readLong(v, MAX_BYTES);
+        maxAckPending = readInteger(v, MAX_ACK_PENDING);
+        maxPullWaiting = readInteger(v, MAX_WAITING);
+        maxBatch = readInteger(v, MAX_BATCH);
+        maxBytes = readInteger(v, MAX_BYTES);
         numReplicas = readInteger(v, NUM_REPLICAS);
 
         flowControl = readBoolean(v, FLOW_CONTROL, null);
@@ -626,12 +626,12 @@ public class ConsumerConfiguration implements JsonSerializable {
         private Duration inactiveThreshold;
 
         private Long startSeq;
-        private Long maxDeliver;
+        private Integer maxDeliver;
         private Long rateLimit;
-        private Long maxAckPending;
-        private Long maxPullWaiting;
-        private Long maxBatch;
-        private Long maxBytes;
+        private Integer maxAckPending;
+        private Integer maxPullWaiting;
+        private Integer maxBatch;
+        private Integer maxBytes;
         private Integer numReplicas;
 
         private Boolean flowControl;
@@ -1243,11 +1243,6 @@ public class ConsumerConfiguration implements JsonSerializable {
         return val == null ? INTEGER_UNSET : val;
     }
 
-    protected static long getOrUnset(Long val)
-    {
-        return val == null ? LONG_UNSET : val;
-    }
-
     protected static long getOrUnsetUlong(Long val)
     {
         return val == null || val < 0 ? ULONG_UNSET : val;
@@ -1258,16 +1253,20 @@ public class ConsumerConfiguration implements JsonSerializable {
         return val == null ? DURATION_UNSET : val;
     }
 
-    protected static Long normalize(Long l, long min) {
+    protected static Integer normalize(Long l, int min) {
         if (l == null) {
             return null;
         }
 
         if (l < min) {
-            return LONG_UNSET;
+            return INTEGER_UNSET;
         }
 
-        return l;
+        if (l > Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+
+        return l.intValue();
     }
 
     protected static Long normalizeUlong(Long u)

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -467,11 +467,11 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
             if (startSeq != null && !startSeq.equals(serverCcc.getStartSequence())) { changes.add("startSequence"); };
             if (rateLimit != null && !rateLimit.equals(serverCcc.getStartSequence())) { changes.add("rateLimit"); };
 
-            if (maxDeliver != null && !maxDeliver.equals(serverCcc.getMaxDeliver())) { changes.add("maxDeliver"); };
-            if (maxAckPending != null && !maxAckPending.equals(serverCcc.getMaxAckPending())) { changes.add("maxAckPending"); };
-            if (maxPullWaiting != null && !maxPullWaiting.equals(serverCcc.getMaxPullWaiting())) { changes.add("maxPullWaiting"); };
-            if (maxBatch != null && !maxBatch.equals(serverCcc.getMaxBatch())) { changes.add("maxBatch"); };
-            if (maxBytes != null && !maxBytes.equals(serverCcc.getMaxBytes())) { changes.add("maxBytes"); };
+            if (maxDeliver != null && maxDeliver != serverCcc.getMaxDeliver()) { changes.add("maxDeliver"); };
+            if (maxAckPending != null && maxAckPending != serverCcc.getMaxAckPending()) { changes.add("maxAckPending"); };
+            if (maxPullWaiting != null && maxPullWaiting != serverCcc.getMaxPullWaiting()) { changes.add("maxPullWaiting"); };
+            if (maxBatch != null && maxBatch != serverCcc.getMaxBatch()) { changes.add("maxBatch"); };
+            if (maxBytes != null && maxBytes != serverCcc.getMaxBytes()) { changes.add("maxBytes"); };
             if (numReplicas != null && !numReplicas.equals(serverCcc.numReplicas)) { changes.add("numReplicas"); };
 
             if (ackWait != null && !ackWait.equals(getOrUnset(serverCcc.ackWait))) { changes.add("ackWait"); };

--- a/src/test/java/io/nats/client/api/ConsumerConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/ConsumerConfigurationTests.java
@@ -34,7 +34,8 @@ public class ConsumerConfigurationTests extends TestBase {
     @Test
     public void testBuilder() {
         ZonedDateTime zdt = ZonedDateTime.of(2012, 1, 12, 6, 30, 1, 500, DateTimeUtils.ZONE_ID_GMT);
-        Map<String, String> metadata = new HashMap<>(); metadata.put("meta-foo", "meta-bar");
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("meta-foo", "meta-bar");
 
         ConsumerConfiguration c = ConsumerConfiguration.builder()
             .ackPolicy(AckPolicy.Explicit)
@@ -162,10 +163,10 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(Duration.ofMillis(MIN_IDLE_HEARTBEAT_MILLIS + 1), c.getIdleHeartbeat());
 
         assertThrows(IllegalArgumentException.class,
-            () ->ConsumerConfiguration.builder().idleHeartbeat(Duration.ofMillis(MIN_IDLE_HEARTBEAT_MILLIS - 1)).build());
+            () -> ConsumerConfiguration.builder().idleHeartbeat(Duration.ofMillis(MIN_IDLE_HEARTBEAT_MILLIS - 1)).build());
 
         assertThrows(IllegalArgumentException.class,
-            () ->ConsumerConfiguration.builder().idleHeartbeat(MIN_IDLE_HEARTBEAT_MILLIS - 1).build());
+            () -> ConsumerConfiguration.builder().idleHeartbeat(MIN_IDLE_HEARTBEAT_MILLIS - 1).build());
 
         // backoff coverage
         c = ConsumerConfiguration.builder().backoff(Duration.ofSeconds(1), null, Duration.ofSeconds(2)).build();
@@ -174,9 +175,9 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(Duration.ofSeconds(2), c.getBackoff().get(1));
 
         assertThrows(IllegalArgumentException.class,
-            () ->ConsumerConfiguration.builder().backoff(Duration.ZERO).build());
+            () -> ConsumerConfiguration.builder().backoff(Duration.ZERO).build());
         assertThrows(IllegalArgumentException.class,
-            () ->ConsumerConfiguration.builder().backoff(Duration.ofNanos(DURATION_MIN_LONG - 1)).build());
+            () -> ConsumerConfiguration.builder().backoff(Duration.ofNanos(DURATION_MIN_LONG - 1)).build());
 
         c = ConsumerConfiguration.builder().backoff(1000, 2000).build();
         assertEquals(2, c.getBackoff().size());
@@ -184,9 +185,9 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(Duration.ofSeconds(2), c.getBackoff().get(1));
 
         assertThrows(IllegalArgumentException.class,
-            () ->ConsumerConfiguration.builder().backoff(0).build());
+            () -> ConsumerConfiguration.builder().backoff(0).build());
         assertThrows(IllegalArgumentException.class,
-            () ->ConsumerConfiguration.builder().backoff(DURATION_MIN_LONG - 1).build());
+            () -> ConsumerConfiguration.builder().backoff(DURATION_MIN_LONG - 1).build());
 
         assertClientError(JsConsumerNameDurableMismatch, () -> ConsumerConfiguration.builder().name(NAME).durable(DURABLE).build());
     }
@@ -297,8 +298,7 @@ public class ConsumerConfigurationTests extends TestBase {
         assertDefaultCc(new ConsumerConfiguration(JsonValue.EMPTY_MAP));
     }
 
-    private static void assertDefaultCc(ConsumerConfiguration c)
-    {
+    private static void assertDefaultCc(ConsumerConfiguration c) {
         assertEquals(DeliverPolicy.All, c.getDeliverPolicy());
         assertEquals(AckPolicy.Explicit, c.getAckPolicy());
         assertEquals(ReplayPolicy.Instant, c.getReplayPolicy());
@@ -333,7 +333,7 @@ public class ConsumerConfigurationTests extends TestBase {
     public void testUtilityMethods() {
         assertEquals(1, ConsumerConfiguration.getOrUnset(1));
         assertEquals(INTEGER_UNSET, ConsumerConfiguration.getOrUnset(INTEGER_UNSET));
-        assertEquals(INTEGER_UNSET, ConsumerConfiguration.getOrUnset((Integer)null));
+        assertEquals(INTEGER_UNSET, ConsumerConfiguration.getOrUnset((Integer) null));
 
         assertEquals(1L, ConsumerConfiguration.getOrUnsetUlong(1L));
         assertEquals(ULONG_UNSET, ConsumerConfiguration.getOrUnsetUlong(ULONG_UNSET));
@@ -342,15 +342,15 @@ public class ConsumerConfigurationTests extends TestBase {
 
         assertEquals(Duration.ZERO, ConsumerConfiguration.getOrUnset(Duration.ZERO));
         assertEquals(DURATION_UNSET, ConsumerConfiguration.getOrUnset(DURATION_UNSET));
-        assertEquals(DURATION_UNSET, ConsumerConfiguration.getOrUnset((Duration)null));
+        assertEquals(DURATION_UNSET, ConsumerConfiguration.getOrUnset((Duration) null));
 
         //noinspection ConstantConditions
         assertNull(ConsumerConfiguration.normalize(null, STANDARD_MIN));
         assertEquals(0, ConsumerConfiguration.normalize(0L, STANDARD_MIN));
         assertEquals(1, ConsumerConfiguration.normalize(1L, STANDARD_MIN));
-        assertEquals(LONG_UNSET, ConsumerConfiguration.normalize(LONG_UNSET, STANDARD_MIN));
-        assertEquals(LONG_UNSET, ConsumerConfiguration.normalize(Long.MIN_VALUE, STANDARD_MIN));
-        assertEquals(Long.MAX_VALUE, ConsumerConfiguration.normalize(Long.MAX_VALUE, STANDARD_MIN));
+        assertEquals(INTEGER_UNSET, ConsumerConfiguration.normalize(LONG_UNSET, STANDARD_MIN));
+        assertEquals(INTEGER_UNSET, ConsumerConfiguration.normalize(Long.MIN_VALUE, STANDARD_MIN));
+        assertEquals(Integer.MAX_VALUE, ConsumerConfiguration.normalize(Long.MAX_VALUE, STANDARD_MIN));
 
         //noinspection ConstantConditions
         assertNull(ConsumerConfiguration.normalizeUlong(null));
@@ -360,7 +360,7 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(ULONG_UNSET, ConsumerConfiguration.normalizeUlong(-1L));
 
         //noinspection ConstantConditions
-        assertNull(ConsumerConfiguration.normalize((Duration)null));
+        assertNull(ConsumerConfiguration.normalize((Duration) null));
         assertEquals(Duration.ofNanos(1), ConsumerConfiguration.normalize(Duration.ofNanos(1)));
         assertEquals(DURATION_UNSET, ConsumerConfiguration.normalize(DURATION_UNSET));
         assertEquals(DURATION_UNSET, ConsumerConfiguration.normalize(Duration.ZERO));
@@ -368,14 +368,37 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(Duration.ofMillis(1), ConsumerConfiguration.normalizeDuration(1));
         assertEquals(DURATION_UNSET, ConsumerConfiguration.normalizeDuration(0));
 
-        assertEquals(DEFAULT_DELIVER_POLICY, ConsumerConfiguration.GetOrDefault((DeliverPolicy)null));
+        assertEquals(DEFAULT_DELIVER_POLICY, ConsumerConfiguration.GetOrDefault((DeliverPolicy) null));
         assertEquals(DeliverPolicy.Last, ConsumerConfiguration.GetOrDefault(DeliverPolicy.Last));
 
-        assertEquals(DEFAULT_ACK_POLICY, ConsumerConfiguration.GetOrDefault((AckPolicy)null));
+        assertEquals(DEFAULT_ACK_POLICY, ConsumerConfiguration.GetOrDefault((AckPolicy) null));
         assertEquals(AckPolicy.All, ConsumerConfiguration.GetOrDefault(AckPolicy.All));
 
-        assertEquals(DEFAULT_REPLAY_POLICY, ConsumerConfiguration.GetOrDefault((ReplayPolicy)null));
+        assertEquals(DEFAULT_REPLAY_POLICY, ConsumerConfiguration.GetOrDefault((ReplayPolicy) null));
         assertEquals(ReplayPolicy.Original, ConsumerConfiguration.GetOrDefault(ReplayPolicy.Original));
+    }
+
+    @Test
+    public void testDowngradeFromLongToInt() {
+        ConsumerConfiguration cc = ConsumerConfiguration.builder()
+            .maxDeliver(Long.MAX_VALUE)
+            .maxAckPending(Long.MAX_VALUE)
+            .maxPullWaiting(Long.MAX_VALUE)
+            .maxBatch(Long.MAX_VALUE)
+            .maxBytes(Long.MAX_VALUE)
+            .build();
+
+        Long maxDeliver = cc.getMaxDeliver();
+        Long maxAckPending = cc.getMaxAckPending();
+        Long maxPullWaiting = cc.getMaxPullWaiting();
+        Long maxBatch = cc.getMaxBatch();
+        Long maxBytes = cc.getMaxBytes();
+
+        assertEquals(Integer.MAX_VALUE, maxDeliver);
+        assertEquals(Integer.MAX_VALUE, maxAckPending);
+        assertEquals(Integer.MAX_VALUE, maxPullWaiting);
+        assertEquals(Integer.MAX_VALUE, maxBatch);
+        assertEquals(Integer.MAX_VALUE, maxBytes);
     }
 }
 


### PR DESCRIPTION
Building a consumer config allowed the user to supply a long for fields that where only 32 bit signed values. Even though it would be unusual for a developer to provide a value larger than 2,147,483,647 it's still possible from the builder interface.
This fix checks the value and if it's larger than 2,147,483,647 it just makes it 2,147,483,647. 
This seems reasonable as the user probably meant unlimited which this still provides.