### PR TITLE
Fast Bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,7 @@ You can however set the deliver policy which will be used to start the subscript
 | JsSoNameMismatch                             | SO    | 90110 | Builder name must match the consumer configuration name if both are provided.                       |
 | JsSoOrderedMemStorageNotSuppliedOrTrue       | SO    | 90111 | Mem Storage must be true if supplied.                                                               |
 | JsSoOrderedReplicasNotSuppliedOrOne          | SO    | 90112 | Replicas must be 1 if supplied.                                                                     |
+| JsSoNameOrDurableRequiredForBind             | SO    | 90113 | Name or Durable required for Bind.                                                                  |
 | JsSubPullCantHaveDeliverGroup                | SUB   | 90001 | Pull subscriptions can't have a deliver group.                                                      |
 | JsSubPullCantHaveDeliverSubject              | SUB   | 90002 | Pull subscriptions can't have a deliver subject.                                                    |
 | JsSubPushCantHaveMaxPullWaiting              | SUB   | 90003 | Push subscriptions cannot supply max pull waiting.                                                  |

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubMultipleWorkers.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubMultipleWorkers.java
@@ -88,7 +88,7 @@ public class NatsJsPullSubMultipleWorkers {
             // - the PullSubscribeOptions can be re-used since all the subscribers are the same
             // - use a concurrent integer to track all the messages received
             // - have a list of subscribers and threads so I can track them
-            PullSubscribeOptions pso = PullSubscribeOptions.bind(exArgs.stream, exArgs.durable);
+            PullSubscribeOptions pso = PullSubscribeOptions.fastBind(exArgs.stream, exArgs.durable);
             AtomicInteger allReceived = new AtomicInteger();
             List<JsPullSubWorker> subscribers = new ArrayList<>();
             List<Thread> subThreads = new ArrayList<>();

--- a/src/main/java/io/nats/client/PullSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PullSubscribeOptions.java
@@ -33,14 +33,36 @@ public class PullSubscribeOptions extends SubscribeOptions {
     }
 
     /**
-     * Create PullSubscribeOptions where you are binding to
-     * a specific stream, specific durable and are using bind mode
+     * Create PullSubscribeOptions for binding to
+     * a specific stream and consumer by name.
+     * The client validates regular (non-fast)
+     * binds to ensure that provided consumer configuration
+     * is consistent with the server version and that
+     * consumer type (push versus pull) matches the subscription type.
+     * and that it matches the subscription type.
+     * @param stream the stream name to bind to
+     * @param name the consumer name
+     * @return push subscribe options
+     */
+    public static PullSubscribeOptions bind(String stream, String name) {
+        return new Builder().stream(stream).name(name).bind(true).build();
+    }
+
+    /**
+     * Create PullSubscribeOptions where you are fast-binding to
+     * a specific stream and consumer by name.
+     * The client does not validate that the provided consumer configuration
+     * is consistent with the server version or that
+     * consumer type (push versus pull) matches the subscription type.
+     * An inconsistent consumer configuration for instance can result in
+     * receiving messages from unexpected subjects.
+     * A consumer type mismatch will result in an error from the server.
      * @param stream the stream name to bind to
      * @param name the consumer name, commonly the durable name
      * @return push subscribe options
      */
-    public static PullSubscribeOptions bind(String stream, String name) {
-        return new PullSubscribeOptions.Builder().stream(stream).durable(name).bind(true).build();
+    public static PullSubscribeOptions fastBind(String stream, String name) {
+        return new Builder().stream(stream).name(name).fastBind(true).build();
     }
 
     /**

--- a/src/main/java/io/nats/client/PullSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PullSubscribeOptions.java
@@ -85,5 +85,21 @@ public class PullSubscribeOptions extends SubscribeOptions {
         public PullSubscribeOptions build() {
             return new PullSubscribeOptions(this);
         }
+
+        /**
+         * Specify binding to an existing consumer via name.
+         * The client does not validate that the provided consumer configuration
+         * is consistent with the server version or that
+         * consumer type (push versus pull) matches the subscription type.
+         * An inconsistent consumer configuration for instance can result in
+         * receiving messages from unexpected subjects.
+         * A consumer type mismatch will result in an error from the server.
+         * @return the builder
+         * @param fastBind whether to fast bind or not
+         */
+        public Builder fastBind(boolean fastBind) {
+            this.fastBind = fastBind;
+            return this;
+        }
     }
 }

