### PR TITLE
Fix reconnect() calls close() when simultaneously 'disconnecting' in another thread

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -614,7 +614,7 @@ class NatsConnection implements Connection {
     // Close is called when the connection should shutdown, period
     void closeSocket(boolean tryReconnectIfConnected) throws InterruptedException {
         // Ensure we close the socket exclusively within one thread.
-//        closeSocketLock.lock();
+        closeSocketLock.lock();
 
         try {
             boolean wasConnected;
@@ -651,7 +651,7 @@ class NatsConnection implements Connection {
                 reconnect();
             }
         } finally {
-//            closeSocketLock.unlock();
+            closeSocketLock.unlock();
         }
     }
 

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -289,7 +289,7 @@ class NatsConnection implements Connection {
                     }
                     else {
                         connectError.set(""); // reset on each loop
-                        if (isDisconnectingOrClosed() || this.isClosing()) {
+                        if (this.isClosed() || this.isClosing()) {
                             keepGoing = false;
                         }
                         else {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -614,7 +614,7 @@ class NatsConnection implements Connection {
     // Close is called when the connection should shutdown, period
     void closeSocket(boolean tryReconnectIfConnected) throws InterruptedException {
         // Ensure we close the socket exclusively within one thread.
-        closeSocketLock.lock();
+//        closeSocketLock.lock();
 
         try {
             boolean wasConnected;
@@ -651,7 +651,7 @@ class NatsConnection implements Connection {
                 reconnect();
             }
         } finally {
-            closeSocketLock.unlock();
+//            closeSocketLock.unlock();
         }
     }
 

--- a/src/test/java/io/nats/client/impl/AuthAndConnectTests.java
+++ b/src/test/java/io/nats/client/impl/AuthAndConnectTests.java
@@ -75,25 +75,11 @@ public class AuthAndConnectTests {
             ts.shutdown(true);
 
             final AtomicBoolean running = new AtomicBoolean(true);
-            Thread closeSocketThread = new Thread(() -> {
-                try {
-                    nc.closeSocket(true);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-
             Thread parallelCommunicationIssues = new Thread(() -> {
                 while (running.get()) {
                     nc.handleCommunicationIssue(new Exception());
                 }
             });
-
-            closeSocketThread.start();
-
-            // Ensure the closeSocket thread runs first
-            Thread.sleep(100);
-
             parallelCommunicationIssues.start();
 
             // Wait for some time to allow for reconnection logic to run.

--- a/src/test/java/io/nats/client/impl/AuthAndConnectTests.java
+++ b/src/test/java/io/nats/client/impl/AuthAndConnectTests.java
@@ -15,10 +15,16 @@ package io.nats.client.impl;
 
 import io.nats.client.Connection;
 import io.nats.client.NatsTestServer;
+import io.nats.client.Options;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import static io.nats.client.utils.TestBase.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AuthAndConnectTests {
@@ -48,6 +54,53 @@ public class AuthAndConnectTests {
             assertClosed(nc);
             nc.reconnect(); // should do nothing
             assertClosed(nc);
+        }
+    }
+
+    /**
+     * Simulates an issue where {@link NatsConnection#closeSocket} is simultaneously called from multiple threads,
+     * and the {@link NatsConnection#reconnect} closes the connection due to overwriting the disconnecting state.
+     */
+    @RepeatedTest(5)
+    public void testNoCloseOnSimultaneouslyClosingSocket() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer(false)) {
+            Options options = Options.builder()
+                    .server(ts.getURI())
+                    .maxReconnects(-1)
+                    .build();
+
+            NatsConnection nc = (NatsConnection) standardConnection(options);
+
+            // After we've connected, shut down, so we can attempt reconnecting.
+            ts.shutdown(true);
+
+            final AtomicBoolean running = new AtomicBoolean(true);
+            Thread closeSocketThread = new Thread(() -> {
+                try {
+                    nc.closeSocket(true);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            Thread parallelCommunicationIssues = new Thread(() -> {
+                while (running.get()) {
+                    nc.handleCommunicationIssue(new Exception());
+                }
+            });
+
+            closeSocketThread.start();
+
+            // Ensure the closeSocket thread runs first
+            Thread.sleep(100);
+
+            parallelCommunicationIssues.start();
+
+            // Wait for some time to allow for reconnection logic to run.
+            Thread.sleep(2000);
+            running.set(false);
+
+            assertNotEquals(Connection.Status.CLOSED, nc.getStatus());
         }
     }
 }


### PR DESCRIPTION
In the unlikely but possible scenario where the reader/writer threads would call into `handleCommunicationIssue` twice, `disconnecting` could be set by the other thread just before going into `reconnect()`.

This would cause these lines to exit the reconnecting loop:
```java
if (isDisconnectingOrClosed() || this.isClosing()) {
    keepGoing = false;
}
```

Which would then call into `close()` here:
```java
if (!isConnected()) {
    this.close();
    return;
}
```

This PR fixes that by not checking the `disconnected` flag, instead checking `isClosed() || isClosing()` as it was [before this commit](https://github.com/nats-io/nats.java/commit/c4d50b2e30c13164dd08a59d3a2d7a936040e8aa#diff-bbcf614ee7ee4ccd15b22d1f95fa40e4e642098386b6d1d14127dab5968d89feR204).

Related to issue reported on Slack: https://natsio.slack.com/archives/C1KU01HD2/p1708455358962679