### PR TITLE
Revert NKey class extraction to ensure no backward compatibility issues.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ repositories {
 
 dependencies {
     implementation 'net.i2p.crypto:eddsa:0.3.0'
-    implementation 'io.nats:nkeys-java:2.0.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:1.2.8'
@@ -163,7 +162,7 @@ jacocoTestReport {
     afterEvaluate { // only report on main library not examples
         classDirectories.setFrom(files(classDirectories.files.collect {
             fileTree(dir: it,
-                    exclude: ['**/examples**', '**/test**'])
+                    exclude: ['**/examples**'])
         }))
     }
 }

--- a/src/examples/java/io/nats/examples/ExampleAuthHandler.java
+++ b/src/examples/java/io/nats/examples/ExampleAuthHandler.java
@@ -14,7 +14,7 @@
 package io.nats.examples;
 
 import io.nats.client.AuthHandler;
-import io.nats.nkey.NKey;
+import io.nats.client.NKey;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/src/main/java/io/nats/client/NKey.java
+++ b/src/main/java/io/nats/client/NKey.java
@@ -16,6 +16,8 @@ package io.nats.client;
 import net.i2p.crypto.eddsa.EdDSAEngine;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveSpec;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
 import net.i2p.crypto.eddsa.spec.EdDSAPrivateKeySpec;
 import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
 
@@ -30,7 +32,6 @@ import static io.nats.client.support.Encoding.base32Decode;
 import static io.nats.client.support.Encoding.base32Encode;
 import static io.nats.client.support.RandomUtils.PRAND;
 import static io.nats.client.support.RandomUtils.SRAND;
-import static io.nats.nkey.NKeyConstants.*;
 
 class DecodedSeed {
     int prefix;
@@ -38,8 +39,6 @@ class DecodedSeed {
 }
 
 /**
- * @deprecated This class has been extracted to the <a href="https://github.com/nats-io/nkeys.java">nkeys.java</a> library.
- * It is left here for full backward compatibility.
  * <p>
  * The NATS ecosystem will be moving to Ed25519 keys for identity,
  * authentication and authorization for entities such as Accounts, Users,
@@ -79,7 +78,7 @@ class DecodedSeed {
  * <p>
  * The NKey libraries have support for exporting a 64 byte private key. This
  * data is encoded into a string starting with the prefix ‘P’ for private. The
- * 64 bytes in a private key consists of the 32 bytes of the seed followed by 
+ * 64 bytes in a private key consists of the 32 bytes of the seed followed by
  * he 32 bytes of the public key. Essentially, the private key is redundant sin
  * e you can get it back from the seed alone. The NATS team recommends sto
  * ing the 32 byte seed and letting the NKey library regenerate anything els
@@ -105,7 +104,6 @@ class DecodedSeed {
  * so we are making the change on a minor jump.
  * </p>
  */
-@Deprecated
 public class NKey {
 
     /**
@@ -152,11 +150,59 @@ public class NKey {
         }
     }
 
+    // PrefixByteSeed is the prefix byte used for encoded NATS Seeds
+    private static final int PREFIX_BYTE_SEED = 18 << 3; // Base32-encodes to 'S...'
+
+    // PrefixBytePrivate is the prefix byte used for encoded NATS Private keys
+    static final int PREFIX_BYTE_PRIVATE = 15 << 3; // Base32-encodes to 'P...'
+
+    // PrefixByteServer is the prefix byte used for encoded NATS Servers
+    static final int PREFIX_BYTE_SERVER = 13 << 3; // Base32-encodes to 'N...'
+
+    // PrefixByteCluster is the prefix byte used for encoded NATS Clusters
+    static final int PREFIX_BYTE_CLUSTER = 2 << 3; // Base32-encodes to 'C...'
+
+    // PrefixByteAccount is the prefix byte used for encoded NATS Accounts
+    static final int PREFIX_BYTE_ACCOUNT = 0; // Base32-encodes to 'A...'
+
+    // PrefixByteUser is the prefix byte used for encoded NATS Users
+    static final int PREFIX_BYTE_USER = 20 << 3; // Base32-encodes to 'U...'
+
+    // PrefixByteOperator is the prefix byte used for encoded NATS Operators
+    static final int PREFIX_BYTE_OPERATOR = 14 << 3; // Base32-encodes to 'O...'
+
+    private static final int ED25519_PUBLIC_KEYSIZE = 32;
+    private static final int ED25519_PRIVATE_KEYSIZE = 64;
+    private static final int ED25519_SEED_SIZE = 32;
+    private static final EdDSANamedCurveSpec ed25519 = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
+
+    // XModem CRC based on the go version of NKeys
+    private final static int[] crc16table = { 0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108,
+        0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef, 0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294,
+        0x72f7, 0x62d6, 0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de, 0x2462, 0x3443, 0x0420,
+        0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485, 0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
+        0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4, 0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df,
+        0xe7fe, 0xd79d, 0xc7bc, 0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823, 0xc9cc, 0xd9ed,
+        0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b, 0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33,
+        0x2a12, 0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a, 0x6ca6, 0x7c87, 0x4ce4, 0x5cc5,
+        0x2c22, 0x3c03, 0x0c60, 0x1c41, 0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49, 0x7e97,
+        0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70, 0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a,
+        0x9f59, 0x8f78, 0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f, 0x1080, 0x00a1, 0x30c2,
+        0x20e3, 0x5004, 0x4025, 0x7046, 0x6067, 0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
+        0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256, 0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e,
+        0xe54f, 0xd52c, 0xc50d, 0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405, 0xa7db, 0xb7fa,
+        0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c, 0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615,
+        0x5634, 0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab, 0x5844, 0x4865, 0x7806, 0x6827,
+        0x18c0, 0x08e1, 0x3882, 0x28a3, 0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a, 0x4a75,
+        0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92, 0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b,
+        0x9de8, 0x8dc9, 0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1, 0xef1f, 0xff3e, 0xcf5d,
+        0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8, 0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0 };
+
     static int crc16(byte[] bytes) {
         int crc = 0;
 
         for (byte b : bytes) {
-            crc = ((crc << 8) & 0xffff) ^ CRC_16_TABLE[((crc >> 8) ^ (b & 0xFF)) & 0x00FF];
+            crc = ((crc << 8) & 0xffff) ^ crc16table[((crc >> 8) ^ (b & 0xFF)) & 0x00FF];
         }
 
         return crc;
@@ -291,22 +337,22 @@ public class NKey {
     }
 
     private static NKey createPair(Type type, SecureRandom random)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         if (random == null) {
             random = SRAND;
         }
 
-        byte[] seed = new byte[ED_25519.getCurve().getField().getb() / 8];
+        byte[] seed = new byte[NKey.ed25519.getCurve().getField().getb() / 8];
         random.nextBytes(seed);
 
         return createPair(type, seed);
     }
 
     private static NKey createPair(Type type, byte[] seed)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
-        EdDSAPrivateKeySpec privKeySpec = new EdDSAPrivateKeySpec(seed, ED_25519);
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        EdDSAPrivateKeySpec privKeySpec = new EdDSAPrivateKeySpec(seed, NKey.ed25519);
         EdDSAPrivateKey privKey = new EdDSAPrivateKey(privKeySpec);
-        EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(privKey.getA(), ED_25519);
+        EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(privKey.getA(), NKey.ed25519);
         EdDSAPublicKey pubKey = new EdDSAPublicKey(pubKeySpec);
         byte[] pubBytes = pubKey.getAbyte();
 
@@ -320,11 +366,11 @@ public class NKey {
 
     /**
      * Create an Account NKey from the provided random number generator.
-     * 
+     *
      * If no random is provided, SecureRandom() will be used to create one.
-     * 
+     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     * 
+     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -332,17 +378,17 @@ public class NKey {
      * @throws NoSuchAlgorithmException if the default secure random cannot be created
      */
     public static NKey createAccount(SecureRandom random)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         return createPair(Type.ACCOUNT, random);
     }
 
     /**
-     * Create a Cluster NKey from the provided random number generator.
-     * 
+     * Create an Cluster NKey from the provided random number generator.
+     *
      * If no random is provided, SecureRandom() will be used to create one.
-     * 
+     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     * 
+     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -350,17 +396,17 @@ public class NKey {
      * @throws NoSuchAlgorithmException if the default secure random cannot be created
      */
     public static NKey createCluster(SecureRandom random)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         return createPair(Type.CLUSTER, random);
     }
 
     /**
      * Create an Operator NKey from the provided random number generator.
-     * 
+     *
      * If no random is provided, SecureRandom() will be used to create one.
-     * 
+     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     * 
+     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -368,17 +414,17 @@ public class NKey {
      * @throws NoSuchAlgorithmException if the default secure random cannot be created
      */
     public static NKey createOperator(SecureRandom random)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         return createPair(Type.OPERATOR, random);
     }
 
     /**
      * Create a Server NKey from the provided random number generator.
-     * 
+     *
      * If no random is provided, SecureRandom() will be used to create one.
-     * 
+     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     * 
+     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -386,17 +432,17 @@ public class NKey {
      * @throws NoSuchAlgorithmException if the default secure random cannot be created
      */
     public static NKey createServer(SecureRandom random)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         return createPair(Type.SERVER, random);
     }
 
     /**
      * Create a User NKey from the provided random number generator.
-     * 
+     *
      * If no random is provided, SecureRandom() will be used to create one.
-     * 
+     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     * 
+     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -404,13 +450,13 @@ public class NKey {
      * @throws NoSuchAlgorithmException if the default secure random cannot be created
      */
     public static NKey createUser(SecureRandom random)
