### PR TITLE
ReentrantLock instead of synchronized

### DIFF
--- a/src/examples/java/io/nats/examples/chaosTestApp/Output.java
+++ b/src/examples/java/io/nats/examples/chaosTestApp/Output.java
@@ -27,13 +27,14 @@ import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class Output extends JPanel {
     public enum Screen {Left, Main, Console}
 
-    static final Object workLock = new Object();
-    static final Object controlLock = new Object();
-    static final Object debugLock = new Object();
+    static final ReentrantLock workLock = new ReentrantLock();
+    static final ReentrantLock controlLock = new ReentrantLock();
+    static final ReentrantLock debugLock = new ReentrantLock();
 
     static boolean console;
     static boolean work;
@@ -202,7 +203,8 @@ public class Output extends JPanel {
 
     public static void workMessage(String label, String s) {
         if (work) {
-            synchronized (workLock) {
+            workLock.lock();
+            try {
                 if (console) {
                     consoleMessage("WORK", label, s);
                 }
@@ -212,6 +214,9 @@ public class Output extends JPanel {
                 if (workLog != null) {
                     consoleMessage(null, label, s, workLog);
                 }
+            }
+            finally {
+                workLock.unlock();
             }
         }
     }
@@ -225,7 +230,8 @@ public class Output extends JPanel {
     }
 
     public static void controlMessage(String label, String s) {
-        synchronized (controlLock) {
+        controlLock.lock();
+        try {
             if (console) {
                 consoleMessage(controlConsoleAreaLabel, label, s);
             }
@@ -235,6 +241,9 @@ public class Output extends JPanel {
             if (workLog != null) {
                 consoleMessage(null, label, s, controlLog);
             }
+        }
+        finally {
+            controlLock.unlock();
         }
     }
 
@@ -258,7 +267,8 @@ public class Output extends JPanel {
 
     public static void debugMessage(String label, String s) {
         if (debug) {
-            synchronized (debugLock) {
+            debugLock.lock();
+            try {
                 if (console) {
                     consoleMessage("DEBUG", label, s);
                 }
@@ -270,6 +280,9 @@ public class Output extends JPanel {
                 if (debugLog != null) {
                     consoleMessage("DEBUG", label, s + "\n", controlLog);
                 }
+            }
+            finally {
+                debugLock.unlock();
             }
         }
     }

--- a/src/main/java/io/nats/client/impl/NatsOrderedConsumerContext.java
+++ b/src/main/java/io/nats/client/impl/NatsOrderedConsumerContext.java
@@ -23,10 +23,10 @@ import java.time.Duration;
  * Implementation of Ordered Consumer Context
  */
 public class NatsOrderedConsumerContext implements OrderedConsumerContext {
-    private NatsConsumerContext impl;
+    private final NatsConsumerContext impl;
 
     NatsOrderedConsumerContext(NatsStreamContext streamContext, OrderedConsumerConfiguration config) {
-        impl = new NatsConsumerContext(streamContext, config);
+        impl = new NatsConsumerContext(streamContext, null, config);
     }
 
     @Override

--- a/src/main/java/io/nats/client/impl/NatsStreamContext.java
+++ b/src/main/java/io/nats/client/impl/NatsStreamContext.java
@@ -80,7 +80,7 @@ class NatsStreamContext implements StreamContext {
      */
     @Override
     public ConsumerContext getConsumerContext(String consumerName) throws IOException, JetStreamApiException {
-        return new NatsConsumerContext(this, jsm.getConsumerInfo(streamName, consumerName));
+        return new NatsConsumerContext(this, jsm.getConsumerInfo(streamName, consumerName), null);
     }
 
     /**
@@ -88,7 +88,7 @@ class NatsStreamContext implements StreamContext {
      */
     @Override
     public ConsumerContext createOrUpdateConsumer(ConsumerConfiguration config) throws IOException, JetStreamApiException {
-        return new NatsConsumerContext(this, jsm.addOrUpdateConsumer(streamName, config));
+        return new NatsConsumerContext(this, jsm.addOrUpdateConsumer(streamName, config), null);
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/PullMessageManager.java
+++ b/src/main/java/io/nats/client/impl/PullMessageManager.java
@@ -44,7 +44,8 @@ class PullMessageManager extends MessageManager {
 
     @Override
     protected void startPullRequest(String pullSubject, PullRequestOptions pro, boolean raiseStatusWarnings, PullManagerObserver pullManagerObserver) {
-        synchronized (stateChangeLock) {
+        stateChangeLock.lock();
+        try {
             this.raiseStatusWarnings = raiseStatusWarnings;
             this.pullManagerObserver = pullManagerObserver;
             pendingMessages += pro.getBatchSize();
@@ -58,6 +59,9 @@ class PullMessageManager extends MessageManager {
                 shutdownHeartbeatTimer(); // just in case the pull was changed from hb to non-hb
             }
         }
+        finally {
+            stateChangeLock.unlock();
+        }
     }
 
     @Override
@@ -70,7 +74,8 @@ class PullMessageManager extends MessageManager {
     }
 
     private void trackIncoming(int m, long b) {
-        synchronized (stateChangeLock) {
+        stateChangeLock.lock();
+        try {
             // message time used for heartbeat tracking
             updateLastMessageReceived();
 
@@ -88,6 +93,9 @@ class PullMessageManager extends MessageManager {
                     pullManagerObserver.pendingUpdated();
                 }
             }
+        }
+        finally {
+            stateChangeLock.unlock();
         }
     }
 

--- a/src/main/java/io/nats/service/Service.java
+++ b/src/main/java/io/nats/service/Service.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static io.nats.client.support.ApiConstants.*;
 import static io.nats.client.support.JsonUtils.endJson;
@@ -51,7 +52,7 @@ public class Service {
     private final PingResponse pingResponse;
     private final InfoResponse infoResponse;
 
-    private final Object startStopLock;
+    private final ReentrantLock startStopLock;
     private CompletableFuture<Boolean> runningIndicator;
     private ZonedDateTime started;
 
@@ -60,7 +61,7 @@ public class Service {
         conn = b.conn;
         drainTimeout = b.drainTimeout;
         dInternals = new ArrayList<>();
-        startStopLock = new Object();
+        startStopLock = new ReentrantLock();
 
         // set up the service contexts
         // ? do we need an internal dispatcher for any user endpoints
@@ -145,7 +146,8 @@ public class Service {
      * @return a future that can be held to see if another thread called stop
      */
     public CompletableFuture<Boolean> startService() {
-        synchronized (startStopLock) {
+        startStopLock.lock();
+        try {
             if (runningIndicator == null) {
                 runningIndicator = new CompletableFuture<>();
                 for (EndpointContext ctx : serviceContexts.values()) {
@@ -157,6 +159,9 @@ public class Service {
                 started = DateTimeUtils.gmtNow();
             }
             return runningIndicator;
+        }
+        finally {
+            startStopLock.unlock();
         }
     }
 
@@ -197,7 +202,8 @@ public class Service {
      * @param t the optional error cause. If supplied, mark the future that was received from the start method that the service completed exceptionally
      */
     public void stop(boolean drain, Throwable t) {
-        synchronized (startStopLock) {
+        startStopLock.lock();
+        try {
             if (runningIndicator != null) {
                 if (drain) {
                     List<CompletableFuture<Boolean>> futures = new ArrayList<>();
@@ -253,6 +259,9 @@ public class Service {
                 }
                 runningIndicator = null; // we don't need a copy anymore
             }
+        }
+        finally {
+            startStopLock.unlock();
         }
     }
 

--- a/src/test/java/io/nats/client/impl/ReconnectTests.java
+++ b/src/test/java/io/nats/client/impl/ReconnectTests.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -640,15 +641,16 @@ public class ReconnectTests {
             }
         }
     }
-    private static class TestReconnecWaitHandler implements ConnectionListener {
-        int disconnectCount = 0;
 
-        public synchronized int getDisconnectCount() {
-            return disconnectCount;
+    private static class TestReconnecWaitHandler implements ConnectionListener {
+        AtomicInteger disconnectCount = new AtomicInteger();
+
+        public int getDisconnectCount() {
+            return disconnectCount.get();
         }
 
-        private synchronized void incrementDisconnectedCount() {
-            disconnectCount++;
+        private void incrementDisconnectedCount() {
+            disconnectCount.incrementAndGet();
         }
 
         @Override

--- a/src/test/java/io/nats/client/impl/TestHandler.java
+++ b/src/test/java/io/nats/client/impl/TestHandler.java
@@ -283,16 +283,24 @@ public class TestHandler implements ErrorListener, ConnectionListener {
         System.out.println("[" + System.currentTimeMillis() + " TestHander." + func + "] " + message);
     }
 
-    private final Object listLock = new Object();
+    private final ReentrantLock listLock = new ReentrantLock();
     private <T> List<T> copy(List<T> list) {
-        synchronized (listLock) {
+        listLock.lock();
+        try {
             return new ArrayList<>(list);
+        }
+        finally {
+            listLock.unlock();
         }
     }
 
     private <T> void add(List<T> list, T t) {
-        synchronized (listLock) {
+        listLock.lock();
+        try {
             list.add(t);
+        }
+        finally {
+            listLock.unlock();
         }
     }
 

--- a/src/test/java/io/nats/client/support/WebsocketSupportClassesTests.java
+++ b/src/test/java/io/nats/client/support/WebsocketSupportClassesTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static io.nats.client.support.WebsocketFrameHeader.OpCode;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -333,9 +334,17 @@ public class WebsocketSupportClassesTests {
                         return tcpSocket.getOutputStream();
                     }
 
+                    final ReentrantLock closeLock = new ReentrantLock();
+
                     @Override
                     public synchronized void close() throws IOException {
-                        tcpSocket.close();
+                        closeLock.lock();
+                        try {
+                            tcpSocket.close();
+                        }
+                        finally {
+                            closeLock.unlock();
+                        }
                     }
 
                     @Override


### PR DESCRIPTION
* Use ReentrantLock in place of synchronized since it's better for virtual threads and equally if not more performant.
* Ensure consumer context implementation is thread safe and switch to reentrant lock instead of synchronized.