--- a/src/main/java/io/nats/client/PushSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PushSubscribeOptions.java
@@ -86,23 +86,6 @@ public class PushSubscribeOptions extends SubscribeOptions {
     }
 
     /**
-     * Create PushSubscribeOptions where you are fast-binding to
-     * a specific stream and consumer by name.
-     * The client does not validate that the provided consumer configuration
-     * is consistent with the server version or that
-     * consumer type (push versus pull) matches the subscription type.
-     * An inconsistent consumer configuration for instance can result in
-     * receiving messages from unexpected subjects.
-     * A consumer type mismatch will result in an error from the server.
-     * @param stream the stream name
-     * @param name the consumer name
-     * @return push subscribe options
-     */
-    public static PushSubscribeOptions fastBind(String stream, String name) {
-        return new Builder().stream(stream).name(name).fastBind(true).build();
-    }
-
-    /**
      * Macro to start a PushSubscribeOptions builder
      * @return push subscribe options builder
      */

--- a/src/main/java/io/nats/client/PushSubscribeOptions.java
+++ b/src/main/java/io/nats/client/PushSubscribeOptions.java
@@ -48,8 +48,8 @@ public class PushSubscribeOptions extends SubscribeOptions {
      * where you must specify the stream because
      * the subject could apply to both a stream and a mirror.
      * @deprecated
-     * This method is no longer used as bind has a different meaning.
-     * See {@link #stream(String)} instead.
+     * This method resolves to {@link #stream(String)} as bind has a different meaning
+     * and requires both stream and consumer name
      * @param stream the stream name
      * @return push subscribe options
      */
@@ -70,14 +70,36 @@ public class PushSubscribeOptions extends SubscribeOptions {
     }
 
     /**
-     * Macro to create a PushSubscribeOptions where you are
-     * binding to an existing stream and durable consumer.
+     * Create PushSubscribeOptions for binding to
+     * a specific stream and consumer by name.
+     * The client validates regular (non-fast)
+     * binds to ensure that provided consumer configuration
+     * is consistent with the server version and that
+     * consumer type (push versus pull) matches the subscription type.
+     * and that it matches the subscription type.
      * @param stream the stream name
-     * @param durable the durable name
+     * @param name the consumer name
      * @return push subscribe options
      */
-    public static PushSubscribeOptions bind(String stream, String durable) {
-        return new PushSubscribeOptions.Builder().stream(stream).durable(durable).bind(true).build();
+    public static PushSubscribeOptions bind(String stream, String name) {
+        return new Builder().stream(stream).name(name).bind(true).build();
+    }
+
+    /**
+     * Create PushSubscribeOptions where you are fast-binding to
+     * a specific stream and consumer by name.
+     * The client does not validate that the provided consumer configuration
+     * is consistent with the server version or that
+     * consumer type (push versus pull) matches the subscription type.
+     * An inconsistent consumer configuration for instance can result in
+     * receiving messages from unexpected subjects.
+     * A consumer type mismatch will result in an error from the server.
+     * @param stream the stream name
+     * @param name the consumer name
+     * @return push subscribe options
+     */
+    public static PushSubscribeOptions fastBind(String stream, String name) {
+        return new Builder().stream(stream).name(name).fastBind(true).build();
     }
 
     /**

--- a/src/main/java/io/nats/client/SubscribeOptions.java
+++ b/src/main/java/io/nats/client/SubscribeOptions.java
@@ -254,23 +254,6 @@ public abstract class SubscribeOptions {
             this.bind = bind;
             return getThis();
         }
-
-        /**
-         * Specify binding to an existing consumer via name.
-         * The client does not validate that the provided consumer configuration
-         * is consistent with the server version or that
-         * consumer type (push versus pull) matches the subscription type.
-         * An inconsistent consumer configuration for instance can result in
-         * receiving messages from unexpected subjects.
-         * A consumer type mismatch will result in an error from the server.
-         * @return the builder
-         * @param fastBind whether to fast bind or not
-         */
-        public B fastBind(boolean fastBind) {
-            this.fastBind = fastBind;
-            return getThis();
-        }
-
         /**
          * Sets the durable name for the consumer.
          * Null or empty clears the field.

--- a/src/main/java/io/nats/client/impl/NatsConsumerContext.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumerContext.java
@@ -51,7 +51,7 @@ public class NatsConsumerContext implements ConsumerContext, SimplifiedSubscript
         consumerName = ci.getName();
         originalOrderedCc = null;
         subscribeSubject = null;
-        unorderedBindPso = PullSubscribeOptions.bind(sc.streamName, consumerName);
+        unorderedBindPso = PullSubscribeOptions.fastBind(sc.streamName, consumerName);
         cachedConsumerInfo = ci;
     }
 

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -315,7 +315,7 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
         String inboxDeliver = userCC.getDeliverSubject();
 
         // 3. Does this consumer already exist?
-        if (consumerName != null && !so.isFastBind()) {
+        if (!so.isFastBind() && consumerName != null) {
             ConsumerInfo serverInfo = lookupConsumerInfo(fnlStream, consumerName);
 
             if (serverInfo != null) { // the consumer for that durable already exists
@@ -390,7 +390,11 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
         //    If the consumer exists, I know what the settled info is
         final String settledConsumerName;
         final ConsumerConfiguration settledServerCC;
-        if (serverCC == null) {
+        if (so.isFastBind()) {
+            settledServerCC = null; // not needed for fast bind which is only allowed on normal pulls
+            settledConsumerName = so.getName();
+        }
+        else if (serverCC == null) {
             ConsumerConfiguration.Builder ccBuilder = ConsumerConfiguration.builder(userCC);
 
             // Pull mode doesn't maintain a deliver subject. It's actually an error if we send it.

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -390,11 +390,11 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
         //    If the consumer exists, I know what the settled info is
         final String settledConsumerName;
         final ConsumerConfiguration settledServerCC;
-        if (so.isFastBind()) {
-            settledServerCC = null; // not needed for fast bind which is only allowed on normal pulls
+        if (so.isFastBind() || serverCC != null) {
+            settledServerCC = serverCC;
             settledConsumerName = so.getName();
         }
-        else if (serverCC == null) {
+        else {
             ConsumerConfiguration.Builder ccBuilder = ConsumerConfiguration.builder(userCC);
 
             // Pull mode doesn't maintain a deliver subject. It's actually an error if we send it.
@@ -410,10 +410,6 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
 
             settledServerCC = ccBuilder.build();
             settledConsumerName = null;
-        }
-        else {
-            settledServerCC = serverCC;
-            settledConsumerName = consumerName;
         }
 
         // 6. create the subscription. lambda needs final or effectively final vars

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -15,6 +15,7 @@ package io.nats.client.impl;
 
 import io.nats.client.*;
 import io.nats.client.api.*;
+import io.nats.client.support.Debug;
 import io.nats.client.support.Validator;
 
 import java.io.IOException;
@@ -298,6 +299,7 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
         // 2B. Did they tell me what stream? No? look it up.
         final String fnlStream;
         if (stream == null) {
+            Debug.dbg("LOOKUP STREAM");
             fnlStream = lookupStreamBySubject(subject);
             if (fnlStream == null) {
                 throw JsSubNoMatchingStreamForSubject.instance();
@@ -315,7 +317,7 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
         String inboxDeliver = userCC.getDeliverSubject();
 
         // 3. Does this consumer already exist?
-        if (consumerName != null) {
+        if (consumerName != null && !so.isFastBind()) {
             ConsumerInfo serverInfo = lookupConsumerInfo(fnlStream, consumerName);
 
             if (serverInfo != null) { // the consumer for that durable already exists

--- a/src/main/java/io/nats/client/impl/NatsJetStream.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStream.java
@@ -15,7 +15,6 @@ package io.nats.client.impl;
 
 import io.nats.client.*;
 import io.nats.client.api.*;
-import io.nats.client.support.Debug;
 import io.nats.client.support.Validator;
 
 import java.io.IOException;
@@ -299,7 +298,6 @@ public class NatsJetStream extends NatsJetStreamImpl implements JetStream {
         // 2B. Did they tell me what stream? No? look it up.
         final String fnlStream;
         if (stream == null) {
-            Debug.dbg("LOOKUP STREAM");
             fnlStream = lookupStreamBySubject(subject);
             if (fnlStream == null) {
                 throw JsSubNoMatchingStreamForSubject.instance();

--- a/src/main/java/io/nats/client/impl/NatsMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsMessage.java
@@ -376,9 +376,9 @@ public class NatsMessage implements Message {
     @Override
     public String toString() {
         if (subject == null) {
-            return "NatsMessage | " + protocolBytesToString();
+            return getClass().getSimpleName() + " | " + protocolBytesToString();
         }
-        return "NatsMessage |" + subject + "|" + replyToString() + "|" + dataToString() + "|";
+        return getClass().getSimpleName() + " |" + subject + "|" + replyToString() + "|" + dataToString() + "|";
     }
 
     String toDetailString() {

--- a/src/main/java/io/nats/client/support/NatsJetStreamClientError.java
+++ b/src/main/java/io/nats/client/support/NatsJetStreamClientError.java
@@ -54,6 +54,7 @@ public class NatsJetStreamClientError {
     public static final NatsJetStreamClientError JsSoNameMismatch = new NatsJetStreamClientError(SO, 90110, "Builder name must match the consumer configuration name if both are provided.");
     public static final NatsJetStreamClientError JsSoOrderedMemStorageNotSuppliedOrTrue = new NatsJetStreamClientError(SO, 90111, "Mem Storage must be true if supplied.");
     public static final NatsJetStreamClientError JsSoOrderedReplicasNotSuppliedOrOne = new NatsJetStreamClientError(SO, 90112, "Replicas must be 1 if supplied.");
+    public static final NatsJetStreamClientError JsSoNameOrDurableRequiredForBind = new NatsJetStreamClientError(SO, 90113, "Name or Durable required for Bind.");
 
     public static final NatsJetStreamClientError OsObjectNotFound = new NatsJetStreamClientError(OS, 90201, "The object was not found.");
     public static final NatsJetStreamClientError OsObjectIsDeleted = new NatsJetStreamClientError(OS, 90202, "The object is deleted.");

--- a/src/main/java/io/nats/client/support/Validator.java
+++ b/src/main/java/io/nats/client/support/Validator.java
@@ -131,6 +131,13 @@ public abstract class Validator {
         return s;
     }
 
+    public static String required(String s1, String s2, String label) {
+        if (emptyAsNull(s1) == null && emptyAsNull(s2) == null) {
+            throw new IllegalArgumentException(label + " cannot be null or empty.");
+        }
+        return s1;
+    }
+
     public static <T> T required(T o, String label) {
         if (o == null) {
             throw new IllegalArgumentException(label + " cannot be null.");

--- a/src/test/java/io/nats/client/SubscribeOptionsTests.java
+++ b/src/test/java/io/nats/client/SubscribeOptionsTests.java
@@ -33,6 +33,7 @@ public class SubscribeOptionsTests extends TestBase {
         // starts out all null which is fine
         assertNull(so.getStream());
         assertNull(so.getDurable());
+        assertNull(so.getName());
         assertNull(so.getDeliverSubject());
 
         so = PushSubscribeOptions.builder()
@@ -40,6 +41,7 @@ public class SubscribeOptionsTests extends TestBase {
 
         assertEquals(STREAM, so.getStream());
         assertEquals(DURABLE, so.getDurable());
+        assertEquals(DURABLE, so.getName());
         assertEquals(DELIVER, so.getDeliverSubject());
 
         // demonstrate that you can clear the builder
@@ -47,6 +49,7 @@ public class SubscribeOptionsTests extends TestBase {
                 .stream(null).deliverSubject(null).durable(null).build();
         assertNull(so.getStream());
         assertNull(so.getDurable());
+        assertNull(so.getName());
         assertNull(so.getDeliverSubject());
         assertFalse(so.isPull());
 
@@ -56,29 +59,32 @@ public class SubscribeOptionsTests extends TestBase {
     @Test
     public void testDurableValidation() {
         // push
-        assertNull(PushSubscribeOptions.builder()
-                .durable(null)
-                .configuration(ConsumerConfiguration.builder().durable(null).build())
-                .build()
-                .getDurable());
+        PushSubscribeOptions uso = PushSubscribeOptions.builder()
+            .durable(null)
+            .configuration(ConsumerConfiguration.builder().durable(null).build())
+            .build();
+        assertNull(uso.getDurable());
 
-        assertEquals("y", PushSubscribeOptions.builder()
-                .durable(null)
-                .configuration(ConsumerConfiguration.builder().durable("y").build())
-                .build()
-                .getDurable());
+        uso = PushSubscribeOptions.builder()
+            .durable(null)
+            .configuration(ConsumerConfiguration.builder().durable("y").build())
+            .build();
+        assertEquals("y", uso.getDurable());
+        assertEquals("y", uso.getName());
 
-        assertEquals("x", PushSubscribeOptions.builder()
-                .durable("x")
-                .configuration(ConsumerConfiguration.builder().durable(null).build())
-                .build()
-                .getDurable());
+        uso = PushSubscribeOptions.builder()
+            .durable("x")
+            .configuration(ConsumerConfiguration.builder().durable(null).build())
+            .build();
+        assertEquals("x", uso.getDurable());
+        assertEquals("x", uso.getName());
 
-        assertEquals("x", PushSubscribeOptions.builder()
-                .durable("x")
-                .configuration(ConsumerConfiguration.builder().durable("x").build())
-                .build()
-                .getDurable());
+        uso = PushSubscribeOptions.builder()
+            .durable("x")
+            .configuration(ConsumerConfiguration.builder().durable("x").build())
+            .build();
+        assertEquals("x", uso.getDurable());
+        assertEquals("x", uso.getName());
 
         assertClientError(JsSoDurableMismatch, () -> PushSubscribeOptions.builder()
                 .durable("x")
@@ -88,23 +94,26 @@ public class SubscribeOptionsTests extends TestBase {
         assertNull(PushSubscribeOptions.builder().build().getDurable());
 
         // pull
-        assertEquals("y", PullSubscribeOptions.builder()
-                .durable(null)
-                .configuration(ConsumerConfiguration.builder().durable("y").build())
-                .build()
-                .getDurable());
+        PullSubscribeOptions lso = PullSubscribeOptions.builder()
+            .durable(null)
+            .configuration(ConsumerConfiguration.builder().durable("y").build())
+            .build();
+        assertEquals("y", lso.getDurable());
+        assertEquals("y", lso.getName());
 
-        assertEquals("x", PullSubscribeOptions.builder()
-                .durable("x")
-                .configuration(ConsumerConfiguration.builder().durable(null).build())
-                .build()
-                .getDurable());
+        lso = PullSubscribeOptions.builder()
+            .durable("x")
+            .configuration(ConsumerConfiguration.builder().durable(null).build())
+            .build();
+        assertEquals("x", lso.getDurable());
+        assertEquals("x", lso.getName());
 
-        assertEquals("x", PullSubscribeOptions.builder()
-                .durable("x")
-                .configuration(ConsumerConfiguration.builder().durable("x").build())
-                .build()
-                .getDurable());
+        lso = PullSubscribeOptions.builder()
+            .durable("x")
+            .configuration(ConsumerConfiguration.builder().durable("x").build())
+            .build();
+        assertEquals("x", lso.getDurable());
+        assertEquals("x", lso.getName());
 
         assertClientError(JsSoDurableMismatch, () -> PullSubscribeOptions.builder()
                 .durable("x")
@@ -185,6 +194,7 @@ public class SubscribeOptionsTests extends TestBase {
         PullSubscribeOptions so = builder.build();
         assertEquals(STREAM, so.getStream());
         assertEquals(DURABLE, so.getDurable());
+        assertEquals(DURABLE, so.getName());
         assertTrue(so.isPull());
 
         assertNotNull(so.toString()); // COVERAGE
@@ -204,14 +214,22 @@ public class SubscribeOptionsTests extends TestBase {
         assertClientError(JsConsumerNameDurableMismatch, () -> PushSubscribeOptions.builder().name(NAME).durable(DURABLE).build());
 
         // durable directly
-        PushSubscribeOptions.builder().durable(DURABLE).build();
-        PushSubscribeOptions.builder().name(NAME).build();
+        PushSubscribeOptions uso = PushSubscribeOptions.builder().durable(DURABLE).build();
+        assertEquals(DURABLE, uso.getDurable());
+        assertEquals(DURABLE, uso.getName());
+        uso = PushSubscribeOptions.builder().name(NAME).build();
+        assertNull(uso.getDurable());
+        assertEquals(NAME, uso.getName());
 
         // in configuration
         ConsumerConfiguration cc = ConsumerConfiguration.builder().durable(DURABLE).build();
-        PushSubscribeOptions.builder().configuration(cc).build();
+        uso = PushSubscribeOptions.builder().configuration(cc).build();
+        assertEquals(DURABLE, uso.getDurable());
+        assertEquals(DURABLE, uso.getName());
         cc = ConsumerConfiguration.builder().name(NAME).build();
-        PushSubscribeOptions.builder().configuration(cc).build();
+        uso = PushSubscribeOptions.builder().configuration(cc).build();
+        assertNull(uso.getDurable());
+        assertEquals(NAME, uso.getName());
 
         // new helper
         ConsumerConfiguration.builder().durable(DURABLE).buildPushSubscribeOptions();
@@ -232,14 +250,20 @@ public class SubscribeOptionsTests extends TestBase {
         assertClientError(JsConsumerNameDurableMismatch, () -> PullSubscribeOptions.builder().name(NAME).durable(DURABLE).build());
 
         // durable directly
-        PullSubscribeOptions.builder().durable(DURABLE).build();
+        PullSubscribeOptions lso = PullSubscribeOptions.builder().durable(DURABLE).build();
+        assertEquals(DURABLE, lso.getDurable());
+        assertEquals(DURABLE, lso.getName());
 
         // in configuration
         ConsumerConfiguration cc = ConsumerConfiguration.builder().durable(DURABLE).build();
-        PullSubscribeOptions.builder().configuration(cc).build();
+        lso = PullSubscribeOptions.builder().configuration(cc).build();
+        assertEquals(DURABLE, lso.getDurable());
+        assertEquals(DURABLE, lso.getName());
 
         // new helper
-        ConsumerConfiguration.builder().durable(DURABLE).buildPullSubscribeOptions();
+        lso = ConsumerConfiguration.builder().durable(DURABLE).buildPullSubscribeOptions();
+        assertEquals(DURABLE, lso.getDurable());
+        assertEquals(DURABLE, lso.getName());
     }
 
     @Test

--- a/src/test/java/io/nats/client/SubscribeOptionsTests.java
+++ b/src/test/java/io/nats/client/SubscribeOptionsTests.java
@@ -259,23 +259,65 @@ public class SubscribeOptionsTests extends TestBase {
 
     @Test
     public void testBindCreationErrors() {
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.bind(null, DURABLE));
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.bind(EMPTY, DURABLE));
+        String durOrName = name();
+
+        // bind
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.bind(null, durOrName));
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.bind(EMPTY, durOrName));
         assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.bind(STREAM, null));
         assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.bind(STREAM, EMPTY));
         assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).bind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).durable(DURABLE).bind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().durable(DURABLE).bind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).durable(durOrName).bind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().durable(durOrName).bind(true).build());
         assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).durable(EMPTY).bind(true).build());
 
-        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.bind(null, DURABLE));
-        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.bind(EMPTY, DURABLE));
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).name(durOrName).bind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().name(durOrName).bind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).name(EMPTY).bind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.bind(null, durOrName));
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.bind(EMPTY, durOrName));
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.bind(STREAM, null));
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.bind(STREAM, EMPTY));
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).bind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(EMPTY).durable(DURABLE).bind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().durable(DURABLE).bind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(EMPTY).durable(durOrName).bind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().durable(durOrName).bind(true).build());
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).durable(EMPTY).bind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(EMPTY).name(durOrName).bind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().name(durOrName).bind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).name(EMPTY).bind(true).build());
+
+        // fast bind
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(null, durOrName));
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(EMPTY, durOrName));
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(STREAM, null));
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(STREAM, EMPTY));
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).fastBind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).durable(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().durable(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).durable(EMPTY).fastBind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).name(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().name(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).name(EMPTY).fastBind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(null, durOrName));
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(EMPTY, durOrName));
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(STREAM, null));
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(STREAM, EMPTY));
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).fastBind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(EMPTY).durable(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().durable(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).durable(EMPTY).fastBind(true).build());
+
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(EMPTY).name(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().name(durOrName).fastBind(true).build());
+        assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).name(EMPTY).fastBind(true).build());
     }
 
     @Test

--- a/src/test/java/io/nats/client/SubscribeOptionsTests.java
+++ b/src/test/java/io/nats/client/SubscribeOptionsTests.java
@@ -291,20 +291,6 @@ public class SubscribeOptionsTests extends TestBase {
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.builder().stream(STREAM).name(EMPTY).bind(true).build());
 
         // fast bind
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(null, durOrName));
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(EMPTY, durOrName));
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(STREAM, null));
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.fastBind(STREAM, EMPTY));
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).fastBind(true).build());
-
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).durable(durOrName).fastBind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().durable(durOrName).fastBind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).durable(EMPTY).fastBind(true).build());
-
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(EMPTY).name(durOrName).fastBind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().name(durOrName).fastBind(true).build());
-        assertThrows(IllegalArgumentException.class, () -> PushSubscribeOptions.builder().stream(STREAM).name(EMPTY).fastBind(true).build());
-
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(null, durOrName));
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(EMPTY, durOrName));
         assertThrows(IllegalArgumentException.class, () -> PullSubscribeOptions.fastBind(STREAM, null));


### PR DESCRIPTION
Currently bind, although reducing the need to lookup the stream for the subject still does a consumer info. This is not required for pull.

Fast bind was added to fix this while not changing the current behavior.