### PR TITLE
Fix `cleanResponses` must handle cleaning up cancelled future

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1171,7 +1171,7 @@ class NatsConnection implements Connection {
                     wasInterrupted = true;
                     break;
                 }
-                catch (Exception ignore) {}
+                catch (Throwable ignore) {}
             }
 
             if (remove) {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1171,7 +1171,7 @@ class NatsConnection implements Connection {
                     wasInterrupted = true;
                     break;
                 }
-                catch (ExecutionException ignore) {}
+                catch (Exception ignore) {}
             }
 
             if (remove) {


### PR DESCRIPTION
If a future would be cancelled outside of `cleanResponses`, calling `future.get()` would throw a `CancellationException`.

This exception was not caught, breaking future cleanup.