### PR TITLE
Add option to `forceReconnect` API to guarantee fair server distribution

### DIFF
--- a/src/main/java/io/nats/client/ForceReconnectOptions.java
+++ b/src/main/java/io/nats/client/ForceReconnectOptions.java
@@ -24,15 +24,21 @@ public class ForceReconnectOptions {
     public static final ForceReconnectOptions FORCE_CLOSE_INSTANCE = ForceReconnectOptions.builder().forceClose().build();
 
     private final boolean forceClose;
+    private final boolean fairServerDistribution;
     private final Duration flushWait;
 
     private ForceReconnectOptions(Builder b) {
         this.forceClose = b.forceClose;
         this.flushWait = b.flushWait;
+        this.fairServerDistribution = b.fairServerDistribution;
     }
 
     public boolean isForceClose() {
         return forceClose;
+    }
+
+    public boolean isFairServerDistribution() {
+        return fairServerDistribution;
     }
 
     public boolean isFlush() {
@@ -56,6 +62,7 @@ public class ForceReconnectOptions {
      */
     public static class Builder {
         boolean forceClose = false;
+        boolean fairServerDistribution = false;
         Duration flushWait;
 
         /**
@@ -65,6 +72,17 @@ public class ForceReconnectOptions {
 
         public Builder forceClose() {
             this.forceClose = true;
+            return this;
+        }
+
+        /**
+         * When disabled, client will never try to force reconnect to currently connected server.
+         * If enabled, list of available servers will be shuffled, so ServerPool#nextServer might return currently
+         * connected server.
+         * @return the builder
+         */
+        public Builder fairServerDistribution() {
+            this.fairServerDistribution = true;
             return this;
         }
 

--- a/src/main/java/io/nats/client/ServerPool.java
+++ b/src/main/java/io/nats/client/ServerPool.java
@@ -78,4 +78,9 @@ public interface ServerPool {
      * @return the flag
      */
     boolean hasSecureServer();
+
+    /**
+     * Randomly shuffle list of servers, so that `nextServer` returns arbitrary server from pool
+     */
+    void shuffle();
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -336,6 +336,9 @@ class NatsConnection implements Connection {
             closeSocketLock.unlock();
         }
 
+        if (options != null && options.isFairServerDistribution()) {
+            serverPool.shuffle();
+        }
         try {
             // calling connect just starts like a new connection versus reconnect
             // but we have to manually resubscribe like reconnect once it is connected

--- a/src/main/java/io/nats/client/impl/NatsServerPool.java
+++ b/src/main/java/io/nats/client/impl/NatsServerPool.java
@@ -298,6 +298,11 @@ public class NatsServerPool implements ServerPool {
         return hasSecureServer;
     }
 
+    @Override
+    public void shuffle() {
+        Collections.shuffle(entryList, ThreadLocalRandom.current());
+    }
+
     protected int findEquivalent(List<NatsUri> list, NatsUri toFind) {
         for (int i = 0; i < list.size(); i++) {
             NatsUri nuri = list.get(i);

--- a/src/test/java/io/nats/client/utils/CoverageServerPool.java
+++ b/src/test/java/io/nats/client/utils/CoverageServerPool.java
@@ -64,4 +64,8 @@ public class CoverageServerPool implements ServerPool {
     public boolean hasSecureServer() {
         return false;
     }
+
+    @Override
+    public void shuffle() {
+    }
 }


### PR DESCRIPTION
This addresses https://github.com/nats-io/nats.java/issues/1184