### PR TITLE
Catch errors in Dispatchers and log

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -106,6 +106,8 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
                                 handler.onMessage(msg);
                             } catch (Exception exp) {
                                 connection.processException(exp);
+                            } catch (Error err) {
+                                connection.processException(new Exception(err));
                             }
 
                             if (sub.reachedUnsubLimit()) {

--- a/src/main/java/io/nats/client/impl/NatsDispatcherWithExecutor.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcherWithExecutor.java
@@ -48,6 +48,8 @@ class NatsDispatcherWithExecutor extends NatsDispatcher {
                                     finalHandler.onMessage(msg);
                                 } catch (Exception exp) {
                                     connection.processException(exp);
+                                } catch (Error err) {
+                                    connection.processException(new Exception(err));
                                 }
 
                                 if (sub.reachedUnsubLimit()) {


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.java/issues/1198

We could handle the `Error` in the `ErrorListener` just like the `Exception` is handled.
But, an `Error` is likely to not be recoverable so probably stopping the dispatcher is the way to go? Just need to log that it happened.