### PR TITLE
Fix: raise status message when doing incorrect pull

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
@@ -55,7 +55,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
             .noWait(isNoWait)
             .build();
         initSub(subscriptionMaker.subscribe(null, null, null, inactiveThreshold));
-        pullSubject = sub._pull(pro, false, this);
+        pullSubject = sub._pull(pro, true, this);
         startNanos = -1;
     }
 


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.java/issues/1194

Simple potential fix is enabling `raiseStatusWarnings` in the `_pull(..)`.

Would keep the behaviour the same, just informing the user of the status message being hit:
```
Aug 09, 2024 12:07:58 PM io.nats.client.impl.ErrorListenerLoggerImpl pullStatusWarning
WARNING: pullStatusWarning, Connection: 13, Subscription: 631365415, Consumer Name: 8V2ygPms7b, Status:Status{code=409, message='Exceeded MaxRequestBatch of 1'}
```