### PR TITLE
Ensure NatsConnection inboxDispatcher is started prior to publishing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1221,7 +1221,7 @@ The java doc is located in `build/docs` and the example jar is in `build/libs`. 
 
 which will create a folder called `build/reports/jacoco` containing the file `index.html` you can open and use to browse the coverage. Keep in mind we have focused on library test coverage, not coverage for the examples.
 
-Many of the tests run nats-server on a custom port. If nats-server is in your path they should just work, but in cases where it is not, or an IDE running tests has issues with the path you can specify the nats-server location with the environment variable `nats_-_server_path`.
+Many of the tests run nats-server on a custom port. If nats-server is in your path they should just work, but in cases where it is not, or an IDE running tests has issues with the path you can specify the nats-server location with the environment variable `nats_server_path`.
 
 ## TLS Certs
 


### PR DESCRIPTION
If multiple treads publish messages at the same time, some messages may not be published because the inboxDispatcher is not started yet.  Change updates NatsConnection to ensure the inboxDispatcher is started prior to publishing messages.

 Fixes #1065