### PR TITLE
Support StreamConfiguration creation from JSON

### DIFF
--- a/src/main/java/io/nats/client/api/StreamConfiguration.java
+++ b/src/main/java/io/nats/client/api/StreamConfiguration.java
@@ -13,9 +13,7 @@
 
 package io.nats.client.api;
 
-import io.nats.client.support.JsonSerializable;
-import io.nats.client.support.JsonUtils;
-import io.nats.client.support.JsonValue;
+import io.nats.client.support.*;
 
 import java.time.Duration;
 import java.util.*;
@@ -144,8 +142,22 @@ public class StreamConfiguration implements JsonSerializable {
     }
 
     /**
+     * Returns a StreamConfiguration deserialized from its JSON form.
+     *
+     * @see #toJson()
+     * @param json
+     * @return StreamConfiguration for the given json
+     * @throws JsonParseException
+     */
+    public static StreamConfiguration instance(String json) throws JsonParseException {
+        JsonValue parsedJson = JsonParser.parse(json);
+        return instance(parsedJson);
+    }
+
+    /**
      * Returns a JSON representation of this consumer configuration.
-     * 
+     *
+     * @see #instance(String)
      * @return json consumer configuration to send to the server.
      */
     public String toJson() {

--- a/src/main/java/io/nats/client/api/StreamConfiguration.java
+++ b/src/main/java/io/nats/client/api/StreamConfiguration.java
@@ -150,14 +150,12 @@ public class StreamConfiguration implements JsonSerializable {
      * @throws JsonParseException
      */
     public static StreamConfiguration instance(String json) throws JsonParseException {
-        JsonValue parsedJson = JsonParser.parse(json);
-        return instance(parsedJson);
+        return instance(JsonParser.parse(json));
     }
 
     /**
      * Returns a JSON representation of this consumer configuration.
      *
-     * @see #instance(String)
      * @return json consumer configuration to send to the server.
      */
     public String toJson() {

--- a/src/test/java/io/nats/client/api/StreamConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/StreamConfigurationTests.java
@@ -124,7 +124,8 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
         String originalJson = ResourceUtils.dataAsString("StreamConfiguration.json");
 
-
+        // Loops through each field in the StreamConfiguration JSON format and ensures that the
+        // StreamConfiguration can be built without that field being present in the JSON
         for (String streamConfigFieldName: streamConfigFields) {
             JsonValue originalParsedJson = JsonParser.parse(originalJson);
             originalParsedJson.map.remove(streamConfigFieldName);
@@ -138,13 +139,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
         String originalJson = ResourceUtils.dataAsString("StreamConfiguration.json");
         JsonValue originalParsedJson = JsonParser.parse(originalJson);
         originalParsedJson.map.put(NAME, new JsonValue("Inavlid*Name"));
-        assertThrows(IllegalArgumentException.class,
-                new Executable() {
-                    @Override
-                    public void execute() throws Throwable {
-                        StreamConfiguration.instance(originalParsedJson.toJson());
-                    }
-                });
+        assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.instance(originalParsedJson.toJson()));
     }
 
     @Test


### PR DESCRIPTION
This commit adds a public method to StreamConfiguration that allows hydrating a StreamConfiguration via a JSON String. Previously this was only package scoped and used in tests.