### PR TITLE
Enable secure websocket connection behind TLS-terminating reverse proxy

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -569,7 +569,7 @@ class NatsConnection implements Connection {
                 }
                 upgradeRequired = false;
             }
-            if (isTLSRequired && !serverInfo.isTLSRequired()) {
+            if (isTLSRequired && upgradeRequired && !serverInfo.isTLSRequired()) {
                 throw new IOException("SSL connection wanted by client.");
             }
             else if (!isTLSRequired && serverInfo.isTLSRequired()) {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -569,7 +569,7 @@ class NatsConnection implements Connection {
                 }
                 upgradeRequired = false;
             }
-            if (isTLSRequired && upgradeRequired && !serverInfo.isTLSRequired()) {
+            if (upgradeRequired && !serverInfo.isTLSRequired()) {
                 throw new IOException("SSL connection wanted by client.");
             }
             else if (!isTLSRequired && serverInfo.isTLSRequired()) {


### PR DESCRIPTION
In reverse proxy environment that supports TLS-terminating(ex. AWS ELB) wss:// connection throws `IOException("SSL connection wanted by client.")`

This should only checked when using TLS not websocket