### PR TITLE
Remove redundant `writer.flushBuffer()` call

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1323,7 +1323,6 @@ class NatsConnection implements Connection {
         }
 
         publishInternal(subject, responseInbox, headers, data, validateSubRep);
-        writer.flushBuffer();
         statistics.incrementRequestsSent();
 
         return future;


### PR DESCRIPTION
When doing a request through `requestFutureInternal` we'd publish the message into the outgoing write queue, and immediately after call `writer.flushBuffer()`.

Due to the message needing to go through the outgoing message queue, which takes a small amount of time, the `flushBuffer` would be done first and before our message got written to the `dataPort`.

Removing the call to `writer.flushBuffer()` since it doesn't actually flush our message/request.

Signed-off-by: Maurice van Veen <github@mauricevanveen.com>