### PR TITLE
Fix: duplicate message for Interest stream fails seq check in PublishAck

### DIFF
--- a/src/main/java/io/nats/client/api/PublishAck.java
+++ b/src/main/java/io/nats/client/api/PublishAck.java
@@ -44,8 +44,8 @@ public class PublishAck extends ApiResponse<PublishAck> {
         if (stream == null) {
             throw new IOException("Invalid JetStream ack.");
         }
-        seq = JsonValueUtils.readLong(jv, SEQ, 0);
-        if (seq == 0) {
+        seq = JsonValueUtils.readLong(jv, SEQ, -1);
+        if (seq < 0) {
             throw new IOException("Invalid JetStream ack.");
         }
         domain = JsonValueUtils.readString(jv, DOMAIN);

--- a/src/test/java/io/nats/client/api/PublishAckTests.java
+++ b/src/test/java/io/nats/client/api/PublishAckTests.java
@@ -39,6 +39,22 @@ public class PublishAckTests {
     }
 
     @Test
+    public void testValidAckForDuplicateWithSeq0() {
+        String json = "{\"stream\":\"test-stream\",\"seq\":0,\"domain\":\"test-domain\", \"duplicate\" : true }";
+
+        try {
+            PublishAck ack = new PublishAck(getDataMessage(json));
+            assertEquals("test-stream", ack.getStream());
+            assertEquals("test-domain", ack.getDomain());
+            assertEquals(0, ack.getSeqno());
+            assertTrue(ack.isDuplicate());
+        }
+        catch (Exception e) {
+            fail("Unexpected Exception: " + e.getMessage());
+        }
+    }
+
+    @Test
     public void testThrowsOnGarbage() {
         assertThrows(JetStreamApiException.class, () -> {
             new PublishAck(getDataMessage("notjson"));


### PR DESCRIPTION
Potential fix for: https://github.com/nats-io/nats.java/issues/1002

Duplicate messages for Interest-based streams are immediately returned by the server with a `seq: 0` if there is no interest, which would error in `PublishAck`.