### PR TITLE
When interrupted call interrupt

### DIFF
--- a/src/main/java/io/nats/client/impl/MessageQueue.java
+++ b/src/main/java/io/nats/client/impl/MessageQueue.java
@@ -185,6 +185,7 @@ class MessageQueue {
             this.length.incrementAndGet();
             return true;
         } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
             return false;
         } finally {
             editLock.unlock();

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -653,6 +653,7 @@ class NatsConnection implements Connection {
                 this.closeSocket(false, true);
             } catch (InterruptedException e) {
                 processException(e);
+                Thread.currentThread().interrupt();
             }
         } finally {
             statusLock.lock();
@@ -1516,7 +1517,11 @@ class NatsConnection implements Connection {
         catch (ExecutionException e) {
             throw new IOException(e.getCause());
         }
-        catch (InterruptedException | TimeoutException e) {
+        catch (TimeoutException e) {
+            throw new IOException(e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IOException(e);
         }
     }
@@ -2211,8 +2216,11 @@ class NatsConnection implements Connection {
 
                 this.close(false, false); // close the connection after the last flush
                 tracker.complete(consumers.isEmpty());
-            } catch (TimeoutException | InterruptedException e) {
+            } catch (TimeoutException e) {
                 this.processException(e);
+            } catch (InterruptedException e) {
+                this.processException(e);
+                Thread.currentThread().interrupt();
             } finally {
                 try {
                     this.close(false, false);// close the connection after the last flush

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -172,8 +172,11 @@ class NatsConnectionReader implements Runnable {
             if (running.get()) {
                 this.connection.handleCommunicationIssue(io);
             }
-        } catch (CancellationException | ExecutionException | InterruptedException ex) {
+        } catch (CancellationException | ExecutionException ex) {
             // Exit
+        } catch (InterruptedException ex) {
+            // Exit
+            Thread.currentThread().interrupt();
         } finally {
             this.running.set(false);
             // Clear the buffers, since they are only used inside this try/catch

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -209,8 +209,11 @@ class NatsConnectionWriter implements Runnable {
             if (running.get()) {
                 this.connection.handleCommunicationIssue(io);
             }
-        } catch (CancellationException | ExecutionException | InterruptedException ex) {
+        } catch (CancellationException | ExecutionException ex) {
             // Exit
+        } catch (InterruptedException ex) {
+            // Exit
+            Thread.currentThread().interrupt();
         } finally {
             this.running.set(false);
         }

--- a/src/main/java/io/nats/client/impl/NatsConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumer.java
@@ -221,6 +221,7 @@ abstract class NatsConsumer implements Consumer {
                 this.cleanUpAfterDrain();
             } catch (InterruptedException e) {
                 this.connection.processException(e);
+                Thread.currentThread().interrupt();
             } finally {
                 tracker.complete(this.isDrained());
             }

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -126,6 +126,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
             if (this.running.get()){
                 this.connection.processException(exp);
             } //otherwise we did it
+            Thread.currentThread().interrupt();
         }
         finally {
             this.running.set(false);

--- a/src/main/java/io/nats/client/impl/NatsDispatcherWithExecutor.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcherWithExecutor.java
@@ -69,6 +69,7 @@ class NatsDispatcherWithExecutor extends NatsDispatcher {
             if (this.running.get()){
                 this.connection.processException(exp);
             } //otherwise we did it
+            Thread.currentThread().interrupt();
         }
         finally {
             this.running.set(false);

--- a/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
@@ -232,6 +232,7 @@ class NatsJetStreamImpl implements NatsJetStreamConstants {
         try {
             return responseRequired(conn.request(prependPrefix(subject), bytes, timeout));
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IOException(e);
         }
     }
@@ -240,6 +241,7 @@ class NatsJetStreamImpl implements NatsJetStreamConstants {
         try {
             return responseRequired(conn.requestInternal(subject, headers, data, timeout, cancelAction, validateSubjectAndReplyTo));
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new IOException(e);
         }
     }


### PR DESCRIPTION
Add missing `Thread.currentThread().interrupt();` calls where `InterruptedException` was caught.