### PR TITLE
Construct Options builder from properties file for user.

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -23,11 +23,14 @@ import io.nats.client.support.SSLUtils;
 
 import javax.net.ssl.SSLContext;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.CharBuffer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -694,16 +697,21 @@ public class Options {
         // ----------------------------------------------------------------------------------------------------
         /**
          * Constructs a new {@code Builder} from a {@link Properties} object.
-         *
-         * <p>If {@link Options#PROP_SECURE PROP_SECURE} is set, the builder will
-         * try to get the default context{@link SSLContext#getDefault() getDefault()}.
-         * If a context can't be found, no context is set and an IllegalArgumentException is thrown.</p>
-         *
          * <p>Methods called on the builder after construction can override the properties.</p>
-         *
          * @param props the {@link Properties} object
          */
         public Builder(Properties props) throws IllegalArgumentException {
+            properties(props);
+        }
+
+        /**
+         * Constructs a new {@code Builder} from a file that contains properties.
+         * @param propertiesFilePath a resolvable path to a file from the location the application is running, either relative or absolute
+         * @throws IOException if the properties file cannot be found, opened or read
+         */
+        public Builder(String propertiesFilePath) throws IOException {
+            Properties props = new Properties();
+            props.load(Files.newInputStream(Paths.get(propertiesFilePath)));
             properties(props);
         }
 

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -26,6 +26,10 @@ import io.nats.client.utils.ResourceUtils;
 import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -418,6 +422,11 @@ public class OptionsTests {
         o = new Options.Builder(props).build();
         _testProperties(o);
 
+        String propertiesFilePath = createTempPropertiesFile(props);
+        System.out.println(propertiesFilePath);
+        o = new Options.Builder(propertiesFilePath).build();
+        _testProperties(o);
+
         // intGtEqZeroProperty not gt zero gives default
         props.setProperty(Options.PROP_MAX_MESSAGES_IN_OUTGOING_QUEUE, "-1");
         o = new Options.Builder(props).build();
@@ -435,6 +444,17 @@ public class OptionsTests {
             .properties(props)
             .build();
         assertEquals(500, o.getMaxMessagesInOutgoingQueue());
+    }
+
+    public static String createTempPropertiesFile(Properties props) throws IOException {
+        File f = File.createTempFile("jnats", ".properties");
+        BufferedWriter writer = new BufferedWriter(new FileWriter(f));
+        for (String key : props.stringPropertyNames()) {
+            writer.write(key + "=" + props.getProperty(key) + System.lineSeparator());
+        }
+        writer.flush();
+        writer.close();
+        return f.getAbsolutePath();
     }
 
     private static void _testProperties(Options o) {


### PR DESCRIPTION
Developer used to have to load the properties file themselves. Now they can just supply the file path and the Options builder will do it for them.