### PR TITLE
Update jnats-server-runner to 1.2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ repositories {
 dependencies {
     implementation 'net.i2p.crypto:eddsa:0.3.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
-    testImplementation 'io.nats:jnats-server-runner:1.2.5'
+    testImplementation 'io.nats:jnats-server-runner:1.2.6'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.12.3'
 }
 


### PR DESCRIPTION
jnats-server-runner 1.2.6 has better output when server fails to run during unit testing.