### PR TITLE
Add SLF4J Simple Logging Facade 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,12 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.slf4j:slf4j-api:2.0.12'
     implementation 'net.i2p.crypto:eddsa:0.3.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:1.2.8'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.12.3'
+    testImplementation 'org.slf4j:slf4j-simple:2.0.12'
 }
 
 sourceSets {

--- a/dependencies.md
+++ b/dependencies.md
@@ -11,27 +11,28 @@ This file lists the dependencies used in this repository.
 
 #### Runtime Dependencies
 
-| Dependency                           | License                                 |
-|--------------------------------------|-----------------------------------------|
-| net.i2p.crypto:eddsa:0.3.0           | CC 1.0 Universal                        |
+| Dependency                 | License          |
+|----------------------------|------------------|
+| net.i2p.crypto:eddsa:0.3.0 | CC 1.0 Universal |
+| org.slf4j:slf4j-api:2.0.12 | MIT License      |
 
 #### Test Dependencies
 
-| Dependency                                      | License                                 |
-|-------------------------------------------------|-----------------------------------------|
-| io.nats:jnats-server-runner:1.2.5               | Apache 2.0 License                      |
-| org.apiguardian:apiguardian-api:1.1.0           | Apache 2.0 License                      |
-| org.junit.jupiter:junit-jupiter:5.9.0           | Eclipse Public License v2.0             |
-| org.junit:junit-bom:5.9.0                       | Eclipse Public License v2.0             |
-| org.junit.jupiter:junit-jupiter:5.9.0           | Eclipse Public License v2.0             |
-| org.junit.jupiter:junit-jupiter-api:5.9.0       | Eclipse Public License v2.0             |
-| org.junit.jupiter:junit-jupiter-api:5.9.0       | Eclipse Public License v2.0             |
-| org.junit.jupiter:junit-jupiter-engine:5.9.0    | Eclipse Public License v2.0             |
-| org.junit.jupiter:junit-jupiter-params:5.9.0    | Eclipse Public License v2.0             |
-| org.junit.platform:junit-platform-commons:1.9.0 | Eclipse Public License v2.0             |
-| org.junit.platform:junit-platform-engine:1.9.0  | Eclipse Public License v2.0             |
-| org.opentest4j:opentest4j:1.2.0                 | Apache 2.0 License                      |
-
+| Dependency                                      | License                     |
+|-------------------------------------------------|-----------------------------|
+| io.nats:jnats-server-runner:1.2.5               | Apache 2.0 License          |
+| org.apiguardian:apiguardian-api:1.1.0           | Apache 2.0 License          |
+| org.junit.jupiter:junit-jupiter:5.9.0           | Eclipse Public License v2.0 |
+| org.junit:junit-bom:5.9.0                       | Eclipse Public License v2.0 |
+| org.junit.jupiter:junit-jupiter:5.9.0           | Eclipse Public License v2.0 |
+| org.junit.jupiter:junit-jupiter-api:5.9.0       | Eclipse Public License v2.0 |
+| org.junit.jupiter:junit-jupiter-api:5.9.0       | Eclipse Public License v2.0 |
+| org.junit.jupiter:junit-jupiter-engine:5.9.0    | Eclipse Public License v2.0 |
+| org.junit.jupiter:junit-jupiter-params:5.9.0    | Eclipse Public License v2.0 |
+| org.junit.platform:junit-platform-commons:1.9.0 | Eclipse Public License v2.0 |
+| org.junit.platform:junit-platform-engine:1.9.0  | Eclipse Public License v2.0 |
+| org.opentest4j:opentest4j:1.2.0                 | Apache 2.0 License          |
+| org.slf4j:slf4j-simple:2.0.12                   | MIT License                 |
 #### Build / Coverage Dependencies
 
 | Dependency                         | License                                 |

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -1990,13 +1990,6 @@ public class Options {
     }
 
     /**
-     * @return should we trace the connection process to system.out
-     */
-    public boolean isTraceConnection() {
-        return traceConnection;
-    }
-
-    /**
      * @return the maximum length of a control line, see {@link Builder#maxControlLine(int) maxControlLine()} in the builder doc
      */
     public int getMaxControlLine() {

--- a/src/main/java/io/nats/client/impl/ErrorListenerLoggerImpl.java
+++ b/src/main/java/io/nats/client/impl/ErrorListenerLoggerImpl.java
@@ -14,45 +14,20 @@
 package io.nats.client.impl;
 
 import io.nats.client.*;
-import io.nats.client.api.ServerInfo;
 import io.nats.client.support.Status;
-
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ErrorListenerLoggerImpl implements ErrorListener {
 
-    private final static Logger LOGGER = Logger.getLogger(ErrorListenerLoggerImpl.class.getName());
-
-    private String supplyMessage(String label, Connection conn, Consumer consumer, Subscription sub, Object... pairs) {
-        StringBuilder sb = new StringBuilder(label);
-        if (conn != null) {
-            ServerInfo si = conn.getServerInfo();
-            if (si != null) {
-                sb.append(", Connection: ").append(conn.getServerInfo().getClientId());
-            }
-        }
-        if (consumer != null) {
-            sb.append(", Consumer: ").append(consumer.hashCode());
-        }
-        if (sub != null) {
-            sb.append(", Subscription: ").append(sub.hashCode());
-            if (sub instanceof JetStreamSubscription) {
-                JetStreamSubscription jssub = (JetStreamSubscription)sub;
-                sb.append(", Consumer Name: ").append(jssub.getConsumerName());
-            }
-        }
-        for (int x = 0; x < pairs.length; x++) {
-            sb.append(", ").append(pairs[x]).append(pairs[++x]);
-        }
-        return sb.toString();
-    }
+    private final static Logger LOG = LoggerFactory.getLogger(ErrorListenerLoggerImpl.class);
 
     /**
      * {@inheritDoc}
      */
     @Override
     public void errorOccurred(final Connection conn, final String error) {
-        LOGGER.severe(() -> supplyMessage("errorOccurred", conn, null, null, "Error: ", error));
+        LOG.error("errorOccurred for connection [{}] with error: [{}]", conn, error);
     }
 
     /**
@@ -60,7 +35,7 @@ public class ErrorListenerLoggerImpl implements ErrorListener {
      */
     @Override
     public void exceptionOccurred(final Connection conn, final Exception exp) {
-        LOGGER.severe(() -> supplyMessage("exceptionOccurred", conn, null, null, "Exception: ", exp));
+        LOG.error("exceptionOccurred for connection [{}], Exception: ", conn, exp);
     }
 
     /**
@@ -68,7 +43,7 @@ public class ErrorListenerLoggerImpl implements ErrorListener {
      */
     @Override
     public void slowConsumerDetected(final Connection conn, final Consumer consumer) {
-        LOGGER.warning(() -> supplyMessage("slowConsumerDetected", conn, consumer, null));
+        LOG.warn("slowConsumerDetected for connection [{}] and consumer [{}]", conn, consumer != null ? consumer.hashCode() : "null");
     }
 
     /**
@@ -76,7 +51,7 @@ public class ErrorListenerLoggerImpl implements ErrorListener {
      */
     @Override
     public void messageDiscarded(final Connection conn, final Message msg) {
-        LOGGER.info(() -> supplyMessage("messageDiscarded", conn, null, null, "Message: ", msg));
+        LOG.info("messageDiscarded for connection [{}] and message [{}]", conn, msg);
     }
 
     /**
@@ -85,7 +60,8 @@ public class ErrorListenerLoggerImpl implements ErrorListener {
     @Override
     public void heartbeatAlarm(final Connection conn, final JetStreamSubscription sub,
                                final long lastStreamSequence, final long lastConsumerSequence) {
-        LOGGER.severe(() -> supplyMessage("heartbeatAlarm", conn, null, sub, "lastStreamSequence: ", lastStreamSequence, "lastConsumerSequence: ", lastConsumerSequence));
+        LOG.error("heartbeatAlarm for connection [{}] and subscription [{}], lastStreamSequence: [{}], lastConsumerSequence: [{}]",
+                conn, sub, lastStreamSequence, lastConsumerSequence);
     }
 
     /**
@@ -93,30 +69,30 @@ public class ErrorListenerLoggerImpl implements ErrorListener {
      */
     @Override
     public void unhandledStatus(final Connection conn, final JetStreamSubscription sub, final Status status) {
-        LOGGER.warning(() -> supplyMessage("unhandledStatus", conn, null, sub, "Status:", status));
+        LOG.warn("unhandledStatus for connection [{}] and subscription [{}], Status: [{}]", conn, sub, status);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void pullStatusWarning(Connection conn, JetStreamSubscription sub, Status status) {
-        LOGGER.warning(() -> supplyMessage("pullStatusWarning", conn, null, sub, "Status:", status));
+    public void pullStatusWarning(final Connection conn, final JetStreamSubscription sub, final Status status) {
+        LOG.warn("pullStatusWarning for connection [{}] and subscription [{}], Status: [{}]", conn, sub, status);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void pullStatusError(Connection conn, JetStreamSubscription sub, Status status) {
-        LOGGER.severe(() -> supplyMessage("pullStatusError", conn, null, sub, "Status:", status));
+    public void pullStatusError(final Connection conn, final JetStreamSubscription sub, final Status status) {
+        LOG.error("pullStatusError for connection [{}] and subscription [{}], Status: [{}]", conn, sub, status);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void flowControlProcessed(Connection conn, JetStreamSubscription sub, String id, FlowControlSource source) {
-        LOGGER.info(() -> supplyMessage("flowControlProcessed", conn, null, sub, "FlowControlSource:", source));
+    public void flowControlProcessed(final Connection conn, final JetStreamSubscription sub, final String id, final FlowControlSource source) {
+       LOG.info("flowControlProcessed for connection [{}] and subscription [{}], ID [{}], FlowControlSource: [{}]", conn, sub, id, source);
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -2247,4 +2247,11 @@ class NatsConnection implements Connection {
             throw new IOException("A JetStream context can't be established during close.");
         }
     }
+
+    @Override
+    public String toString() {
+        return "NatsConnection{" +
+                "ClientID='" + getServerInfo().getClientId() + "'" +
+                "}";
+    }
 }

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -14,6 +14,8 @@
 package io.nats.client.impl;
 
 import io.nats.client.support.IncomingHeadersProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -28,6 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static io.nats.client.support.NatsConstants.*;
 
 class NatsConnectionReader implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NatsConnectionReader.class);
 
     enum Mode {
         GATHER_OP,
@@ -157,6 +161,7 @@ class NatsConnectionReader implements Runnable {
                 }
             }
         } catch (IOException io) {
+            LOG.error("IO exception reading data: ", io);
             this.connection.handleCommunicationIssue(io);
         } catch (CancellationException | ExecutionException | InterruptedException ex) {
             // Exit

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -15,6 +15,8 @@ package io.nats.client.impl;
 
 import io.nats.client.Options;
 import io.nats.client.StatisticsCollector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.BufferOverflowException;
@@ -31,6 +33,7 @@ import static io.nats.client.support.BuilderBase.bufferAllocSize;
 import static io.nats.client.support.NatsConstants.*;
 
 class NatsConnectionWriter implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(NatsConnectionWriter.class);
     private static final int BUFFER_BLOCK_SIZE = 256;
 
     private final NatsConnection connection;
@@ -187,6 +190,7 @@ class NatsConnectionWriter implements Runnable {
                 sendMessageBatch(msg, dataPort, stats);
             }
         } catch (IOException | BufferOverflowException io) {
+            LOG.error("exception sending messages: ", io);
             this.connection.handleCommunicationIssue(io);
         } catch (CancellationException | ExecutionException | InterruptedException ex) {
             // Exit

--- a/src/main/java/io/nats/client/impl/NatsJetStreamSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamSubscription.java
@@ -289,6 +289,7 @@ public class NatsJetStreamSubscription extends NatsSubscription implements JetSt
                 "consumer='" + consumerName + '\'' +
                 ", stream='" + stream + '\'' +
                 ", deliver='" + getSubject() + '\'' +
+                ", hashCode='" + hashCode() + '\'' +
                 ", isPullMode=" + isPullMode() +
                 '}';
     }

--- a/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
@@ -15,6 +15,8 @@ package io.nats.client.impl;
 
 import io.nats.client.Options;
 import io.nats.client.support.NatsUri;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Timer;
@@ -24,7 +26,7 @@ import java.util.TimerTask;
  * This class is not thread-safe.  Caller must ensure thread safety.
  */
 public class SocketDataPortWithWriteTimeout extends SocketDataPort {
-
+    private static final Logger LOG = LoggerFactory.getLogger(SocketDataPortWithWriteTimeout.class);
     private long writeTimeoutNanos;
     private long delayPeriodMillis;
     private Timer writeWatcherTimer;
@@ -37,6 +39,8 @@ public class SocketDataPortWithWriteTimeout extends SocketDataPort {
             //  if now is after when it was supposed to be done by
             if (System.nanoTime() > writeMustBeDoneBy) {
                 try {
+                    LOG.warn("forcefully closing write socket as timeout [{}]msec expired [{}]",
+                            delayPeriodMillis, connection.getConnectedUrl());
                     connection.closeSocket(true);
                 }
                 catch (InterruptedException e) {

--- a/src/main/java/io/nats/client/support/JsonUtils.java
+++ b/src/main/java/io/nats/client/support/JsonUtils.java
@@ -14,6 +14,8 @@
 package io.nats.client.support;
 
 import io.nats.client.impl.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -36,6 +38,8 @@ import static io.nats.client.support.NatsConstants.COLON;
  * Read helpers deprecated Prefer using the {@link JsonParser}
  */
 public abstract class JsonUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class);
+
     public static final String EMPTY_JSON = "{}";
 
     private static final String STRING_RE  = "\"(.+?)\"";
@@ -493,8 +497,8 @@ public abstract class JsonUtils {
         return sb.toString();
     }
 
-    public static void printFormatted(Object o) {
-        System.out.println(getFormatted(o));
+    public static void printFormatted(final Object o) {
+        LOG.info("[{}]", getFormatted(o));
     }
 
     // ----------------------------------------------------------------------------------------------------

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,34 @@
+# SLF4J's SimpleLogger configuration file
+# Simple implementation of Logger that sends all enabled log messages, for all defined loggers, to System.err.
+
+# Default logging detail level for all instances of SimpleLogger.
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, defaults to "info".
+org.slf4j.simpleLogger.defaultLogLevel=trace
+
+# Logging detail level for a SimpleLogger instance named "xxxxx".
+# Must be one of ("trace", "debug", "info", "warn", or "error").
+# If not specified, the default logging detail level is used.
+#org.slf4j.simpleLogger.log.xxxxx=
+
+# Set to true if you want the current date and time to be included in output messages.
+# Default is false, and will output the number of milliseconds elapsed since startup.
+org.slf4j.simpleLogger.showDateTime=true
+
+# The date and time format to be used in the output messages.
+# The pattern describing the date and time format is the same that is used in java.text.SimpleDateFormat.
+# If the format is not specified or is invalid, the default format is used.
+# The default format is yyyy-MM-dd HH:mm:ss:SSS Z.
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+
+# Set to true if you want to output the current thread name.
+# Defaults to true.
+#org.slf4j.simpleLogger.showThreadName=true
+
+# Set to true if you want the Logger instance name to be included in output messages.
+# Defaults to true.
+#org.slf4j.simpleLogger.showLogName=true
+
+# Set to true if you want the last component of the name to be included in output messages.
+# Defaults to false.
+#org.slf4j.simpleLogger.showShortLogName=false


### PR DESCRIPTION
This a pull request to add SLF4J logging facade to NATS Java Library. 
This has a number of benefits: 

1. Consumers of the library can plug in their logging framework of choice and have all the NATS Java logs where they expect them to be
2. A lot of boilerplate code was removed by using SLF4J
3. I added a few logs, but not too many especially around areas where I would have expected some and where we had troubles with resulting in us extending NATS Java to get logs from that code points. E.g., DNS resolving.
4. I added simplelogger for testing so that there are no differences in daily usage for testing

Happy to receive your thought and feedback on this. 
Happy also to change things upon your input/request. 

@scottf THX in advance for taking the time to at least have a quick look at this PR. 
Let me know if there is anything I have to accept in terms of contribution agreements.