### PR TITLE
Initialize SocketDataPort directly

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -1806,6 +1806,9 @@ public class Options {
      * @return the data port described by these options
      */
     public DataPort buildDataPort() {
+        if (dataPortType.equals(DEFAULT_DATA_PORT_TYPE)) {
+            return new SocketDataPort();
+        }
         return (DataPort) Options.createInstanceOf(dataPortType);
     }
 


### PR DESCRIPTION
Initialize SocketDataPort directly when dataPortType is not overridden. Better for GraalVM