### PR TITLE
Add fix to be able to use NKey + Seed auth handler and username + pas…

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -2374,51 +2374,50 @@ public class Options {
                 appendOption(connectString, Options.OPTION_SIG, encodedSig, true, true);
                 appendOption(connectString, Options.OPTION_JWT, jwt, true, true);
             }
-            else {
-                String uriUser = null;
-                String uriPass = null;
-                String uriToken = null;
 
-                // Values from URI override options
-                try {
-                    URI uri = this.createURIForServer(serverURI);
-                    String userInfo = uri.getRawUserInfo();
-                    if (userInfo != null) {
-                        int at = userInfo.indexOf(":");
-                        if (at == -1) {
-                            uriToken = uriDecode(userInfo);
-                        }
-                        else {
-                            uriUser = uriDecode(userInfo.substring(0, at));
-                            uriPass = uriDecode(userInfo.substring(at + 1));
-                        }
+            String uriUser = null;
+            String uriPass = null;
+            String uriToken = null;
+
+            // Values from URI override options
+            try {
+                URI uri = this.createURIForServer(serverURI);
+                String userInfo = uri.getRawUserInfo();
+                if (userInfo != null) {
+                    int at = userInfo.indexOf(":");
+                    if (at == -1) {
+                        uriToken = uriDecode(userInfo);
+                    }
+                    else {
+                        uriUser = uriDecode(userInfo.substring(0, at));
+                        uriPass = uriDecode(userInfo.substring(at + 1));
                     }
                 }
-                catch (URISyntaxException e) {
-                    // the createURIForServer call is the one that potentially throws this
-                    // uriUser, uriPass and uriToken will already be null
-                }
+            }
+            catch (URISyntaxException e) {
+                // the createURIForServer call is the one that potentially throws this
+                // uriUser, uriPass and uriToken will already be null
+            }
 
-                if (uriUser != null) {
-                    appendOption(connectString, Options.OPTION_USER, uriUser, true, true);
-                }
-                else if (this.username != null) {
-                    appendOption(connectString, Options.OPTION_USER, this.username, true, true);
-                }
+            if (uriUser != null) {
+                appendOption(connectString, Options.OPTION_USER, uriUser, true, true);
+            }
+            else if (this.username != null) {
+                appendOption(connectString, Options.OPTION_USER, this.username, true, true);
+            }
 
-                if (uriPass != null) {
-                    appendOption(connectString, Options.OPTION_PASSWORD, uriPass, true, true);
-                }
-                else if (this.password != null) {
-                    appendOption(connectString, Options.OPTION_PASSWORD, this.password, true, true);
-                }
+            if (uriPass != null) {
+                appendOption(connectString, Options.OPTION_PASSWORD, uriPass, true, true);
+            }
+            else if (this.password != null) {
+                appendOption(connectString, Options.OPTION_PASSWORD, this.password, true, true);
+            }
 
-                if (uriToken != null) {
-                    appendOption(connectString, Options.OPTION_AUTH_TOKEN, uriToken, true, true);
-                }
-                else if (this.token != null) {
-                    appendOption(connectString, Options.OPTION_AUTH_TOKEN, this.token, true, true);
-                }
+            if (uriToken != null) {
+                appendOption(connectString, Options.OPTION_AUTH_TOKEN, uriToken, true, true);
+            }
+            else if (this.token != null) {
+                appendOption(connectString, Options.OPTION_AUTH_TOKEN, this.token, true, true);
             }
         }
 

--- a/src/test/java/io/nats/client/AuthHandlerForTesting.java
+++ b/src/test/java/io/nats/client/AuthHandlerForTesting.java
@@ -18,13 +18,21 @@ import java.security.GeneralSecurityException;
 
 public class AuthHandlerForTesting implements AuthHandler {
     private final NKey nkey;
+    private final char[] jwt;
 
     public AuthHandlerForTesting(NKey nkey) {
         this.nkey = nkey;
+        this.jwt = null;
+    }
+
+    public AuthHandlerForTesting(NKey nkey, char[] jwt) {
+        this.nkey = nkey;
+        this.jwt = jwt;
     }
 
     public AuthHandlerForTesting() throws Exception {
         this.nkey = NKey.createUser(null);
+        this.jwt = null;
     }
 
     public NKey getNKey() {
@@ -48,6 +56,6 @@ public class AuthHandlerForTesting implements AuthHandler {
     }
 
     public char[] getJWT() {
-        return null;
+        return this.jwt;
     }
 }


### PR DESCRIPTION
Updated PR based on discussion in https://github.com/nats-io/nats.java/pull/1129

When trying to connect to a NATS server with [Auth Callout](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_callout), the client may be required to use a combination of an auth handler (NKey + Seed) plus user info (username + password). Currently, only either auth handler or user info is append in the options when building the client options string.

AuthHandler authHandler = Nats.staticCredentials(jwt, nkey);
Options connectOptions = Options.builder()
        .server(serverUri)
        .authHandler(authHandler)
        .userInfo(username, password)  
        .build();

This PR fixes the behavior in the client options to allow the usage of an auth handler in combination with username and password.