### PR TITLE
Improve socket close behavior

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'signing'
 }
 
-def jarVersion = "2.18.2"
+def jarVersion = "2.19.0"
 
 def isRelease = System.getenv("BUILD_EVENT") == "release"
 def brn = System.getenv("BRANCH_REF_NAME")

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -278,6 +278,11 @@ public class Options {
     public static final String PROP_SOCKET_WRITE_TIMEOUT = PFX + "socket.write.timeout";
     /**
      * Property used to configure a builder from a Properties object. {@value}, see
+     * {@link Builder#socketSoLinger(int) socketSoLinger}.
+     */
+    public static final String PROP_SOCKET_SO_LINGER = PFX + "socket.so.linger";
+    /**
+     * Property used to configure a builder from a Properties object. {@value}, see
      * {@link Builder#reconnectBufferSize(long) reconnectBufferSize}.
      */
     public static final String PROP_RECONNECT_BUF_SIZE = PFX + "reconnect.buffer.size";
@@ -589,6 +594,7 @@ public class Options {
     private final Duration reconnectJitterTls;
     private final Duration connectionTimeout;
     private final Duration socketWriteTimeout;
+    private final int socketSoLinger;
     private final Duration pingInterval;
     private final Duration requestCleanupInterval;
     private final int maxPingsOut;
@@ -700,6 +706,7 @@ public class Options {
         private Duration reconnectJitterTls = DEFAULT_RECONNECT_JITTER_TLS;
         private Duration connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
         private Duration socketWriteTimeout = DEFAULT_SOCKET_WRITE_TIMEOUT;
+        private int socketSoLinger = -1;
         private Duration pingInterval = DEFAULT_PING_INTERVAL;
         private Duration requestCleanupInterval = DEFAULT_REQUEST_CLEANUP_INTERVAL;
         private int maxPingsOut = DEFAULT_MAX_PINGS_OUT;
@@ -833,6 +840,7 @@ public class Options {
             longProperty(props, PROP_RECONNECT_BUF_SIZE, DEFAULT_RECONNECT_BUF_SIZE, l -> this.reconnectBufferSize = l);
             durationProperty(props, PROP_CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT, d -> this.connectionTimeout = d);
             durationProperty(props, PROP_SOCKET_WRITE_TIMEOUT, DEFAULT_SOCKET_WRITE_TIMEOUT, d -> this.socketWriteTimeout = d);
+            intProperty(props, PROP_SOCKET_SO_LINGER, -1, i -> socketSoLinger = i);
 
             intGtEqZeroProperty(props, PROP_MAX_CONTROL_LINE, DEFAULT_MAX_CONTROL_LINE, i -> this.maxControlLine = i);
             durationProperty(props, PROP_PING_INTERVAL, DEFAULT_PING_INTERVAL, d -> this.pingInterval = d);
@@ -1282,6 +1290,19 @@ public class Options {
          */
         public Builder socketWriteTimeout(Duration socketWriteTimeout) {
             this.socketWriteTimeout = socketWriteTimeout;
+            return this;
+        }
+
+        /**
+         * Set the value of the socket SO LINGER property in seconds.
+         * This feature is built in to library data port implementations.
+         * A value greater than or equal to 0 will call
+         * socket.setSoLinger with true and the timeout value
+         * @param socketSoLinger the number of seconds to linger
+         * @return the Builder for chaining
+         */
+        public Builder socketSoLinger(int socketSoLinger) {
+            this.socketSoLinger = socketSoLinger;
             return this;
         }
 
@@ -1757,6 +1778,10 @@ public class Options {
                 }
             }
 
+            if (socketSoLinger < 0) {
+                socketSoLinger = -1;
+            }
+
             if (errorListener == null) {
                 errorListener = new ErrorListenerLoggerImpl();
             }
@@ -1803,6 +1828,7 @@ public class Options {
             this.reconnectJitterTls = o.reconnectJitterTls;
             this.connectionTimeout = o.connectionTimeout;
             this.socketWriteTimeout = o.socketWriteTimeout;
+            this.socketSoLinger = o.socketSoLinger;
             this.pingInterval = o.pingInterval;
             this.requestCleanupInterval = o.requestCleanupInterval;
             this.maxPingsOut = o.maxPingsOut;
@@ -1864,6 +1890,7 @@ public class Options {
         this.reconnectJitterTls = b.reconnectJitterTls;
         this.connectionTimeout = b.connectionTimeout;
         this.socketWriteTimeout = b.socketWriteTimeout;
+        this.socketSoLinger = b.socketSoLinger;
         this.pingInterval = b.pingInterval;
         this.requestCleanupInterval = b.requestCleanupInterval;
         this.maxPingsOut = b.maxPingsOut;
@@ -2184,6 +2211,13 @@ public class Options {
      */
     public Duration getSocketWriteTimeout() {
         return socketWriteTimeout;
+    }
+
+    /**
+     * @return the socket so linger number of seconds, see {@link Builder#socketSoLinger(int) socketSoLinger()} in the builder doc
+     */
+    public int getSocketSoLinger() {
+        return socketSoLinger;
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/DataPort.java
+++ b/src/main/java/io/nats/client/impl/DataPort.java
@@ -52,5 +52,9 @@ public interface DataPort {
 
     void close() throws IOException;
 
+    default void forceClose() throws IOException {
+        close();
+    }
+
     void flush() throws IOException;
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -300,7 +300,7 @@ class NatsConnection implements Connection {
                 dataPort = null;
                 executor.submit(() -> {
                     try {
-                        closeMe.close();
+                        closeMe.forceClose();
                     }
                     catch (IOException ignore) {}
                 });

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -284,8 +284,6 @@ class NatsConnection implements Connection {
     }
 
     void forceReconnectImpl() throws IOException, InterruptedException {
-        NatsConnectionWriter oldWriter = writer;
-
         closeSocketLock.lock();
         try {
             updateStatus(Status.DISCONNECTED);
@@ -299,8 +297,7 @@ class NatsConnection implements Connection {
                 try {
                     dataPort.close();
                 }
-                catch (IOException ignore) {
-                }
+                catch (IOException ignore) {}
                 finally {
                     dataPort = null;
                 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -628,7 +628,9 @@ class NatsConnection implements Connection {
         } catch (Exception exp) {
             processException(exp);
             try {
-                this.closeSocket(false);
+                // allow force reconnect since this is pretty exceptional,
+                // a connection failure while trying to connect
+                this.closeSocket(false, true);
             } catch (InterruptedException e) {
                 processException(e);
             }
@@ -691,7 +693,9 @@ class NatsConnection implements Connection {
         // waiting on read/write threads
         executor.submit(() -> {
             try {
-                this.closeSocket(true);
+                // any issue that brings us here is pretty serious
+                // so we are comfortable forcing the close
+                this.closeSocket(true, true);
             } catch (InterruptedException e) {
                 processException(e);
                 Thread.currentThread().interrupt();
@@ -701,7 +705,7 @@ class NatsConnection implements Connection {
 
     // Close socket is called when another connect attempt is possible
     // Close is called when the connection should shut down, period
-    void closeSocket(boolean tryReconnectIfConnected) throws InterruptedException {
+    void closeSocket(boolean tryReconnectIfConnected, boolean forceClose) throws InterruptedException {
         // Ensure we close the socket exclusively within one thread.
         closeSocketLock.lock();
         try {
@@ -720,7 +724,7 @@ class NatsConnection implements Connection {
                 statusLock.unlock();
             }
 
-            closeSocketImpl();
+            closeSocketImpl(forceClose);
 
             statusLock.lock();
             try {
@@ -749,10 +753,10 @@ class NatsConnection implements Connection {
      */
     @Override
     public void close() throws InterruptedException {
-        this.close(true);
+        this.close(true, false);
     }
 
-    void close(boolean checkDrainStatus) throws InterruptedException {
+    void close(boolean checkDrainStatus, boolean forceClose) throws InterruptedException {
         statusLock.lock();
         try {
             if (checkDrainStatus && this.isDraining()) {
@@ -779,7 +783,7 @@ class NatsConnection implements Connection {
             this.reconnectWaiter.cancel(true);
         }
 
-        closeSocketImpl();
+        closeSocketImpl(forceClose);
 
         this.dispatchers.forEach((nuid, d) -> d.stop(false));
 
@@ -831,7 +835,7 @@ class NatsConnection implements Connection {
     }
 
     // Should only be called from closeSocket or close
-    void closeSocketImpl() {
+    void closeSocketImpl(boolean forceClose) {
         this.currentServer = null;
 
         // Signal both to stop.
@@ -854,8 +858,13 @@ class NatsConnection implements Connection {
 
         // Close the current socket and cancel anyone waiting for it
         try {
-            if (this.dataPort != null) {
-                this.dataPort.close();
+            if (dataPort != null) {
+                if (forceClose) {
+                    dataPort.forceClose();
+                }
+                else {
+                    dataPort.close();
+                }
             }
 
         } catch (IOException ex) {
@@ -2121,7 +2130,7 @@ class NatsConnection implements Connection {
         try {
             this.flush(timeout); // Flush and wait up to the timeout, if this fails, let the caller know
         } catch (Exception e) {
-            this.close(false);
+            this.close(false, false);
             throw e;
         }
 
@@ -2163,13 +2172,13 @@ class NatsConnection implements Connection {
                     }
                 }
 
-                this.close(false); // close the connection after the last flush
+                this.close(false, false); // close the connection after the last flush
                 tracker.complete(consumers.isEmpty());
             } catch (TimeoutException | InterruptedException e) {
                 this.processException(e);
             } finally {
                 try {
-                    this.close(false);// close the connection after the last flush
+                    this.close(false, false);// close the connection after the last flush
                 } catch (InterruptedException e) {
                     processException(e);
                     Thread.currentThread().interrupt();

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -94,13 +94,17 @@ class NatsConnectionReader implements Runnable {
         this.stopped = connection.getExecutor().submit(this, Boolean.TRUE);
     }
 
+    Future<Boolean> stop() {
+        return stop(true);
+    }
+
     // May be called several times on an error.
     // Returns a future that is completed when the thread completes, not when this
     // method does.
-    Future<Boolean> stop() {
+    Future<Boolean> stop(boolean shutdownDataPort) {
         if (running.get()) {
             running.set(false);
-            if (dataPort != null) {
+            if (shutdownDataPort && dataPort != null) {
                 try {
                     dataPort.shutdownInput();
                 }

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketException;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -166,15 +167,10 @@ public class SocketDataPort implements DataPort {
     @Override
     public void forceClose() throws IOException {
         try {
-            // If we are here, and are being asked to force close,
-            // there is no need to linger. The dev might have set
-            // their own linger, in which case use theirs,
-            // otherwise set it to 0 for the quickest close
-            if (soLinger < 0) {
-                socket.setSoLinger(true, 0);
-            }
+            // If we are being asked to force close, there is no need to linger.
+            socket.setSoLinger(true, 0);
         }
-        catch (IOException e) {
+        catch (SocketException e) {
             // don't want to fail if I couldn't set linger
         }
         close();

--- a/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
@@ -38,12 +38,15 @@ public class SocketDataPortWithWriteTimeout extends SocketDataPort {
             if (System.nanoTime() > writeMustBeDoneBy) {
                 writeWatcherTimer.cancel(); // we don't need to repeat this
                 connection.executeCallback((c, el) -> el.socketWriteTimeout(c));
-                connection.getExecutor().submit(() -> {
-                    try {
-                        connection.forceReconnect();
-                    }
-                    catch (IOException | InterruptedException ignore) {}
-                });
+                try {
+                    connection.forceReconnect();
+                }
+                catch (IOException e) {
+                    // retry maybe? forceReconnect
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }

--- a/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
@@ -53,6 +53,7 @@ public class SocketDataPortWithWriteTimeout extends SocketDataPort {
 
     @Override
     public void afterConstruct(Options options) {
+        super.afterConstruct(options);
         long writeTimeoutMillis;
         if (options.getSocketWriteTimeout() == null) {
             writeTimeoutMillis = Options.DEFAULT_SOCKET_WRITE_TIMEOUT.toMillis();

--- a/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
@@ -38,10 +38,6 @@ public class SocketDataPortWithWriteTimeout extends SocketDataPort {
             if (System.nanoTime() > writeMustBeDoneBy) {
                 writeWatcherTimer.cancel(); // we don't need to repeat this
                 connection.executeCallback((c, el) -> el.socketWriteTimeout(c));
-                try {
-                    out.close();
-                }
-                catch (IOException ignore) {}
                 connection.getExecutor().submit(() -> {
                     try {
                         connection.forceReconnect();


### PR DESCRIPTION
### Force Reconnect improvement
Execute `forceClose` with an executor task inside `forceReconnect`. This prevents the force reconnect behavior from being blocked if close blocks.

---

### SocketDataPortWithWriteTimeout tuning
In the SocketDataPortWithWriteTimeout implementation of the timeout watcher task:
1. Call the `forceReconnect` directly instead of running it on an executor task thread. It's already running on an executor task thread because that's where the watcher runs.
2. Removed the call to close the output stream of the socket. It's going to get closed anyway when the socket gets closed.

---

### Socket SO LINGER

Added an `Options.socketSoLinger(int socketSoLinger)` for the user to set the underlying `socket.setSoLinger()`. This will be used in normal close operations. If a `forceClose` is requested, any option value supplied will be overridden with `setSoLinger(true, 0)`

---

### Force Close

Added a `forceClose()` to the `DataPort` interface (with a default implementation that calls `close()`, to ensure interface backward compatibility) 
1. the base internal implementation, `SocketDataPort` implements `forceClose()`
2. `forceReconnect` calls `forceClose()`
3. `handleCommunicationIssue` calls `forceClose`