### PR TITLE
While `handleCommunicationIssue`, `closeSocket` should use reconnect impl otherwise `tryingToConnect` will guard

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -880,7 +880,11 @@ class NatsConnection implements Connection {
             //
         }
 
-        this.dataPortFuture.cancel(true);
+        // Close and reset the current data port and future
+        if (dataPortFuture != null) {
+            dataPortFuture.cancel(true);
+            dataPortFuture = null;
+        }
 
         // Close the current socket and cancel anyone waiting for it
         try {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -765,7 +765,7 @@ class NatsConnection implements Connection {
             if (isClosing()) { // isClosing() means we are in the close method or were asked to be
                 close();
             } else if (wasConnected && tryReconnectIfConnected) {
-                reconnect();
+                reconnectImpl(); // call the impl here otherwise the tryingToConnect guard will block the behavior
             }
         } finally {
             closeSocketLock.unlock();

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -326,12 +326,12 @@ class NatsConnection implements Connection {
 
             // stop i/o
             try {
-                this.reader.stop(false).get(10, TimeUnit.SECONDS);
+                this.reader.stop(false).get(100, TimeUnit.MILLISECONDS);
             } catch (Exception ex) {
                 processException(ex);
             }
             try {
-                this.writer.stop().get(10, TimeUnit.SECONDS);
+                this.writer.stop().get(100, TimeUnit.MILLISECONDS);
             } catch (Exception ex) {
                 processException(ex);
             }

--- a/src/test/java/io/nats/client/ConnectTests.java
+++ b/src/test/java/io/nats/client/ConnectTests.java
@@ -617,4 +617,17 @@ public class ConnectTests {
         assertTrue(urls3.contains(port2));
         assertTrue(urls3.contains(port3));
     }
+
+    // https://github.com/nats-io/nats.java/issues/1201
+    @Test
+    void testLowConnectionTimeoutResultsInIOException() {
+        Options options = Options.builder()
+                .connectionTimeout(Duration.ZERO)
+                .build();
+
+        assertThrows(IOException.class, () -> {
+            Connection nc = Nats.connect(options);
+            nc.close();
+        });
+    }
 }


### PR DESCRIPTION
If we'd call `handleCommunicationIssue` the `tryingToConnect` would be set to `true`.
Then if `reconnect()` was called it would check if `tryingToConnect` was not set, but because we did set it before we didn't reconnect.

Using `reconnectImpl` bypasses that guard, since we're already in `tryingToConnect` state.