### PR TITLE
Add quickfix to be able to use auth handler and user info

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -2371,7 +2371,9 @@ public class Options {
             appendOption(connectString, Options.OPTION_NKEY, nkey, true, true);
             appendOption(connectString, Options.OPTION_SIG, encodedSig, true, true);
             appendOption(connectString, Options.OPTION_JWT, jwt, true, true);
-        } else if (includeAuth) {
+        }
+
+        if (includeAuth) {
             String uriUser = null;
             String uriPass = null;
             String uriToken = null;

--- a/src/test/java/io/nats/client/AuthHandlerForTesting.java
+++ b/src/test/java/io/nats/client/AuthHandlerForTesting.java
@@ -18,13 +18,21 @@ import java.security.GeneralSecurityException;
 
 public class AuthHandlerForTesting implements AuthHandler {
     private final NKey nkey;
+    private final char[] jwt;
 
     public AuthHandlerForTesting(NKey nkey) {
         this.nkey = nkey;
+        this.jwt = null;
+    }
+
+    public AuthHandlerForTesting(NKey nkey, char[] jwt) {
+        this.nkey = nkey;
+        this.jwt = jwt;
     }
 
     public AuthHandlerForTesting() throws Exception {
         this.nkey = NKey.createUser(null);
+        this.jwt = null;
     }
 
     public NKey getNKey() {
@@ -48,6 +56,6 @@ public class AuthHandlerForTesting implements AuthHandler {
     }
 
     public char[] getJWT() {
-        return null;
+        return this.jwt;
     }
 }

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -693,6 +693,41 @@ public class OptionsTests {
         assertEquals(expectedWithAuth, o.buildProtocolConnectOptionsString("nats://localhost:4222", true, nonce).toString(), "auth connect options");
     }
 
+    // Test for auth handler from nkey, option JWT and user info
+    @Test
+    public void testNKeyJWTAndUserInfoOptions() throws Exception {
+        // "jwt" is encoded from:
+        // Header:    {"alg":"HS256"}
+        // Payload:   {"jti":"","iat":2000000000,"iss":"","name":"user_jwt","sub":"","nats":{"pub":{"deny":[">"]},
+        //            "sub":{"deny":[">"]},"subs":-1,"data":-1,"payload":-1,"type":"user","version":2}}
+        String jwt = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIiLCJpYXQiOjIwMDAwMDAwMDAsImlzcyI6IiIsIm5hbWUiOiJ1c2VyX2p3"
+                + "dCIsInN1YiI6IiIsIm5hdHMiOnsicHViIjp7ImRlbnkiOlsiPiJdfSwic3ViIjp7ImRlbnkiOlsiPiJdfSwic3VicyI6LTEsImRh"
+                + "dGEiOi0xLCJwYXlsb2FkIjotMSwidHlwZSI6InVzZXIiLCJ2ZXJzaW9uIjoyfX0";
+        NKey nkey = NKey.createUser(null);
+        String username = "username";
+        String password = "password";
+        AuthHandlerForTesting th = new AuthHandlerForTesting(nkey, jwt.toCharArray());
+        byte[] nonce = "abcdefg".getBytes(StandardCharsets.UTF_8);
+        String sig = Base64.getUrlEncoder().withoutPadding().encodeToString(th.sign(nonce));
+
+        Options options = new Options.Builder().authHandler(th)
+                .userInfo(username.toCharArray(), password.toCharArray()).build();
+        String expectedWithoutAuth = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
+            + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,"
+            + "\"headers\":true,\"no_responders\":true}";
+        String actualWithoutAuth = options
+                .buildProtocolConnectOptionsString("nats://localhost:4222", false, nonce).toString();
+        assertEquals(expectedWithoutAuth, actualWithoutAuth, "no auth connect options");
+
+        String expectedWithAuth = "{\"lang\":\"java\",\"version\":\"" + Nats.CLIENT_VERSION + "\""
+                + ",\"protocol\":1,\"verbose\":false,\"pedantic\":false,\"tls_required\":false,\"echo\":true,"
+                + "\"headers\":true,\"no_responders\":true,\"nkey\":\"" + new String(th.getID()) + "\",\"sig\":\""
+                + sig + "\",\"jwt\":\"" + jwt + "\",\"user\":\"" + username + "\",\"pass\":\"" + password + "\"}";
+        String actualWithAuth = options
+                .buildProtocolConnectOptionsString("nats://localhost:4222", true, nonce).toString();
+        assertEquals(expectedWithAuth, actualWithAuth, "auth connect options");
+    }
+
     @Test
     public void testDefaultDataPort() {
         Options o = new Options.Builder().socketWriteTimeout(null).build();


### PR DESCRIPTION
When trying to connect to a NATS server with [Auth Callout](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout), the client may be required to use a combination of an auth handler (NKey + Seed) plus user info (username + password). This is working as expected in the go reference implementation.

However, this is not working in the current nats.java implementation, as user info is stripped out when building connection options:

```java
AuthHandler authHandler = Nats.staticCredentials(jwt, nkey);
Options connectOptions = Options.builder()
        .server(config.getUrl())
        .authHandler(authHandler)
        .userInfo(username, password)  
        .build();
```
This PR fixes the behavior in the client options to allow the usage of an auth handler in combination with username and password. 