### PR TITLE
Offer timeout millis no longer hardcoded

### DIFF
--- a/src/main/java/io/nats/client/impl/MessageManager.java
+++ b/src/main/java/io/nats/client/impl/MessageManager.java
@@ -14,7 +14,6 @@
 package io.nats.client.impl;
 
 import io.nats.client.Message;
-import io.nats.client.NUID;
 import io.nats.client.PullRequestOptions;
 import io.nats.client.SubscribeOptions;
 
@@ -123,7 +122,6 @@ abstract class MessageManager {
     }
 
     class MmTimerTask extends TimerTask {
-        public String id = new NUID().nextSequence();
         long alarmPeriod;
         final AtomicBoolean alive;
 
@@ -154,7 +152,6 @@ abstract class MessageManager {
         public String toString() {
             long sinceLast = System.currentTimeMillis() - lastMsgReceived.get();
             return "MmTimerTask{" +
-                "id='" + id + '\'' +
                 ", alarmPeriod=" + alarmPeriod +
                 ", alive=" + alive.get() +
                 ", sinceLast=" + sinceLast +

--- a/src/main/java/io/nats/client/impl/MessageQueue.java
+++ b/src/main/java/io/nats/client/impl/MessageQueue.java
@@ -75,7 +75,7 @@ class MessageQueue {
     }
 
     private static long calculateOfferTimeoutMillis(Duration requestCleanupInterval) {
-        return Math.max(1, requestCleanupInterval.toMillis() * 9 / 10);
+        return Math.max(1, requestCleanupInterval.toMillis() * 95 / 100);
     }
 
     boolean isSingleReaderMode() {

--- a/src/main/java/io/nats/client/impl/MessageQueue.java
+++ b/src/main/java/io/nats/client/impl/MessageQueue.java
@@ -26,9 +26,9 @@ import java.util.function.Predicate;
 import static io.nats.client.support.NatsConstants.EMPTY_BODY;
 
 class MessageQueue {
-    protected final static int STOPPED = 0;
-    protected final static int RUNNING = 1;
-    protected final static int DRAINING = 2;
+    protected static final int STOPPED = 0;
+    protected static final int RUNNING = 1;
+    protected static final int DRAINING = 2;
 
     protected final AtomicLong length;
     protected final AtomicLong sizeInBytes;
@@ -37,11 +37,16 @@ class MessageQueue {
     protected final LinkedBlockingQueue<NatsMessage> queue;
     protected final Lock filterLock;
     protected final boolean discardWhenFull;
+    protected final long offerTimeoutMillis;
 
     // Poison pill is a graphic, but common term for an item that breaks loops or stop something.
     // In this class the poisonPill is used to break out of timed waits on the blocking queue.
     // A simple == is used to check if any message in the queue is this message.
     protected final NatsMessage poisonPill;
+
+    MessageQueue(boolean singleReaderMode, Duration requestCleanupInterval) {
+        this(singleReaderMode, -1, false, requestCleanupInterval);
+    }
 
     /**
      * If publishHighwaterMark is set to 0 the underlying queue can grow forever (or until the max size of a linked blocking queue that is).
@@ -51,13 +56,15 @@ class MessageQueue {
      * @param singleReaderMode allows the use of "accumulate"
      * @param publishHighwaterMark sets a limit on the size of the underlying queue
      * @param discardWhenFull allows to discard messages when the underlying queue is full
+     * @param requestCleanupInterval is used to figure the offerTimeoutMillis
      */
-    MessageQueue(boolean singleReaderMode, int publishHighwaterMark, boolean discardWhenFull) {
-        this.queue = publishHighwaterMark > 0 ? new LinkedBlockingQueue<NatsMessage>(publishHighwaterMark) : new LinkedBlockingQueue<NatsMessage>();
+    MessageQueue(boolean singleReaderMode, int publishHighwaterMark, boolean discardWhenFull, Duration requestCleanupInterval) {
+        this.queue = publishHighwaterMark > 0 ? new LinkedBlockingQueue<>(publishHighwaterMark) : new LinkedBlockingQueue<>();
         this.discardWhenFull = discardWhenFull;
         this.running = new AtomicInteger(RUNNING);
         this.sizeInBytes = new AtomicLong(0);
         this.length = new AtomicLong(0);
+        this.offerTimeoutMillis = calculateOfferTimeoutMillis(requestCleanupInterval);
 
         // The poisonPill is used to stop poll and accumulate when the queue is stopped
         this.poisonPill = new NatsMessage("_poison", null, EMPTY_BODY);
@@ -67,12 +74,8 @@ class MessageQueue {
         this.singleThreadedReader = singleReaderMode;
     }
 
-    MessageQueue(boolean singleReaderMode) {
-        this(singleReaderMode, 0);
-    }
-
-    MessageQueue(boolean singleReaderMode, int publishHighwaterMark) {
-        this(singleReaderMode, publishHighwaterMark, false);
+    private static long calculateOfferTimeoutMillis(Duration requestCleanupInterval) {
+        return Math.max(1, requestCleanupInterval.toMillis() * 9 / 10);
     }
 
     boolean isSingleReaderMode() {
@@ -143,7 +146,7 @@ class MessageQueue {
 
     boolean offer(NatsMessage msg) {
         try {
-            return this.queue.offer(msg, 5, TimeUnit.SECONDS);
+            return this.queue.offer(msg, offerTimeoutMillis, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ie) {
             return false;
         }

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -64,11 +64,12 @@ class NatsConnectionWriter implements Runnable {
         sendBuffer = new byte[sbl];
 
         outgoing = new MessageQueue(true,
-                options.getMaxMessagesInOutgoingQueue(),
-                options.isDiscardMessagesWhenOutgoingQueueFull());
+            options.getMaxMessagesInOutgoingQueue(),
+            options.isDiscardMessagesWhenOutgoingQueueFull(),
+            options.getRequestCleanupInterval());
 
         // The "reconnect" buffer contains internal messages, and we will keep it unlimited in size
-        reconnectOutgoing = new MessageQueue(true, 0);
+        reconnectOutgoing = new MessageQueue(true, options.getRequestCleanupInterval());
         reconnectBufferSize = options.getReconnectBufferSize();
     }
 

--- a/src/main/java/io/nats/client/impl/NatsConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumer.java
@@ -34,9 +34,6 @@ abstract class NatsConsumer implements Consumer {
     private final AtomicReference<CompletableFuture<Boolean>> drainingFuture;
 
     NatsConsumer(NatsConnection conn) {
-        if (conn == null) {
-            throw new IllegalStateException("Connection Required");
-        }
         this.connection = conn;
         this.maxMessages = new AtomicLong(Consumer.DEFAULT_MAX_MESSAGES);
         this.maxBytes = new AtomicLong(Consumer.DEFAULT_MAX_BYTES);

--- a/src/main/java/io/nats/client/impl/NatsConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumer.java
@@ -34,6 +34,9 @@ abstract class NatsConsumer implements Consumer {
     private final AtomicReference<CompletableFuture<Boolean>> drainingFuture;
 
     NatsConsumer(NatsConnection conn) {
+        if (conn == null) {
+            throw new IllegalStateException("Connection Required");
+        }
         this.connection = conn;
         this.maxMessages = new AtomicLong(Consumer.DEFAULT_MAX_MESSAGES);
         this.maxBytes = new AtomicLong(Consumer.DEFAULT_MAX_BYTES);

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -53,7 +53,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     NatsDispatcher(NatsConnection conn, MessageHandler handler) {
         super(conn);
         this.defaultHandler = handler;
-        this.incoming = new MessageQueue(true);
+        this.incoming = new MessageQueue(true, conn.getOptions().getRequestCleanupInterval());
         this.subscriptionsUsingDefaultHandler = new ConcurrentHashMap<>();
         this.subscriptionsWithHandlers = new ConcurrentHashMap<>();
         this.subscriptionHandlers = new ConcurrentHashMap<>();

--- a/src/main/java/io/nats/client/impl/NatsSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsSubscription.java
@@ -44,7 +44,7 @@ class NatsSubscription extends NatsConsumer implements Subscription {
         this.unSubMessageLimit = new AtomicLong(-1);
 
         if (this.dispatcher == null) {
-            this.incoming = new MessageQueue(false);
+            this.incoming = new MessageQueue(false, connection.getOptions().getRequestCleanupInterval());
         }
 
         setBeforeQueueProcessor(null);

--- a/src/test/java/io/nats/client/impl/JetStreamGeneralTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamGeneralTests.java
@@ -972,7 +972,12 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
         IllegalStateException ise = assertThrows(IllegalStateException.class, njsm::getJetStreamValidatedConnection);
         assertTrue(ise.getMessage().contains("subscription"));
 
-        njsm.subscription = new NatsSubscription("sid", "sub", "q", null, null);
+        // make a dummy connection so we can make a subscription
+        Options options = Options.builder().build();
+        NatsConnection nc = new NatsConnection(options);
+        njsm.subscription = new NatsSubscription("sid", "sub", "q", nc, null);
+        // remove the connection so we can test the coverage
+        njsm.subscription.connection = null;
         ise = assertThrows(IllegalStateException.class, njsm::getJetStreamValidatedConnection);
         assertTrue(ise.getMessage().contains("connection"));
     }

--- a/src/test/java/io/nats/client/impl/MessageManagerTests.java
+++ b/src/test/java/io/nats/client/impl/MessageManagerTests.java
@@ -634,9 +634,13 @@ public class MessageManagerTests extends JetStreamTestBase {
 
     @Test
     public void testMessageManagerInterfaceDefaultImplCoverage() {
+        // make a dummy connection so we can make a subscription
+        Options options = Options.builder().build();
+        NatsConnection nc = new NatsConnection(options);
+
         TestMessageManager tmm = new TestMessageManager();
         NatsJetStreamSubscription sub =
-            new NatsJetStreamSubscription(mockSid(), "sub", null, null, null, null, "stream", "con", tmm);
+            new NatsJetStreamSubscription(mockSid(), "sub", null, nc, null, null, "stream", "con", tmm);
         tmm.startup(sub);
         assertSame(sub, tmm.getSub());
     }

--- a/src/test/java/io/nats/client/impl/MessageQueueTests.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueTests.java
@@ -26,14 +26,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MessageQueueTests {
-    byte[] PING = "PING".getBytes();
-    byte[] ONE = "one".getBytes();
-    byte[] TWO = "two".getBytes();
-    byte[] THREE = "three".getBytes();
+    static final Duration REQUEST_CLEANUP_INTERVAL = Duration.ofSeconds(5);
+    static final byte[] PING = "PING".getBytes();
+    static final byte[] ONE = "one".getBytes();
+    static final byte[] TWO = "two".getBytes();
+    static final byte[] THREE = "three".getBytes();
 
     @Test
     public void testEmptyPop() throws InterruptedException {
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg = q.popNow();
         assertNull(msg);
         assertFalse(q.isSingleReaderMode());
@@ -42,7 +43,7 @@ public class MessageQueueTests {
     @Test
     public void testAccumulateThrowsOnNonSingleReader() {
         assertThrows(IllegalStateException.class, () -> {
-            MessageQueue q = new MessageQueue(false);
+            MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
             q.push(new ProtocolMessage(PING));
             q.accumulate(100,1,null);
         });
@@ -50,7 +51,7 @@ public class MessageQueueTests {
 
     @Test
     public void testPushPop() throws InterruptedException {
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         NatsMessage expected = new ProtocolMessage(PING);
         q.push(expected);
         NatsMessage actual = q.popNow();
@@ -60,7 +61,7 @@ public class MessageQueueTests {
     @Test
     public void testTimeout() throws InterruptedException {
         long waitTime = 500;
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         long start = System.nanoTime();
         NatsMessage msg = q.pop(Duration.ofMillis(waitTime));
         long end = System.nanoTime();
@@ -75,7 +76,7 @@ public class MessageQueueTests {
 
     @Test
     public void testTimeoutZero() throws InterruptedException {
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         NatsMessage expected = new ProtocolMessage(PING);
         q.push(expected);
         NatsMessage msg = q.pop(Duration.ZERO);
@@ -85,7 +86,7 @@ public class MessageQueueTests {
     @Test
     public void testInterupt() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         Thread t = new Thread(() -> {try {Thread.sleep(100);}catch(Exception e){/**/} q.pause();});
         t.start();
         NatsMessage msg = q.pop(Duration.ZERO);
@@ -95,7 +96,7 @@ public class MessageQueueTests {
     @Test
     public void testReset() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         Thread t = new Thread(() -> {try {Thread.sleep(100);}catch(Exception e){/**/} q.pause();});
         t.start();
         NatsMessage msg = q.pop(Duration.ZERO);
@@ -115,7 +116,7 @@ public class MessageQueueTests {
     @Test
     public void testPopBeforeTimeout() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
 
         Thread t = new Thread(() -> {
             try {
@@ -135,7 +136,7 @@ public class MessageQueueTests {
     @Test
     public void testMultipleWriters() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         int threads = 10;
 
         for (int i=0;i<threads;i++) {
@@ -155,7 +156,7 @@ public class MessageQueueTests {
     @Test
     public void testMultipleReaders() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         int threads = 10;
         AtomicInteger count = new AtomicInteger(0);
         CountDownLatch latch = new CountDownLatch(threads);
@@ -183,7 +184,7 @@ public class MessageQueueTests {
     @Test
     public void testMultipleReadersAndWriters() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         int threads = 10;
         int msgPerThread = 10;
         AtomicInteger count = new AtomicInteger(0);
@@ -218,7 +219,7 @@ public class MessageQueueTests {
     @Test
     public void testMultipleReaderWriters() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(false);
+        MessageQueue q = new MessageQueue(false, REQUEST_CLEANUP_INTERVAL);
         int threads = 10;
         int msgPerThread = 1_000;
         AtomicInteger count = new AtomicInteger(0);
@@ -246,7 +247,7 @@ public class MessageQueueTests {
 
     @Test
     public void testEmptyAccumulate() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg = q.accumulate(1,1,null);
         assertNull(msg);
         assertTrue(q.isSingleReaderMode());
@@ -254,7 +255,7 @@ public class MessageQueueTests {
 
     @Test
     public void testSingleAccumulate() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         NatsMessage msg = q.accumulate(100,1,null);
         assertNotNull(msg);
@@ -262,7 +263,7 @@ public class MessageQueueTests {
 
     @Test
     public void testMultiAccumulate() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
@@ -282,7 +283,7 @@ public class MessageQueueTests {
 
     @Test
     public void testPartialAccumulateOnCount() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
@@ -296,7 +297,7 @@ public class MessageQueueTests {
 
     @Test
     public void testMultipleAccumulateOnCount() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
@@ -316,7 +317,7 @@ public class MessageQueueTests {
 
     @Test
     public void testPartialAccumulateOnSize() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
@@ -330,7 +331,7 @@ public class MessageQueueTests {
 
     @Test
     public void testMultipleAccumulateOnSize() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
@@ -349,7 +350,7 @@ public class MessageQueueTests {
     
     @Test
     public void testAccumulateAndPop() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
         q.push(new ProtocolMessage(PING));
@@ -367,7 +368,7 @@ public class MessageQueueTests {
     @Test
     public void testMultipleWritersOneAccumulator() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         int threads = 4;
         int msgPerThread = 77;
         int msgCount = threads * msgPerThread;
@@ -407,7 +408,7 @@ public class MessageQueueTests {
     @Test
     public void testInteruptAccumulate() throws InterruptedException {
         // Possible flaky test, since we can't be sure of thread timing
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         Thread t = new Thread(() -> {try {Thread.sleep(100);}catch(Exception e){} q.pause();});
         t.start();
         NatsMessage msg = q.accumulate(100,100, Duration.ZERO);
@@ -416,7 +417,7 @@ public class MessageQueueTests {
     
     @Test
     public void testLength() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(PING);
         NatsMessage msg2 = new ProtocolMessage(PING);
         NatsMessage msg3 = new ProtocolMessage(PING);
@@ -435,7 +436,7 @@ public class MessageQueueTests {
     
     @Test
     public void testSizeInBytes() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
         NatsMessage msg3 = new ProtocolMessage(THREE);
@@ -455,7 +456,7 @@ public class MessageQueueTests {
 
     @Test
     public void testSizeInBytesWithData() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
 
         String subject = "subj";
         String replyTo = "reply";
@@ -483,7 +484,7 @@ public class MessageQueueTests {
 
     @Test
     public void testFilterTail() throws InterruptedException, UnsupportedEncodingException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
         NatsMessage msg3 = new ProtocolMessage(THREE);
@@ -507,7 +508,7 @@ public class MessageQueueTests {
 
     @Test
     public void testFilterHead() throws InterruptedException, UnsupportedEncodingException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
         NatsMessage msg3 = new ProtocolMessage(THREE);
@@ -531,7 +532,7 @@ public class MessageQueueTests {
 
     @Test
     public void testFilterMiddle() throws InterruptedException, UnsupportedEncodingException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
         NatsMessage msg3 = new ProtocolMessage(THREE);
@@ -555,7 +556,7 @@ public class MessageQueueTests {
 
     @Test
     public void testPausedAccumulate() throws InterruptedException {
-        MessageQueue q = new MessageQueue(true);
+        MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         q.pause();
         NatsMessage msg = q.accumulate(1,1,null);
         assertNull(msg);
@@ -564,15 +565,15 @@ public class MessageQueueTests {
     @Test
     public void testThrowOnFilterIfRunning() {
         assertThrows(IllegalStateException.class, () -> {
-            MessageQueue q = new MessageQueue(true);
-            q.filter((msg) -> {return true;});
-            assertFalse(true);
+            MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
+            q.filter((msg) -> true);
+            fail();
         });
     }
 
     @Test
     public void testExceptionWhenQueueIsFull() {
-        MessageQueue q  = new MessageQueue(true, 2);
+        MessageQueue q  = new MessageQueue(true, 2, false, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
         NatsMessage msg3 = new ProtocolMessage(THREE);
@@ -589,7 +590,7 @@ public class MessageQueueTests {
 
     @Test
     public void testDiscardMessageWhenQueueFull() {
-        MessageQueue q  = new MessageQueue(true, 2, true);
+        MessageQueue q  = new MessageQueue(true, 2, true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
         NatsMessage msg3 = new ProtocolMessage(THREE);


### PR DESCRIPTION
The offer timeout was hard-coded to 5 seconds. This change takes the request cleanup intervalfrom Options and takes 95% of that time.
* request cleanup interval is the time allotted for request reply messages to sit un-responded to in the internal map.
* offer timeout is the time to offer an incoming reply response message to be enqueued. It used to be the same as the default request cleanup interval. If it takes too long to be enqueued, the waiting handler is going to be cleaned up anyway.