-            throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
         return createPair(Type.USER, random);
     }
 
     /**
      * Create an NKey object from the encoded public key. This NKey can be used for verification but not for signing.
-     * 
+     *
      * @param publicKey the string encoded public key
      * @return the new Nkey
      */
@@ -428,7 +474,7 @@ public class NKey {
 
     /**
      * Creates an NKey object from a string encoded seed. This NKey can be used to sign or verify.
-     * 
+     *
      * @param seed the string encoded seed, see {@link NKey#getSeed() getSeed()}
      * @return the Nkey
      */
@@ -507,7 +553,7 @@ public class NKey {
     /**
      * Clear the seed and public key char arrays by filling them
      * with random bytes then zero-ing them out.
-     * 
+     *
      * The nkey is unusable after this operation.
      */
     public void clear() {
@@ -544,7 +590,7 @@ public class NKey {
 
     /**
      * @return the encoded public key for this NKey
-     * 
+     *
      * @throws GeneralSecurityException if there is an encryption problem
      * @throws IOException              if there is a problem encoding the public
      *                                  key
@@ -563,7 +609,7 @@ public class NKey {
 
     /**
      * @return the encoded private key for this NKey
-     * 
+     *
      * @throws GeneralSecurityException if there is an encryption problem
      * @throws IOException              if there is a problem encoding the key
      */
@@ -579,7 +625,7 @@ public class NKey {
     /**
      * @return A Java security keypair that represents this NKey in Java security
      *         form.
-     * 
+     *
      * @throws GeneralSecurityException if there is an encryption problem
      * @throws IOException              if there is a problem encoding or decoding
      */
@@ -595,9 +641,9 @@ public class NKey {
         System.arraycopy(decoded.bytes, 0, seedBytes, 0, seedBytes.length);
         System.arraycopy(decoded.bytes, seedBytes.length, pubBytes, 0, pubBytes.length);
 
-        EdDSAPrivateKeySpec privKeySpec = new EdDSAPrivateKeySpec(seedBytes, ED_25519);
+        EdDSAPrivateKeySpec privKeySpec = new EdDSAPrivateKeySpec(seedBytes, NKey.ed25519);
         EdDSAPrivateKey privKey = new EdDSAPrivateKey(privKeySpec);
-        EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(pubBytes, ED_25519);
+        EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(pubBytes, NKey.ed25519);
         EdDSAPublicKey pubKey = new EdDSAPublicKey(pubKeySpec);
 
         return new KeyPair(pubKey, privKey);
@@ -612,15 +658,15 @@ public class NKey {
 
     /**
      * Sign aribitrary binary input.
-     * 
+     *
      * @param input the bytes to sign
      * @return the signature for the input from the NKey
-     * 
+     *
      * @throws GeneralSecurityException if there is an encryption problem
      * @throws IOException              if there is a problem reading the data
      */
     public byte[] sign(byte[] input) throws GeneralSecurityException, IOException {
-        Signature sgr = new EdDSAEngine(MessageDigest.getInstance(ED_25519.getHashAlgorithm()));
+        Signature sgr = new EdDSAEngine(MessageDigest.getInstance(NKey.ed25519.getHashAlgorithm()));
         PrivateKey sKey = getKeyPair().getPrivate();
 
         sgr.initSign(sKey);
@@ -631,16 +677,16 @@ public class NKey {
 
     /**
      * Verify a signature.
-     * 
+     *
      * @param input     the bytes that were signed
      * @param signature the bytes for the signature
      * @return true if the signature matches this keys signature for the input.
-     * 
+     *
      * @throws GeneralSecurityException if there is an encryption problem
      * @throws IOException              if there is a problem reading the data
      */
     public boolean verify(byte[] input, byte[] signature) throws GeneralSecurityException, IOException {
-        Signature sgr = new EdDSAEngine(MessageDigest.getInstance(ED_25519.getHashAlgorithm()));
+        Signature sgr = new EdDSAEngine(MessageDigest.getInstance(NKey.ed25519.getHashAlgorithm()));
         PublicKey sKey = null;
 
         if (privateKeyAsSeed != null) {
@@ -648,7 +694,7 @@ public class NKey {
         } else {
             char[] encodedPublicKey = getPublicKey();
             byte[] decodedPublicKey = decode(this.type, encodedPublicKey, false);
-            EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(decodedPublicKey, ED_25519);
+            EdDSAPublicKeySpec pubKeySpec = new EdDSAPublicKeySpec(decodedPublicKey, NKey.ed25519);
             sKey = new EdDSAPublicKey(pubKeySpec);
         }
 

--- a/src/main/java/io/nats/client/impl/FileAuthHandler.java
+++ b/src/main/java/io/nats/client/impl/FileAuthHandler.java
@@ -14,7 +14,7 @@
 package io.nats.client.impl;
 
 import io.nats.client.AuthHandler;
-import io.nats.nkey.NKey;
+import io.nats.client.NKey;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;

--- a/src/main/java/io/nats/client/impl/StringAuthHandler.java
+++ b/src/main/java/io/nats/client/impl/StringAuthHandler.java
@@ -14,9 +14,7 @@
 package io.nats.client.impl;
 
 import io.nats.client.AuthHandler;
-import io.nats.nkey.NKey;
-
-import static io.nats.nkey.NKey.fromSeed;
+import io.nats.client.NKey;
 
 class StringAuthHandler implements AuthHandler {
     private final char[] nkey;
@@ -36,7 +34,7 @@ class StringAuthHandler implements AuthHandler {
      */ 
     public byte[] sign(byte[] nonce) {
         try {
-            NKey nkey = fromSeed(this.nkey);
+            NKey nkey = NKey.fromSeed(this.nkey);
             byte[] sig = nkey.sign(nonce);
             nkey.clear();
             return sig;
@@ -53,7 +51,7 @@ class StringAuthHandler implements AuthHandler {
      */
     public char[] getID() {
         try {
-            NKey nkey = fromSeed(this.nkey);
+            NKey nkey = NKey.fromSeed(this.nkey);
             char[] pubKey = nkey.getPublicKey();
             nkey.clear();
             return pubKey;

--- a/src/test/java/io/nats/client/NKeyTests.java
+++ b/src/test/java/io/nats/client/NKeyTests.java
@@ -27,10 +27,8 @@ import static io.nats.client.NKey.removePaddingAndClear;
 import static io.nats.client.support.Encoding.base32Decode;
 import static io.nats.client.support.Encoding.base32Encode;
 import static io.nats.client.utils.ResourceUtils.dataAsLines;
-import static io.nats.nkey.NKeyConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@SuppressWarnings("deprecation")
 public class NKeyTests {
     private static final int ED25519_SIGNATURE_SIZE = 64;
 
@@ -558,12 +556,12 @@ public class NKeyTests {
 
     @Test
     public void testTypeEnum() {
-        assertEquals(NKey.Type.USER, NKey.Type.fromPrefix(PREFIX_BYTE_USER));
-        assertEquals(NKey.Type.ACCOUNT, NKey.Type.fromPrefix(PREFIX_BYTE_ACCOUNT));
-        assertEquals(NKey.Type.SERVER, NKey.Type.fromPrefix(PREFIX_BYTE_SERVER));
-        assertEquals(NKey.Type.OPERATOR, NKey.Type.fromPrefix(PREFIX_BYTE_OPERATOR));
-        assertEquals(NKey.Type.CLUSTER, NKey.Type.fromPrefix(PREFIX_BYTE_CLUSTER));
-        assertEquals(NKey.Type.ACCOUNT, NKey.Type.fromPrefix(PREFIX_BYTE_PRIVATE));
+        assertEquals(NKey.Type.USER, NKey.Type.fromPrefix(NKey.PREFIX_BYTE_USER));
+        assertEquals(NKey.Type.ACCOUNT, NKey.Type.fromPrefix(NKey.PREFIX_BYTE_ACCOUNT));
+        assertEquals(NKey.Type.SERVER, NKey.Type.fromPrefix(NKey.PREFIX_BYTE_SERVER));
+        assertEquals(NKey.Type.OPERATOR, NKey.Type.fromPrefix(NKey.PREFIX_BYTE_OPERATOR));
+        assertEquals(NKey.Type.CLUSTER, NKey.Type.fromPrefix(NKey.PREFIX_BYTE_CLUSTER));
+        assertEquals(NKey.Type.ACCOUNT, NKey.Type.fromPrefix(NKey.PREFIX_BYTE_PRIVATE));
         assertThrows(IllegalArgumentException.class, () -> { NKey.Type ignored = NKey.Type.fromPrefix(9999); });
     }
 


### PR DESCRIPTION
The NKey library was extracted to another repo and was then this project was made to depend on that library and also keep the existing library. Since there is zero functionality change, this is being reverted to ensure that there is absolutely no backward compatibility issues, even though there probably wasn't.