### PR TITLE
KeyValue atomic delete and purge methods.

### DIFF
--- a/src/main/java/io/nats/client/KeyValue.java
+++ b/src/main/java/io/nats/client/KeyValue.java
@@ -139,6 +139,16 @@ public interface KeyValue {
     void delete(String key) throws IOException, JetStreamApiException;
 
     /**
+     * Soft deletes the key by placing a delete marker iff the key exists and its last revision matches the expected
+     * @param key the key
+     * @param expectedRevision the expected last revision
+     * @throws IOException covers various communication issues with the NATS
+     *         server such as timeout or interruption
+     * @throws JetStreamApiException the request had an error related to the data
+     */
+    void delete(String key, long expectedRevision) throws IOException, JetStreamApiException;
+
+    /**
      * Purge all values/history from the specific key
      * @param key the key
      * @throws IOException covers various communication issues with the NATS
@@ -146,6 +156,16 @@ public interface KeyValue {
      * @throws JetStreamApiException the request had an error related to the data
      */
     void purge(String key) throws IOException, JetStreamApiException;
+
+    /**
+     * Purge all values/history from the specific key iff the key exists and its last revision matches the expected
+     * @param key the key
+     * @param expectedRevision the expected last revision
+     * @throws IOException covers various communication issues with the NATS
+     *         server such as timeout or interruption
+     * @throws JetStreamApiException the request had an error related to the data
+     */
+    void purge(String key, long expectedRevision) throws IOException, JetStreamApiException;
 
     /**
      * Watch updates for a specific key.

--- a/src/main/java/io/nats/client/impl/NatsKeyValue.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValue.java
@@ -207,8 +207,27 @@ public class NatsKeyValue extends NatsFeatureBase implements KeyValue {
      * {@inheritDoc}
      */
     @Override
+    public void delete(String key, long expectedRevision) throws IOException, JetStreamApiException {
+        validateNonWildcardKvKeyRequired(key);
+        Headers h = getDeleteHeaders().put(EXPECTED_LAST_SUB_SEQ_HDR, Long.toString(expectedRevision));
+        _write(key, null, h).getSeqno();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void purge(String key) throws IOException, JetStreamApiException {
         _write(key, null, getPurgeHeaders());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void purge(String key, long expectedRevision) throws IOException, JetStreamApiException {
+        Headers h = getPurgeHeaders().put(EXPECTED_LAST_SUB_SEQ_HDR, Long.toString(expectedRevision));
+        _write(key, null, h);
     }
 
     private PublishAck _write(String key, byte[] data, Headers h) throws IOException, JetStreamApiException {


### PR DESCRIPTION
https://github.com/nats-io/nats-architecture-and-design/issues/271
https://github.com/nats-io/nats.java/issues/1091

#### What's in this patch?

1. New public methods in KeyValue for delete and purge with optimistic concurrency support:
```
void delete(String key, long expectedRevision) throws IOException, JetStreamApiException;
void purge(String key, long expectedRevision) throws IOException, JetStreamApiException;
```

2. New unit test `testAtomicDeleteAtomicPurge` with positive and negative cases.


#### Testing

I wasn't able to get a 100% pass of unit tests in my environment, but the `KeyValueTests` suite (including the new UT) was 100% passing.