### PR TITLE
Added data validation support while pub/sub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'signing'
 }
 
-def jarVersion = "2.17.2"
+def jarVersion = "2.17.3"
 
 def isRelease = System.getenv("BUILD_EVENT") == "release"
 def bs = System.getenv("BRANCH_SNAPSHOT")
@@ -37,6 +37,7 @@ repositories {
 
 dependencies {
     implementation 'net.i2p.crypto:eddsa:0.3.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.1'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:1.2.8'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.12.3'

--- a/src/main/java/io/nats/client/Deserializer.java
+++ b/src/main/java/io/nats/client/Deserializer.java
@@ -1,0 +1,36 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package io.nats.client;
+
+import io.nats.client.impl.Headers;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+
+public interface Deserializer extends Closeable, Serializable {
+
+    default void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    byte[] decode(String var1, byte[] var2) throws IOException;
+
+    default byte[] decode(String topic, Headers headers, byte[] data) throws IOException {
+        return this.decode(topic, data);
+    }
+
+    default void close() throws IOException{
+    }
+}

--- a/src/main/java/io/nats/client/PublishOptions.java
+++ b/src/main/java/io/nats/client/PublishOptions.java
@@ -45,8 +45,9 @@ public class PublishOptions {
     private final long expectedLastSeq;
     private final long expectedLastSubSeq;
     private final String msgId;
+    private final Serializer serializer;
 
-    private PublishOptions(String stream, Duration streamTimeout, String expectedStream, String expectedLastId, long expectedLastSeq, long expectedLastSubSeq, String msgId) {
+    private PublishOptions(String stream, Duration streamTimeout, String expectedStream, String expectedLastId, long expectedLastSeq, long expectedLastSubSeq, String msgId, Serializer serializer) {
         this.stream = stream;
         this.streamTimeout = streamTimeout;
         this.expectedStream = expectedStream;
@@ -54,6 +55,7 @@ public class PublishOptions {
         this.expectedLastSeq = expectedLastSeq;
         this.expectedLastSubSeq = expectedLastSubSeq;
         this.msgId = msgId;
+        this.serializer = serializer;
     }
 
     /**
@@ -114,6 +116,9 @@ public class PublishOptions {
         return expectedLastSubSeq;
     }
 
+    public Serializer getSerializer() { return this.serializer; }
+
+
     /**
      * Gets the message ID
      * @return the message id;
@@ -144,6 +149,7 @@ public class PublishOptions {
         long expectedLastSeq = UNSET_LAST_SEQUENCE;
         long expectedLastSubSeq = UNSET_LAST_SEQUENCE;
         String msgId;
+        Serializer serializer;
 
         /**
          * Constructs a new publish options Builder with the default values.
@@ -254,12 +260,17 @@ public class PublishOptions {
             return this;
         }
 
+        public Builder serializer(Serializer serializer) {
+            this.serializer = serializer;
+            return this;
+        }
+
         /**
          * Builds the publish options.
          * @return publish options
          */
         public PublishOptions build() {
-            return new PublishOptions(stream, streamTimeout, expectedStream, expectedLastId, expectedLastSeq, expectedLastSubSeq, msgId);
+            return new PublishOptions(stream, streamTimeout, expectedStream, expectedLastId, expectedLastSeq, expectedLastSubSeq, msgId, serializer);
         }
     }
 }

--- a/src/main/java/io/nats/client/Serializer.java
+++ b/src/main/java/io/nats/client/Serializer.java
@@ -1,0 +1,32 @@
+// Copyright 2020 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package io.nats.client;
+
+import io.nats.client.impl.Headers;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+
+public interface Serializer extends Closeable, Serializable{
+
+    byte[] encode(String subject, byte[] message) throws IOException;
+
+    default byte[] encode(String subject, Headers headers, byte[] message) throws IOException {
+        return encode(subject, message);
+    }
+
+    default void close() throws IOException{
+    }
+}

--- a/src/main/java/io/nats/client/SubscribeOptions.java
+++ b/src/main/java/io/nats/client/SubscribeOptions.java
@@ -37,6 +37,7 @@ public abstract class SubscribeOptions {
     protected final long pendingMessageLimit; // Only applicable for non dispatched (sync) push consumers.
     protected final long pendingByteLimit; // Only applicable for non dispatched (sync) push consumers.
     protected final String name;
+    protected Deserializer deserializer;
 
     @SuppressWarnings("rawtypes") // Don't need the type of the builder to get its vars
     protected SubscribeOptions(Builder builder, boolean isPull,
@@ -134,6 +135,10 @@ public abstract class SubscribeOptions {
                 .deliverGroup(deliverGroup)
                 .build();
         }
+        
+        if(builder.deserializer != null) {
+            this.deserializer = builder.deserializer;
+        }
     }
 
     /**
@@ -226,6 +231,8 @@ public abstract class SubscribeOptions {
         return pendingByteLimit;
     }
 
+    public Deserializer getDeserializer() { return deserializer; };
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{" +
@@ -253,6 +260,8 @@ public abstract class SubscribeOptions {
         protected ConsumerConfiguration cc;
         protected long messageAlarmTime = -1;
         protected boolean ordered;
+        protected Deserializer deserializer;
+
 
         protected abstract B getThis();
 
@@ -331,5 +340,10 @@ public abstract class SubscribeOptions {
          * @return subscribe options
          */
         public abstract SO build();
+
+        public B deserializer(Deserializer deserializer) {
+            this.deserializer = deserializer;
+            return getThis();
+        }
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumer.java
@@ -14,6 +14,7 @@
 package io.nats.client.impl;
 
 import io.nats.client.Consumer;
+import io.nats.client.Deserializer;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -32,6 +33,7 @@ abstract class NatsConsumer implements Consumer {
     private final AtomicLong messagesDelivered;
     private final AtomicBoolean slow;
     private final AtomicReference<CompletableFuture<Boolean>> drainingFuture;
+    private Deserializer deserializer;
 
     NatsConsumer(NatsConnection conn) {
         this.connection = conn;
@@ -251,4 +253,12 @@ abstract class NatsConsumer implements Consumer {
      * Abstract method, called by the connection when the drain is complete.
      */
     abstract void cleanUpAfterDrain();
+
+    public void setDeserializer(Deserializer deserializer){
+        this.deserializer = deserializer;
+    }
+
+    public Deserializer getDeserializer() {
+        return deserializer;
+    }
 }

--- a/src/main/java/io/nats/client/impl/NatsJetStreamPullSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamPullSubscription.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import io.nats.client.Deserializer;
 
 public class NatsJetStreamPullSubscription extends NatsJetStreamSubscription {
 
@@ -35,6 +36,15 @@ public class NatsJetStreamPullSubscription extends NatsJetStreamSubscription {
                                   MessageManager manager) {
         super(sid, subject, null, connection, dispatcher, js, stream, consumer, manager);
         pullSubjectIdHolder = new AtomicLong();
+    }
+
+    NatsJetStreamPullSubscription(String sid, String subject,
+                                  NatsConnection connection, NatsDispatcher dispatcher,
+                                  NatsJetStream js,
+                                  String stream, String consumer,
+                                  MessageManager manager, Deserializer deserializer) {
+        this(sid,subject, connection, dispatcher, js, stream, consumer, manager);
+        setDeserializer(deserializer);
     }
 
     @Override

--- a/src/main/java/io/nats/client/impl/NatsSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsSubscription.java
@@ -18,6 +18,7 @@ import io.nats.client.Message;
 import io.nats.client.MessageHandler;
 import io.nats.client.Subscription;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
@@ -166,6 +167,15 @@ class NatsSubscription extends NatsConsumer implements Subscription {
 
         if (this.reachedUnsubLimit()) {
             this.connection.invalidate(this);
+        }
+
+        if(getDeserializer() != null) {
+            try{
+                byte[] data = getDeserializer().decode(subject, msg.data);
+                msg.data = data;
+            }catch(IOException e){
+                throw new IllegalStateException("Unable to decode data", e);
+            }
         }
 
         return msg;


### PR DESCRIPTION
The objective of this PR is to integrate client-initiated data validation within the message publishing or subscribing workflow. It's important to note that I have conducted testing exclusively with JSON Schema at this stage. Raising this PR as an initial draft, I seek early feedback and welcome any constructive suggestions for enhancement.