### PR TITLE
chore: upgrade documentation to specify backoff behaviour

### DIFF
--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -1166,6 +1166,7 @@ public class ConsumerConfiguration implements JsonSerializable {
 
         /**
          * Set the list of backoff. Will override ackwait setting.
+         * @see <a href="https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#delivery-reliability">Delivery Reliability</a>
          * @param backoffs zero or more backoff durations or an array of backoffs
          * @return Builder
          */
@@ -1194,6 +1195,7 @@ public class ConsumerConfiguration implements JsonSerializable {
 
         /**
          * Set the list of backoff. Will override ackwait setting.
+         * @see <a href="https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#delivery-reliability">Delivery Reliability</a>
          * @param backoffsMillis zero or more backoff in millis or an array of backoffsMillis
          * @return Builder
          */

--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -1165,7 +1165,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         }
 
         /**
-         * Set the list of backoff.
+         * Set the list of backoff. Will override ackwait setting.
          * @param backoffs zero or more backoff durations or an array of backoffs
          * @return Builder
          */
@@ -1193,7 +1193,7 @@ public class ConsumerConfiguration implements JsonSerializable {
         }
 
         /**
-         * Set the list of backoff.
+         * Set the list of backoff. Will override ackwait setting.
          * @param backoffsMillis zero or more backoff in millis or an array of backoffsMillis
          * @return Builder
          */


### PR DESCRIPTION
Hi there 👋

Just stumbled upon an issue setting both ackwait and backoff in the consumer configuration. 

As per the [documentation ](https://docs.nats.io/using-nats/developer/develop_jetstream/consumers#delivery-reliability):
> You can control the timing of re-deliveries using either the single AckWait duration attribute of the consumer, or as a sequence of durations in the BackOff attribute (which overrides AckWait).

Backoff will override AckWait, I thought it would be great to specify this in the javadoc.
I think it's also worth logging an error at runtime when both are set but I'm not sure where to plug this ?

Let me know if you want me to do any change