### PR TITLE
WS: some cleanup (Java code, JavaDoc, JUnit method signatures, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@
 [![Build Main Badge](https://github.com/nats-io/nats.java/actions/workflows/build-main.yml/badge.svg?event=push)](https://github.com/nats-io/nats.java/actions/workflows/build-main.yml)
 [![Release Badge](https://github.com/nats-io/nats.java/actions/workflows/build-release.yml/badge.svg?event=release)](https://github.com/nats-io/nats.java/actions/workflows/build-release.yml)
 
-The [**API**](https://javadoc.io/doc/io.nats/jnats/latest/index.html) is simple to use and highly performant.
 
-**Check out [NATS by Example](https://natsbyexample.com) - An evolving collection of runnable, cross-client reference examples for NATS.**
+### Examples and other documentation...
 
-There are also many basic examples in the [examples](https://github.com/nats-io/nats.java/tree/main/src/examples/java/io/nats/examples) directory of this repo
-and more simple application examples in the [Java Nats Examples](https://github.com/nats-io/java-nats-examples) repo.
+1. [**Java API Docs**](https://javadoc.io/doc/io.nats/jnats/latest/index.html) - the latest Java API docs.
+1. [**NATS by Example**](https://natsbyexample.com) - An evolving collection of runnable, cross-client reference examples for NATS.
+1. The [**examples directory**](https://github.com/nats-io/nats.java/tree/main/src/examples/java/io/nats/examples) covers basic api use.
+1. The [**Java Nats Examples**](https://github.com/nats-io/java-nats-examples) github repo, a collection of simple use case examples.
 
 ## Table of Contents
 * [Simplification](#simplification)

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ The ability to reconnect on  the initial connection failure is _NOT_ an Options 
 
 #### Clusters & Reconnecting
 
-The Java client will automatically reconnect if it loses its connection the nats-server. If given a single server, the client will keep trying that one. If given a list of servers, the client will rotate between them. When the nats servers are in a cluster, they will tell the client about the other servers, so that in the simplest case a client could connect to one server, learn about the cluster and reconnect to another server if its initial one goes down.
+The Java client will automatically reconnect if it loses its connection to the nats-server. If given a single server, the client will keep trying that one. If given a list of servers, the client will rotate between them. When the nats servers are in a cluster, they will tell the client about the other servers, so that in the simplest case a client could connect to one server, learn about the cluster and reconnect to another server if its initial one goes down.
 
 To tell the connection about multiple servers for the initial connection, use the `servers()` method on the options builder, or call `server()` multiple times.
 

--- a/src/examples/java/io/nats/examples/ConnectTime.java
+++ b/src/examples/java/io/nats/examples/ConnectTime.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 
 /**
  * This example will demonstrate how to build a listener that will track connect time.
- *
+ * <p>
  * Usage: java ConnectTime [server]
  *   Use tls:// or opentls:// to require tls, via the Default SSLContext
  *   Set the environment variable NATS_NKEY to use challenge response authentication by setting a file containing your private key.

--- a/src/examples/java/io/nats/examples/autobench/JsPubAsyncRoundsBenchmark.java
+++ b/src/examples/java/io/nats/examples/autobench/JsPubAsyncRoundsBenchmark.java
@@ -70,7 +70,7 @@ public class JsPubAsyncRoundsBenchmark extends AutoBenchmark {
                     for (long l = 0; l < thisRound; l++) {
                         futures.add(js.publishAsync(subject, payload));
                     }
-                    while (futures.size() > 0) {
+                    while (!futures.isEmpty()) {
                         List<CompletableFuture<PublishAck>> notDone = new ArrayList<>((int)roundSize);
                         for (CompletableFuture<PublishAck> f : futures) {
                             if (!f.isDone()) {

--- a/src/examples/java/io/nats/examples/autobench/JsPubBenchmark.java
+++ b/src/examples/java/io/nats/examples/autobench/JsPubBenchmark.java
@@ -26,7 +26,7 @@ public class JsPubBenchmark extends AutoBenchmark {
     private static final Map<String, String> SAVED_SUBJECTS = new HashMap<>();
 
     public static String getKey(long messageCount, long messageSize) {
-        return "" + messageCount + "x" + messageSize;
+        return messageCount + "x" + messageSize;
     }
 
     public static String getStream(long messageCount, long messageSize) {

--- a/src/examples/java/io/nats/examples/autobench/LatencyBenchmark.java
+++ b/src/examples/java/io/nats/examples/autobench/LatencyBenchmark.java
@@ -43,7 +43,7 @@ public class LatencyBenchmark extends AutoBenchmark {
         this.lcsv = lcsv;
     }
 
-    public void execute(Options connectOptions) throws InterruptedException {
+    public void execute(Options connectOptions) {
         byte[] payload = createPayload();
         String subject = getSubject();
 
@@ -240,7 +240,7 @@ public class LatencyBenchmark extends AutoBenchmark {
         measurements.sort(Long::compareTo);
 
         if (size % 2 == 1) {
-            return measurements.get(middle).longValue();
+            return measurements.get(middle);
         } else {
             double low = measurements.get(middle-1).doubleValue() / 2.0;
             double high = measurements.get(middle).doubleValue() / 2.0;

--- a/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
+++ b/src/examples/java/io/nats/examples/autobench/NatsAutoBench.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Implements a benchmark more like the .net client that loops over a number
  * of scenarios benchmarking each one. This class hard codes most settings to minimize
  * boilerplate and focus on the nats client code (plus measurement).
- * 
+ * <p>
  * Each benchmark is implemented in its own class, and this main class just builds instances
  * and runs them.
  */
@@ -62,7 +62,7 @@ public class NatsAutoBench {
                                                     connectionTimeout(Duration.ofSeconds(1)).
                                                     noReconnect();
 
-            /**
+            /*
              * The conscrypt flag is provided for testing with the conscrypt jar. Using it through reflection is
              * deprecated but allows the library to ship without a dependency. Using conscrypt should only require the
              * jar plus the flag. For example, to run after building locally and using the test cert files:

--- a/src/examples/java/io/nats/examples/autobench/ThrottledBenchmark.java
+++ b/src/examples/java/io/nats/examples/autobench/ThrottledBenchmark.java
@@ -73,10 +73,8 @@ public abstract class ThrottledBenchmark extends AutoBenchmark {
      * become slow consumers. The addition of this code was motivated by the asymetry in the java library between
      * publishers and subscribers, especially if UTF-8 subjects are enabled.
      * @param nc the connection
-     * @throws InterruptedException
      */
-	void adjustAndSleep(Connection nc) throws InterruptedException {
-
+	void adjustAndSleep(Connection nc) {
         long count = sent.incrementAndGet();
 
         if (this.targetPubRate <= 0) {

--- a/src/examples/java/io/nats/examples/benchmark/Benchmark.java
+++ b/src/examples/java/io/nats/examples/benchmark/Benchmark.java
@@ -44,8 +44,8 @@ public class Benchmark extends Sample {
     public Benchmark(String name, String runId) {
         this.name = name;
         this.runId = runId;
-        this.subChannel = new LinkedBlockingQueue<Sample>();
-        this.pubChannel = new LinkedBlockingQueue<Sample>();
+        this.subChannel = new LinkedBlockingQueue<>();
+        this.pubChannel = new LinkedBlockingQueue<>();
     }
 
     public final void addPubSample(Sample sample) {
@@ -60,10 +60,10 @@ public class Benchmark extends Sample {
      * Closes this benchmark and calculates totals and times.
      */
     public final void close() {
-        while (subChannel.size() > 0) {
+        while (!subChannel.isEmpty()) {
             subs.addSample(subChannel.poll());
         }
-        while (pubChannel.size() > 0) {
+        while (!pubChannel.isEmpty()) {
             pubs.addSample(pubChannel.poll());
         }
 

--- a/src/examples/java/io/nats/examples/benchmark/JsPublishInRoundsBench.java
+++ b/src/examples/java/io/nats/examples/benchmark/JsPublishInRoundsBench.java
@@ -78,7 +78,7 @@ public class JsPublishInRoundsBench {
                 for (int x = 0; x < a.roundSize; x++) {
                     futures.add(js.publishAsync(m));
                 }
-                while (futures.size() > 0) {
+                while (!futures.isEmpty()) {
                     List<CompletableFuture<PublishAck>> notDone = new ArrayList<>();
                     for (CompletableFuture<PublishAck> f : futures) {
                         if (f.isDone()) {

--- a/src/examples/java/io/nats/examples/benchmark/NatsBench.java
+++ b/src/examples/java/io/nats/examples/benchmark/NatsBench.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * boilerplate.
  */
 public class NatsBench {
-    final BlockingQueue<Throwable> errorQueue = new LinkedBlockingQueue<Throwable>();
+    final BlockingQueue<Throwable> errorQueue = new LinkedBlockingQueue<>();
 
     // Default test values
     private int numMsgs = 5_000_000;
@@ -68,7 +68,7 @@ public class NatsBench {
             + "    -tls                            Set the secure flag on the SSL context to true (false)\n"
             + "    -stats                          Track and print out internal statistics (false)\n";
 
-    public NatsBench(String[] args) throws Exception {
+    public NatsBench(String[] args) {
         if (args == null || args.length < 1) {
             usage();
             return;
@@ -76,7 +76,7 @@ public class NatsBench {
         parseArgs(args);
     }
 
-    public NatsBench(Properties properties) throws NoSuchAlgorithmException {
+    public NatsBench(Properties properties) {
         urls = properties.getProperty("bench.nats.servers", urls);
         secure = Boolean.parseBoolean(properties.getProperty("bench.nats.secure", Boolean.toString(secure)));
         numMsgs = Integer.parseInt(properties.getProperty("bench.nats.msg.count", Integer.toString(numMsgs)));
@@ -115,7 +115,7 @@ public class NatsBench {
             builder.turnOnAdvancedStats();
         }
 
-        /**
+        /*
          * The conscrypt flag is provided for testing with the conscrypt jar. Using it
          * through reflection is deprecated but allows the library to ship without a
          * dependency. Using conscrypt should only require the jar plus the flag. For
@@ -405,7 +405,7 @@ public class NatsBench {
     }
 
     private void parseArgs(String[] args) {
-        List<String> argList = new ArrayList<String>(Arrays.asList(args));
+        List<String> argList = new ArrayList<>(Arrays.asList(args));
 
         subject = argList.get(argList.size() - 1);
         argList.remove(argList.size() - 1);

--- a/src/examples/java/io/nats/examples/benchmark/NatsBench2.java
+++ b/src/examples/java/io/nats/examples/benchmark/NatsBench2.java
@@ -37,7 +37,7 @@ import static io.nats.client.support.NatsConstants.OUTPUT_QUEUE_IS_FULL;
  * boilerplate.
  */
 public class NatsBench2 {
-    final BlockingQueue<Throwable> errorQueue = new LinkedBlockingQueue<Throwable>();
+    final BlockingQueue<Throwable> errorQueue = new LinkedBlockingQueue<>();
 
     // Default test values
     private int numMsgs = 5_000_000;
@@ -136,7 +136,7 @@ public class NatsBench2 {
             builder.turnOnAdvancedStats();
         }
 
-        /**
+        /*
          * The conscrypt flag is provided for testing with the conscrypt jar. Using it
          * through reflection is deprecated but allows the library to ship without a
          * dependency. Using conscrypt should only require the jar plus the flag. For
@@ -276,7 +276,7 @@ public class NatsBench2 {
 
                     boolean success = false ;
                     
-                    for (int idx = 5; idx < 10 && success == false; idx++) {
+                    for (int idx = 5; idx < 10 && !success; idx++) {
                         try {
                             nc.publish(subject, payload);
                             success = true;
@@ -446,7 +446,7 @@ public class NatsBench2 {
     }
 
     private void parseArgs(String[] args) {
-        List<String> argList = new ArrayList<String>(Arrays.asList(args));
+        List<String> argList = new ArrayList<>(Arrays.asList(args));
 
         subject = argList.get(argList.size() - 1);
         argList.remove(argList.size() - 1);

--- a/src/examples/java/io/nats/examples/benchmark/RawTCPLatencyTest.java
+++ b/src/examples/java/io/nats/examples/benchmark/RawTCPLatencyTest.java
@@ -6,7 +6,6 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.SocketException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -65,7 +64,7 @@ public class RawTCPLatencyTest {
         }
     }
 
-    private static void runClient() throws SocketException, IOException {
+    private static void runClient() throws IOException {
         Socket socket = new Socket();
         socket.setTcpNoDelay(true);
         socket.setReceiveBufferSize(2 * 1024 * 1024);

--- a/src/examples/java/io/nats/examples/benchmark/SampleGroup.java
+++ b/src/examples/java/io/nats/examples/benchmark/SampleGroup.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 class SampleGroup extends Sample {
-    private final List<Sample> samples = new ArrayList<Sample>();
+    private final List<Sample> samples = new ArrayList<>();
 
     SampleGroup(SampleGroup... groups) {
         for (SampleGroup g : groups) {

--- a/src/examples/java/io/nats/examples/benchmark/Utils.java
+++ b/src/examples/java/io/nats/examples/benchmark/Utils.java
@@ -47,10 +47,10 @@ public final class Utils {
      *
      * @param numMsgs    the total number of messages
      * @param numClients the total number of clients
-     * @return an array of message counts
+     * @return a {@link List} of message counts
      */
     public static List<Integer> msgsPerClient(int numMsgs, int numClients) {
-        List<Integer> counts = new ArrayList<Integer>(numClients);
+        List<Integer> counts = new ArrayList<>(numClients);
         if (numClients == 0 || numMsgs == 0) {
             return counts;
         }

--- a/src/examples/java/io/nats/examples/chaosTestApp/ChaosTestApp.java
+++ b/src/examples/java/io/nats/examples/chaosTestApp/ChaosTestApp.java
@@ -53,7 +53,7 @@ public class ChaosTestApp {
 //            + " --logdir c:\\temp"
     ).split(" ");
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
 
         args = MANUAL_ARGS; // comment out for real command line
 

--- a/src/examples/java/io/nats/examples/chaosTestApp/ConnectableConsumer.java
+++ b/src/examples/java/io/nats/examples/chaosTestApp/ConnectableConsumer.java
@@ -37,7 +37,7 @@ public abstract class ConnectableConsumer implements ConnectionListener {
     protected String durableName;
     protected String label;
 
-    public ConnectableConsumer(CommandLine cmd, String initials, ConsumerKind consumerKind) throws IOException, InterruptedException, JetStreamApiException {
+    public ConnectableConsumer(CommandLine cmd, String initials, ConsumerKind consumerKind) throws IOException, InterruptedException {
         this.cmd = cmd;
         lastReceivedSequence = new AtomicLong(0);
         this.consumerKind = consumerKind;

--- a/src/examples/java/io/nats/examples/chaosTestApp/Output.java
+++ b/src/examples/java/io/nats/examples/chaosTestApp/Output.java
@@ -63,7 +63,7 @@ public class Output extends JPanel {
         String fontName = Font.MONOSPACED;
         GraphicsEnvironment localEnv;
         localEnv= GraphicsEnvironment.getLocalGraphicsEnvironment();
-        String allfonts[] = localEnv.getAvailableFontFamilyNames();
+        String[] allfonts = localEnv.getAvailableFontFamilyNames();
         for (String allfont : allfonts) {
             if (allfont.equals("JetBrains Mono")) {
                 fontName = allfont;

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPrefix.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPrefix.java
@@ -26,7 +26,7 @@ import static io.nats.examples.jetstream.NatsJsUtils.printStreamInfo;
 
 /**
  * This example will demonstrate connecting on an account that uses a custom prefix.
- *
+ * <p>
  * Server configuration (prefix.conf)
  * <pre>
  * port: 4222

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPubAsync.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPubAsync.java
@@ -87,7 +87,7 @@ public class NatsJsPubAsync {
                 futures.add(js.publishAsync(msg));
             }
 
-            while (futures.size() > 0) {
+            while (!futures.isEmpty()) {
                 CompletableFuture<PublishAck> f = futures.remove(0);
                 if (f.isDone()) {
                     try {

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPubAsync2.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPubAsync2.java
@@ -23,8 +23,6 @@ import io.nats.examples.ExampleArgs;
 import io.nats.examples.ExampleUtils;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.*;
 
 /**

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPubVersusCorePub.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPubVersusCorePub.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 /**
  * This example will demonstrate the ability to publish to a stream with either
  * the JetStream.publish(...) or with core Connection.publish(...)
- *
+ * <p>
  * The difference lies in the whether it's important to your application to receive
  * a publish ack and whether or not you want to set publish expectations.
  */

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubBatchSize.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubBatchSize.java
@@ -87,7 +87,7 @@ public class NatsJsPullSubBatchSize {
                 while (m != null) {
                     if (m.isJetStream()) {
                         red++; // process message
-                        System.out.println("" + red + ". " + m);
+                        System.out.println(red + ". " + m);
                         m.ack();
                     }
                     m = sub.nextMessage(Duration.ofMillis(100)); // other messages should already be on the client

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubExpiresIn.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubExpiresIn.java
@@ -77,7 +77,7 @@ public class NatsJsPullSubExpiresIn {
                 while (m != null) {
                     if (m.isJetStream()) {
                         red++; // process message
-                        System.out.println("" + red + ". " + m);
+                        System.out.println(red + ". " + m);
                         m.ack();
                     }
                     m = sub.nextMessage(Duration.ofMillis(100)); // other messages should already be on the client

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubFetch.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubFetch.java
@@ -82,7 +82,7 @@ public class NatsJsPullSubFetch {
                 List<Message> list = sub.fetch(10, Duration.ofSeconds(1));
                 for (Message m : list) {
                     red++; // process message
-                    System.out.println("" + red + ". " + m);
+                    System.out.println(red + ". " + m);
                     m.ack();
                 }
             }

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubIterate.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubIterate.java
@@ -83,7 +83,7 @@ public class NatsJsPullSubIterate {
                 while (iter.hasNext()) {
                     Message m = iter.next();
                     red++; // process message
-                    System.out.println("" + red + ". " + m);
+                    System.out.println(red + ". " + m);
                     m.ack();
                 }
             }

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubMultipleWorkers.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsPullSubMultipleWorkers.java
@@ -190,7 +190,7 @@ public class NatsJsPullSubMultipleWorkers {
         public void run() {
             while (allReceived.get() < exArgs.msgCount) {
                 List<Message> messages = sub.fetch(5, 500);
-                while (messages != null && messages.size() > 0) {
+                while (messages != null && !messages.isEmpty()) {
                     for (Message msg : messages) {
                         thisReceived++;
                         allReceived.incrementAndGet();

--- a/src/examples/java/io/nats/examples/jetstream/NatsJsUtils.java
+++ b/src/examples/java/io/nats/examples/jetstream/NatsJsUtils.java
@@ -343,7 +343,7 @@ public class NatsJsUtils {
         }
 
         if (verbose) {
-            System.out.println(messages.size() == 0 ? " No messages available <-" : " <- ");
+            System.out.println(messages.isEmpty() ? " No messages available <-" : " <- ");
         }
 
         return messages;

--- a/src/examples/java/io/nats/examples/jetstream/ResilientPublisher.java
+++ b/src/examples/java/io/nats/examples/jetstream/ResilientPublisher.java
@@ -31,7 +31,7 @@ import static io.nats.examples.jetstream.NatsJsUtils.report;
 /**
  * This example will demonstrate simplified fetch that is resilient
  * HOW TO TEST
- * 1. Set up and run a simple cluster. See https://github.com/nats-io/java-nats-examples/tree/main/example-cluster-config
+ * 1. Set up and run a simple cluster. See <a href="https://github.com/nats-io/java-nats-examples/tree/main/example-cluster-config">https://github.com/nats-io/java-nats-examples/tree/main/example-cluster-config</a>
  * 2. Run this program, watch the output for some time
  * 3. Kill the server that is the leader, let it stay down for a short time or a long time
  * 4. See the output showing things aren't running.

--- a/src/examples/java/io/nats/examples/jetstream/simple/FetchResilientExample.java
+++ b/src/examples/java/io/nats/examples/jetstream/simple/FetchResilientExample.java
@@ -26,7 +26,7 @@ import static io.nats.examples.jetstream.NatsJsUtils.*;
 /**
  * This example will demonstrate simplified fetch that is resilient
  * HOW TO TEST
- * 1. Set up and run a simple cluster. See https://github.com/nats-io/java-nats-examples/tree/main/example-cluster-config
+ * 1. Set up and run a simple cluster. See <a href="https://github.com/nats-io/java-nats-examples/tree/main/example-cluster-config">https://github.com/nats-io/java-nats-examples/tree/main/example-cluster-config</a>
  * 2. Run this program, watch the output for some time
  * 3. Kill the server that is the leader, let it stay down for a short time or a long time
  * 4. See the output showing things aren't running.
@@ -44,13 +44,19 @@ public class FetchResilientExample implements Runnable {
     static final long STREAM_REPORT_FREQUENCY = 30000;
 
     static String SERVER = "nats://localhost:4222";
+    public final AtomicBoolean keepGoing = new AtomicBoolean(true);
+    private final ConsumerContext cc;
+    private long reportAt = 0;
+    public FetchResilientExample(ConsumerContext cc) {
+        this.cc = cc;
+    }
 
     public static void main(String[] args) {
         Options options = Options.builder().server(SERVER)
-            .connectionListener((c, t) -> {
-                report("Connection: " + c.getServerInfo().getPort() + " " + t);
-            })
-            .build();
+                .connectionListener((c, t) -> {
+                    report("Connection: " + c.getServerInfo().getPort() + " " + t);
+                })
+                .build();
 
         try (Connection nc = Nats.connect(options)) {
             final JetStreamManagement jsm = nc.jetStreamManagement();
@@ -62,9 +68,9 @@ public class FetchResilientExample implements Runnable {
 
             // simulating a publisher somewhere else.
             ResilientPublisher rp = new ResilientPublisher(nc, jsm, STREAM, SUBJECT)
-                .basicDataPrefix(MESSAGE_PREFIX)
-                .delay(PUBLISH_DELAY)
-                .reportFrequency(PUB_REPORT_FREQUENCY);
+                    .basicDataPrefix(MESSAGE_PREFIX)
+                    .delay(PUBLISH_DELAY)
+                    .reportFrequency(PUB_REPORT_FREQUENCY);
             Thread pubThread = new Thread(rp);
             pubThread.start();
 
@@ -72,34 +78,23 @@ public class FetchResilientExample implements Runnable {
 
             StreamContext sc = js.getStreamContext(STREAM);
             ConsumerContext cc = sc.createOrUpdateConsumer(
-                ConsumerConfiguration.builder()
-                    .durable(CONSUMER_NAME)
-                    .filterSubject(SUBJECT)
-                    .build());
+                    ConsumerConfiguration.builder()
+                            .durable(CONSUMER_NAME)
+                            .filterSubject(SUBJECT)
+                            .build());
 
             FetchResilientExample example = new FetchResilientExample(cc);
             Thread consumeThread = new Thread(example);
             consumeThread.start();
 
             consumeThread.join(); // just letting this run
-        }
-        catch (IOException ioe) {
+        } catch (IOException ioe) {
             // problem making the connection or
-        }
-        catch (InterruptedException e) {
+        } catch (InterruptedException e) {
             // thread interruption in the body of the example
-        }
-        catch (JetStreamApiException e) {
+        } catch (JetStreamApiException e) {
             // some api exception
         }
-    }
-
-    public final AtomicBoolean keepGoing = new AtomicBoolean(true);
-    private final ConsumerContext cc;
-    private long reportAt = 0;
-
-    public FetchResilientExample(ConsumerContext cc) {
-        this.cc = cc;
     }
 
     public void stop() {
@@ -121,8 +116,7 @@ public class FetchResilientExample implements Runnable {
                     m.ack();
                     m = fc.nextMessage();
                 }
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
                 // do we care if the autocloseable FetchConsumer errors on close?
                 // probably not, but maybe log it.
             }
@@ -135,8 +129,7 @@ public class FetchResilientExample implements Runnable {
                 }
                 //noinspection BusyWait
                 Thread.sleep(10);
-            }
-            catch (InterruptedException e) {
+            } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/src/examples/java/io/nats/examples/stability/StabilityPub.java
+++ b/src/examples/java/io/nats/examples/stability/StabilityPub.java
@@ -28,7 +28,7 @@ public class StabilityPub {
             "\nUsage: java -cp <classpath> StabilityPub [server] <subject> <msgSize>"
                     + "\n\nUse tls:// or opentls:// to require tls, via the Default SSLContext\n";
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         String subject;
         String server;
         int msgSize;

--- a/src/examples/java/io/nats/examples/stability/StabilitySub.java
+++ b/src/examples/java/io/nats/examples/stability/StabilitySub.java
@@ -26,7 +26,7 @@ public class StabilitySub {
             "\nUsage: java -cp <classpath> StabilitySub [server] <subject>"
                     + "\n\nUse tls:// or opentls:// to require tls, via the Default SSLContext\n";
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         String subject;
         String server;
         long nullCount = 0;

--- a/src/examples/java/io/nats/examples/stan/Stan.java
+++ b/src/examples/java/io/nats/examples/stan/Stan.java
@@ -35,7 +35,7 @@ public class Stan {
             + "Messages to stan.exit will cause stan to go away, if they contain the data \"confirm\".\n" 
             + "The server name help will print this message.\n";
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         String server = "help";
 
         if (args.length == 1) {

--- a/src/examples/java/io/nats/examples/stan/StanExit.java
+++ b/src/examples/java/io/nats/examples/stan/StanExit.java
@@ -27,7 +27,7 @@ public class StanExit {
             "\nUsage: java StanExit [server]"
             + "\n\nUse tls:// or opentls:// to require tls, via the Default SSLContext\n";
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         String server = "help";
 
         if (args.length == 1) {

--- a/src/examples/java/io/nats/examples/stan/StanRandom.java
+++ b/src/examples/java/io/nats/examples/stan/StanRandom.java
@@ -27,7 +27,7 @@ public class StanRandom {
             "\nUsage: java StanRandom [server]"
             + "\n\nUse tls:// or opentls:// to require tls, via the Default SSLContext\n";
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         String server = "help";
 
         if (args.length == 1) {

--- a/src/examples/java/io/nats/examples/stan/StanTime.java
+++ b/src/examples/java/io/nats/examples/stan/StanTime.java
@@ -27,7 +27,7 @@ public class StanTime {
             "\nUsage: java StanTime [server]"
             + "\n\nUse tls:// or opentls:// to require tls, via the Default SSLContext\n";
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         String server = "help";
 
         if (args.length == 1) {

--- a/src/main/java/io/nats/client/AuthHandler.java
+++ b/src/main/java/io/nats/client/AuthHandler.java
@@ -14,10 +14,10 @@
 package io.nats.client;
 
 /**
- * NATS provides a challenge-response based authentication scheme based on {@link NKey NKeys}. Since 
+ * NATS provides a challenge-response based authentication scheme based on {@link NKey NKeys}. Since
  * NKeys depend on a private seed, we do not handle them directly in the client library. Instead, you can
  * work with them inside an AuthHandler that only makes the public key available to the library.
- * 
+ *
  * <pre>
  * {@code
     char[] nkey;
@@ -55,26 +55,26 @@ public interface AuthHandler {
     /**
      * Sign is called by the library when the server sends a nonce.
      * The client's NKey should be used to sign the provided value.
-     * 
+     *
      * @param nonce the nonce to sign
      * @return the signature for the nonce
-     */ 
-    public byte[] sign(byte[] nonce);
+     */
+    byte[] sign(byte[] nonce);
 
     /**
      * getID should return a public key associated with a client key known to the server.
      * If the server is not in nonce-mode, this array can be empty.
-     * 
+     *
      * @return the public key as a char array
      */
-    public char[] getID();
+    char[] getID();
 
     /**
      * getJWT should return the user JWT associated with this connection.
      * This can return null for challenge only authentication, but for account/user
      * JWT-based authentication you need to return the JWT bytes here.
-     * 
+     *
      * @return the user JWT
-     */ 
-    public char[] getJWT();
+     */
+    char[] getJWT();
 }

--- a/src/main/java/io/nats/client/AuthenticationException.java
+++ b/src/main/java/io/nats/client/AuthenticationException.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * AuthenticationException is used when the connect process fails due to an authentication
  * problem.
- * 
+ * <p>
  * The exception will not include the authentication tokens, but as a subclass
  * of IOException allows the client to distinguish an IO problem from an
  * authentication problem.

--- a/src/main/java/io/nats/client/BaseConsumerContext.java
+++ b/src/main/java/io/nats/client/BaseConsumerContext.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 
 /**
  * The Consumer Context provides a convenient interface around a defined JetStream Consumer
+ * <p> Note: ConsumerContext requires a <b>pull consumer</b>.
  */
 public interface BaseConsumerContext {
     /**

--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -103,7 +103,7 @@ public interface Connection extends AutoCloseable {
          * The {@code Connection} is currently connecting to a server for the first
          * time.
          */
-        CONNECTING;
+        CONNECTING
     }
 
     /**

--- a/src/main/java/io/nats/client/ConnectionListener.java
+++ b/src/main/java/io/nats/client/ConnectionListener.java
@@ -18,7 +18,7 @@ package io.nats.client;
  * listener is configured in the {@link Options Options} at creation time.
  */
 public interface ConnectionListener {
-    public enum Events {
+    enum Events {
         /** The connection has successfully completed the handshake with the nats-server. */
         CONNECTED(true, "opened"),
         /** The connection is permanently closed, either by manual action or failed reconnects. */
@@ -77,5 +77,5 @@ public interface ConnectionListener {
      * @param conn the connection associated with the error
      * @param type the type of event that has occurred
      */
-    public void connectionEvent(Connection conn, Events type);
+    void connectionEvent(Connection conn, Events type);
 }

--- a/src/main/java/io/nats/client/Consumer.java
+++ b/src/main/java/io/nats/client/Consumer.java
@@ -35,12 +35,12 @@ public interface Consumer {
     /**
      * The default number of messages a consumer will hold before it starts to drop them.
      */
-    public static final long DEFAULT_MAX_MESSAGES = 512 * 1024;
+    long DEFAULT_MAX_MESSAGES = 512 * 1024;
 
     /**
      * The default number of bytes a consumer will hold before it starts to drop messages.
      */
-    public static final long DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+    long DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
 
     /**
      * Set limits on the maximum number of messages, or maximum size of messages this consumer
@@ -57,54 +57,54 @@ public interface Consumer {
      * @param maxMessages the maximum message count to hold, defaults to {@value #DEFAULT_MAX_MESSAGES}
      * @param maxBytes the maximum bytes to hold, defaults to {@value #DEFAULT_MAX_BYTES}
      */
-    public void setPendingLimits(long maxMessages, long maxBytes);
+    void setPendingLimits(long maxMessages, long maxBytes);
 
     /**
      * @return the pending message limit set by {@link #setPendingLimits(long, long) setPendingLimits}
      */
-    public long getPendingMessageLimit();
+    long getPendingMessageLimit();
 
     /**
      * @return the pending byte limit set by {@link #setPendingLimits(long, long) setPendingLimits}
      */
-    public long getPendingByteLimit();
+    long getPendingByteLimit();
 
     /**
      * @return the number of messages waiting to be delivered/popped, {@link #setPendingLimits(long, long) setPendingLimits}
      */
-    public long getPendingMessageCount();
+    long getPendingMessageCount();
 
     /**
      * @return the cumulative size of the messages waiting to be delivered/popped, {@link #setPendingLimits(long, long) setPendingLimits}
      */
-    public long getPendingByteCount();
+    long getPendingByteCount();
 
     /**
      * @return the total number of messages delivered to this consumer, for all time
      */
-    public long getDeliveredCount();
+    long getDeliveredCount();
 
     /**
      * @return the number of messages dropped from this consumer, since the last call to {@link #clearDroppedCount() clearDroppedCount}.
      */
-    public long getDroppedCount();
+    long getDroppedCount();
 
     /**
      * Reset the drop count to 0.
      */
-    public void clearDroppedCount();
+    void clearDroppedCount();
 
     /**
      * @return whether this consumer is still processing messages.
      * For a subscription the answer is false after unsubscribe. For a dispatcher, false after stop.
      */
-    public boolean isActive();
+    boolean isActive();
 
     /**
      * Drain tells the consumer to process in flight, or cached messages, but stop receiving new ones. The library will
      * flush the unsubscribe call(s) insuring that any publish calls made by this client are included. When all messages
      * are processed the consumer effectively becomes unsubscribed.
-     * 
+     * <p>
      * A future is used to allow this call to be treated as synchronous or asynchronous as
      * needed by the application.
      * 
@@ -114,5 +114,5 @@ public interface Consumer {
      * @return A future that can be used to check if the drain has completed
      * @throws InterruptedException if the thread is interrupted
      */
-    public CompletableFuture<Boolean> drain(Duration timeout) throws InterruptedException;
+    CompletableFuture<Boolean> drain(Duration timeout) throws InterruptedException;
 }

--- a/src/main/java/io/nats/client/ConsumerContext.java
+++ b/src/main/java/io/nats/client/ConsumerContext.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 
 /**
  * The Consumer Context provides a convenient interface around a defined JetStream Consumer
+ * <p> Note: ConsumerContext requires a <b>pull consumer</b>.
+ * <p> For basic usage examples see {@link JetStream JetStream}
  */
 public interface ConsumerContext extends BaseConsumerContext {
     /**

--- a/src/main/java/io/nats/client/ErrorListener.java
+++ b/src/main/java/io/nats/client/ErrorListener.java
@@ -28,20 +28,20 @@ import io.nats.client.support.Status;
  * <dt>Fast Producers</dt>
  * <dd>One of the connections producers is too fast, and is discarding messages</dd>
  * </dl>
- * <p>All of these problems are reported to the application code using the ErrorListener. The 
+ * <p>All of these problems are reported to the application code using the ErrorListener. The
  * listener is configured in the {@link Options Options} at creation time.
  */
 public interface ErrorListener {
     /**
      * NATs related errors that occur asynchronously in the client library are sent
      * to an ErrorListener via errorOccurred. The ErrorListener can use the error text to decide what to do about the problem.
-     * <p>The text for an error is described in the protocol doc at `https://nats.io/documentation/internals/nats-protocol`.
+     * <p>The text for an error is described in the protocol doc at <a href="https://nats.io/documentation/internals/nats-protocol">https://nats.io/documentation/internals/nats-protocol</a>.
      * <p>In some cases the server will close the clients connection after sending one of these errors. In that case, the
      * connections {@link ConnectionListener ConnectionListener} will be notified.
      * @param conn The connection associated with the error
      * @param error The text of error that has occurred, directly from the server
      */
-    default void errorOccurred(Connection conn, String error) {};
+    default void errorOccurred(Connection conn, String error) {}
 
     /**
      * Exceptions that occur in the "normal" course of operations are sent to the
@@ -49,27 +49,27 @@ public interface ErrorListener {
      * during Dispatcher callbacks, IOExceptions from the underlying socket, etc..
      * The library will try to handle these, via reconnect or catching them, but they are
      * forwarded here in case the application code needs them for debugging purposes.
-     * 
+     *
      * @param conn The connection associated with the error
      * @param exp The exception that has occurred, and was handled by the library
      */
-    default void exceptionOccurred(Connection conn, Exception exp) {};
+    default void exceptionOccurred(Connection conn, Exception exp) {}
 
     /**
      * Called by the connection when a &quot;slow&quot; consumer is detected. This call is only made once
      * until the consumer stops being slow. At which point it will be called again if the consumer starts
      * being slow again.
-     * 
-     * <p>See {@link Consumer#setPendingLimits(long, long) Consumer.setPendingLimits} 
+     *
+     * <p>See {@link Consumer#setPendingLimits(long, long) Consumer.setPendingLimits}
      * for information on how to configure when this method is fired.
-     * 
+     *
      * <p> Slow consumers will result in dropped messages each consumer provides a method
      * for retrieving the count of dropped messages, see {@link Consumer#getDroppedCount() Consumer.getDroppedCount}.
-     * 
+     *
      * @param conn The connection associated with the error
      * @param consumer The consumer that is being marked slow
      */
-    default void slowConsumerDetected(Connection conn, Consumer consumer) {};
+    default void slowConsumerDetected(Connection conn, Consumer consumer) {}
 
     /**
      * Called by the connection when a message is discarded.

--- a/src/main/java/io/nats/client/JetStream.java
+++ b/src/main/java/io/nats/client/JetStream.java
@@ -25,76 +25,75 @@ import java.util.concurrent.CompletableFuture;
 
 /**
  * JetStream context for access to streams and consumers in NATS.
- * 
+ *
  * <h3>Basic usage</h3>
- * 
- * <p>{@link #publish(String, byte[]) JetStream.Publish} will send a message on the specified subject, waiting for acknowledgement. 
+ *
+ * <p>{@link #publish(String, byte[]) JetStream.Publish} will send a message on the specified subject, waiting for acknowledgement.
  * A  <b>503 No responders</b> error will be received if no stream is listening on said subject.
- * 
- * <p>{@link #publishAsync(String, byte[]) PublishAsync} will not wait for acknowledgement but return a {@link CompletableFuture CompletableFuture}, 
+ *
+ * <p>{@link #publishAsync(String, byte[]) PublishAsync} will not wait for acknowledgement but return a {@link CompletableFuture CompletableFuture},
  * which can be checked for acknowledgement at a later point.
- * 
- * <p> Use {@link #getStreamContext(String ) getStreamContext(String)} to access a simplified API for <b>consuming/subscribing</b> messages from Jetstream. 
- * It is <b>recommened</b> to manage consumers explicitely through {@link StreamContext StreamContext} or {@link JetStreamManagement JetStreamManagement}
- * 
- * <p>{@link #subscribe(String)} is a convenience method for implicitly creating a consumer on a stream and receiving messages. This method should be used for ephemeral (not durable) conusmers. 
- * It can create a named durable consumers though Options, but we prefer to avoid creating durable consumers implictly. 
- * It is <b>recommened</b> to manage consumers explicitely through {@link StreamContext StreamContext} or {@link JetStreamManagement JetStreamManagement}
- *  
- *  {@link ConsumerContext ConsumerContext} based subscription. 
- * 
+ *
+ * <p> Use {@link #getStreamContext(String ) getStreamContext(String)} to access a simplified API for <b>consuming/subscribing</b> messages from Jetstream.
+ * It is <b>recommened</b> to manage consumers explicitly through {@link StreamContext StreamContext} or {@link JetStreamManagement JetStreamManagement}
+ *
+ * <p>{@link #subscribe(String)} is a convenience method for implicitly creating a consumer on a stream and receiving messages. This method should be used for ephemeral (not durable) conusmers.
+ * It can create a named durable consumers though Options, but we prefer to avoid creating durable consumers implictly.
+ * It is <b>recommened</b> to manage consumers explicitly through {@link StreamContext StreamContext} and {@link ConsumerContext ConsumerContext} or {@link JetStreamManagement JetStreamManagement}
+ *
+ *
  * <h3>Recommended usage for creating streams, consumers, publish and listen on a stream</h3>
  * <pre>
  *  io.nats.client.Connection nc = Nats.connect();
- *	
- *  //Setting up a stream and a consumer	
+ *
+ *  //Setting up a stream and a consumer
  *  JetStreamManagement jsm = nc.jetStreamManagement();
  *  StreamConfiguration sc = StreamConfiguration.builder()
  *    .name("my-stream")
  *    .storageType(StorageType.File)
  *    .subjects("foo.*", "bar.*")
  *    .build();
- *      
+ *
  *  jsm.addStream(sc);
- *       
+ *
  *  ConsumerConfiguration consumerConfig = ConsumerConfiguration.builder()
  *    .durable("my-consumer")
  *    .build();
- *		
+ *
  *  jsm.createConsumer("my-stream", consumerConfig);
- *    	
- *  //Listening and publishing  
+ *
+ *  //Listening and publishing
  *  io.nats.client.JetStream js = nc.jetStream();
- *  ConsumerContext consumerContext = js.getConsumerContext("my-stream", "my-consumer"); 
+ *  ConsumerContext consumerContext = js.getConsumerContext("my-stream", "my-consumer");
  *  MessageConsumer mc = consumerContext.consume(
  *    msg -&gt; {
  *      System.out.println("   Received " + msg.getSubject());
  *      msg.ack();
  *    });
- *    	
+ *
  *  js.publish("foo.joe", "Hello World".getBytes());
- *  
+ *
  *  //Wait a moment, then stop the MessageConsumer
  *  Thread.sleep(3000);
  *  mc.stop();
- *  
+ *
  *  </pre>
- *  
+ *
  *	<h3>Recommended usage of asynchronous publishing</h3>
- *  
- *  Jetstream messages can be published asynchronously, returning a CompletableFuture. 
- *  Note that you need to check the Future eventually otherwise the delivery guarantee is the same a regular {@link Connection#publish(String, byte[]) Connection.Publish} 
- *  
+ *
+ *  Jetstream messages can be published asynchronously, returning a CompletableFuture.
+ *  Note that you need to check the Future eventually otherwise the delivery guarantee is the same a regular {@link Connection#publish(String, byte[]) Connection.Publish}
+ *
  *  <p>We are publishing a batch of 100 messages and check for completion afterwards.
- * 
+ *
  *  <pre>
  *  int COUNT = 100;
  *  java.util.concurrent.CompletableFuture&lt;?&gt;[] acks = new java.util.concurrent.CompletableFuture&lt;?&gt;[COUNT];
- * 
+ *
  *  for( int i=0; i&lt;COUNT; i++ ) {
  *    acks[i] = js.publishAsync("foo.joe", ("Hello "+i).getBytes());
  *  }
- *    	
+ *
  *  //Acknowledgments may arrive out of sequence, but CompletableFuture is handling this for us.
  *  for( int i=0; i&lt;COUNT; i++ ) {
  *    try {
@@ -103,11 +102,11 @@ import java.util.concurrent.CompletableFuture;
  *      //Retry or handle error
  *    }
  *  }
- *  
+ *
  *  //Now we may send anther batch
- * 
+ *
  * </pre>
- * 
+ *
  */
 public interface JetStream {
 
@@ -545,7 +544,7 @@ public interface JetStream {
 
     /**
      * Create an asynchronous subscription to the specified subject in the mode of pull, with additional options.
-     * 
+     *
      * @param subscribeSubject The subject to subscribe to
      *                         Can be null or empty when the options have a ConsumerConfiguration that supplies a filter subject.
      * @param dispatcher The dispatcher to handle this subscription
@@ -560,25 +559,25 @@ public interface JetStream {
 
     /**
      * Get a stream context for a specific named stream. Verifies that the stream exists.
-     * 
-     * <p><b>Recommended usage:</b> {@link StreamContext StreamContext} and {@link ConsumerContext ConsumerContext} are the preferred way to interact with existing streams and consume from streams. 
-     * {@link JetStreamManagement JetStreamManagement} should be used to create streams and consumers. {@link ConsumerContext#consume ConsumerContext.consume()} supports both push and pull consumers transparently.
-     * 
+     *
+     * <p><b>Recommended usage:</b> {@link StreamContext StreamContext} and {@link ConsumerContext ConsumerContext} are the preferred way to interact with existing streams and consume from streams.
+     * {@link JetStreamManagement JetStreamManagement} should be used to create streams and consumers. Note that {@link ConsumerContext#consume ConsumerContext.consume()} only supports both pull consumers.
+     *
      * <pre>
      *  nc = Nats.connect();
      *  Jetstream js = nc.jetStream();
 	 *  StreamContext streamContext = js.getStreamContext("my-stream");
 	 *  ConsumerContext consumerContext = streamContext.getConsumerContext("my-consumer");
-	 *  // Or 
-	 *  // ConsumerContext consumerContext = js.getConsumerContext("my-stream", "my-consumer"); 
+	 *  // Or
+	 *  // ConsumerContext consumerContext = js.getConsumerContext("my-stream", "my-consumer");
 	 *  consumerContext.consume(
 	 *    msg -&gt; {
 	 *      System.out.println("   Received " + msg.getSubject());
 	 *      msg.ack();
 	 *    });
-	 *  </pre>        
-     * 
-     * 
+	 *  </pre>
+     *
+     *
      * @param streamName the name of the stream
      * @return a StreamContext object
      * @throws IOException covers various communication issues with the NATS
@@ -589,16 +588,16 @@ public interface JetStream {
 
     /**
      * Get a consumer context for a specific named stream and specific named consumer.
-     * 
-     * <p><b>Recommended usage:</b> See {@link #getStreamContext(String) getStreamContext(String)} 
-     * 
+     * <p> Note that ConsumerContext expects a <b>pull consumer</b>.
+     * <p><b>Recommended usage:</b> See {@link #getStreamContext(String) getStreamContext(String)}
+     *
      * Verifies that the stream and consumer exist.
      * @param streamName the name of the stream
      * @param consumerName the name of the consumer
      * @return a ConsumerContext object
      * @throws IOException covers various communication issues with the NATS
      *         server such as timeout or interruption
-     * @throws JetStreamApiException the request had an error related to the data
+     * @throws JetStreamApiException the request had an error related to the data.
      */
-    ConsumerContext getConsumerContext(String streamName, String consumerName) throws IOException, JetStreamApiException;
+	ConsumerContext getConsumerContext(String streamName, String consumerName) throws IOException, JetStreamApiException;
 }

--- a/src/main/java/io/nats/client/JetStream.java
+++ b/src/main/java/io/nats/client/JetStream.java
@@ -13,10 +13,7 @@
 
 package io.nats.client;
 
-import io.nats.client.api.ConsumerConfiguration;
 import io.nats.client.api.PublishAck;
-import io.nats.client.api.StorageType;
-import io.nats.client.api.StreamConfiguration;
 import io.nats.client.impl.Headers;
 
 import java.io.IOException;

--- a/src/main/java/io/nats/client/JetStreamManagement.java
+++ b/src/main/java/io/nats/client/JetStreamManagement.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 /**
  * JetStream Management context for creation and access to streams and consumers in NATS.
+ * <p> Using JetStream Management is the <b>recommended</b> way of managing Jetstream resources.
+ * <p> Basic usage examples can be found in {@link JetStream JetStream}
  */
 public interface JetStreamManagement {
 
@@ -219,7 +221,7 @@ public interface JetStreamManagement {
 
     /**
      * Get a list of stream names that have subjects matching the subject filter.
-     * 
+     *
      * @param subjectFilter the subject. Wildcards are allowed.
      * @return The list of stream names matching the subject filter. May be empty, will not be null.
      * @throws IOException covers various communication issues with the NATS

--- a/src/main/java/io/nats/client/JetStreamReader.java
+++ b/src/main/java/io/nats/client/JetStreamReader.java
@@ -16,7 +16,8 @@ package io.nats.client;
 import java.time.Duration;
 
 /**
- * This interface provides push like ability for a pull consumer. Was the pre-cursor to simplified consume.
+ * This interface provides a simple iterative access to a pull consumer.
+ * <p>Note: This interface is superseded by  {@link ConsumerContext ConsumerContext}. For examples for <b>recommended usage</b> see {@link JetStream JetStream}.
  */
 public interface JetStreamReader {
     /**

--- a/src/main/java/io/nats/client/JetStreamSubscription.java
+++ b/src/main/java/io/nats/client/JetStreamSubscription.java
@@ -53,7 +53,7 @@ public interface JetStreamSubscription extends Subscription {
 
     /**
      * Initiate pull in noWait mode with the specified batch size.
-     *
+     * <p>
      * ! Pull subscriptions only. Push subscription will throw IllegalStateException
      * ! Primitive API for ADVANCED use only, officially not supported. Prefer fetch, iterate or reader.
      *

--- a/src/main/java/io/nats/client/Message.java
+++ b/src/main/java/io/nats/client/Message.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeoutException;
  *
  * <p>The byte[] returned by {@link #getData() getData()} is not shared with any library code
  * and is safe to manipulate.
- *
+ * <p>
  * NOTICE: This interface is intended only to be implemented internally,
  * although since it is public it is technically available to anyone and
  * breaking changes should be avoided. For instance:

--- a/src/main/java/io/nats/client/NKey.java
+++ b/src/main/java/io/nats/client/NKey.java
@@ -232,9 +232,7 @@ public class NKey {
         char[] withoutPad = new char[i+1];
         System.arraycopy(withPad, 0, withoutPad, 0, withoutPad.length);
 
-        for (int j=0;j<withPad.length;j++) {
-            withPad[j] = '\0';
-        }
+        Arrays.fill(withPad, '\0');
 
         return withoutPad;
     }
@@ -366,9 +364,9 @@ public class NKey {
 
     /**
      * Create an Account NKey from the provided random number generator.
-     *
+     * <p>
      * If no random is provided, SecureRandom() will be used to create one.
-     *
+     * <p>
      * The new NKey contains the private seed, which should be saved in a secure location.
      *
      * @param random A secure random provider
@@ -384,9 +382,9 @@ public class NKey {
 
     /**
      * Create an Cluster NKey from the provided random number generator.
-     *
+     * <p>
      * If no random is provided, SecureRandom() will be used to create one.
-     *
+     * <p>
      * The new NKey contains the private seed, which should be saved in a secure location.
      *
      * @param random A secure random provider
@@ -402,9 +400,9 @@ public class NKey {
 
     /**
      * Create an Operator NKey from the provided random number generator.
-     *
+     * <p>
      * If no random is provided, SecureRandom() will be used to create one.
-     *
+     * <p>
      * The new NKey contains the private seed, which should be saved in a secure location.
      *
      * @param random A secure random provider
@@ -420,9 +418,9 @@ public class NKey {
 
     /**
      * Create a Server NKey from the provided random number generator.
-     *
+     * <p>
      * If no random is provided, SecureRandom() will be used to create one.
-     *
+     * <p>
      * The new NKey contains the private seed, which should be saved in a secure location.
      *
      * @param random A secure random provider
@@ -438,9 +436,9 @@ public class NKey {
 
     /**
      * Create a User NKey from the provided random number generator.
-     *
+     * <p>
      * If no random is provided, SecureRandom() will be used to create one.
-     *
+     * <p>
      * The new NKey contains the private seed, which should be saved in a secure location.
      *
      * @param random A secure random provider
@@ -535,14 +533,14 @@ public class NKey {
     /**
      * The seed or private key per the Ed25519 spec, encoded with encodeSeed.
      */
-    private char[] privateKeyAsSeed;
+    private final char[] privateKeyAsSeed;
 
     /**
      * The public key, maybe null. Used for public only NKeys.
      */
-    private char[] publicKey;
+    private final char[] publicKey;
 
-    private Type type;
+    private final Type type;
 
     private NKey(Type t, char[] publicKey, char[] privateKey) {
         this.type = t;
@@ -553,7 +551,7 @@ public class NKey {
     /**
      * Clear the seed and public key char arrays by filling them
      * with random bytes then zero-ing them out.
-     *
+     * <p>
      * The nkey is unusable after this operation.
      */
     public void clear() {

--- a/src/main/java/io/nats/client/NUID.java
+++ b/src/main/java/io/nats/client/NUID.java
@@ -64,7 +64,7 @@ public final class NUID {
 
     /**
      * The default NUID constructor.
-     * 
+     * <p>
      * Relies on the OS Default instance of SecureRandom.
      * 
      * @throws IllegalStateException
@@ -73,7 +73,7 @@ public final class NUID {
      */
     public NUID() {
         nextLock = new ReentrantLock();
-        // Generate a cryto random int, 0 <= val < max to seed pseudorandom
+        // Generate a crypto random int, 0 <= val < max to seed pseudorandom
         seq = nextLong(PRAND, maxSeq);
         inc = minInc + nextLong(PRAND, maxInc - minInc);
         pre = new char[preLen];
@@ -166,7 +166,7 @@ public final class NUID {
      * called automatically when we exhaust the sequential range.
      */
 
-    final void randomizePrefix() {
+    void randomizePrefix() {
         byte[] cb = new byte[preLen];
 
         // Use SecureRandom for prefix only

--- a/src/main/java/io/nats/client/Nats.java
+++ b/src/main/java/io/nats/client/Nats.java
@@ -278,10 +278,8 @@ public abstract class Nats {
      *                           failure
      * 
      * @throws IllegalArgumentException if no connection listener is set in the options
-     * @throws InterruptedException if the current thread is interrupted
      */
-    public static void connectAsynchronously(Options options, boolean reconnectOnConnect)
-            throws InterruptedException {
+    public static void connectAsynchronously(Options options, boolean reconnectOnConnect) {
 
         if (options.getConnectionListener() == null) {
             throw new IllegalArgumentException("Connection Listener required in connectAsynchronously");

--- a/src/main/java/io/nats/client/StreamContext.java
+++ b/src/main/java/io/nats/client/StreamContext.java
@@ -21,6 +21,7 @@ import java.util.List;
 /**
  * The Stream Context provide a set of operations for managing the stream
  * and its contents and for managing consumers.
+ * <p> For basic usage examples see {@link JetStream JetStream}
  */
 public interface StreamContext {
     /**
@@ -74,21 +75,23 @@ public interface StreamContext {
     /**
      * Get a consumer context for the context's stream and specific named consumer.
      * Verifies that the consumer exists.
+     * <p> Note that ConsumerContext expects a <b>pull consumer</b>.
      * @param consumerName the name of the consumer
      * @return a ConsumerContext object
      * @throws IOException covers various communication issues with the NATS
      *         server such as timeout or interruption
-     * @throws JetStreamApiException the request had an error related to the data
+     * @throws JetStreamApiException the request had an error related to the data.
      */
     ConsumerContext getConsumerContext(String consumerName) throws IOException, JetStreamApiException;
 
     /**
      * Management function to create or update a consumer on this stream.
+     * <p> Note that ConsumerContext expects a <b>pull consumer</b>.
      * @param config the consumer configuration to use.
      * @return a ConsumerContext object
      * @throws IOException covers various communication issues with the NATS
      *         server such as timeout or interruption
-     * @throws JetStreamApiException the request had an error related to the data
+     * @throws JetStreamApiException the request had an error related to the data.
      */
     ConsumerContext createOrUpdateConsumer(ConsumerConfiguration config) throws IOException, JetStreamApiException;
 

--- a/src/main/java/io/nats/client/api/AckPolicy.java
+++ b/src/main/java/io/nats/client/api/AckPolicy.java
@@ -20,8 +20,17 @@ import java.util.Map;
  * Represents the Ack Policy of a consumer
  */
 public enum AckPolicy {
+	/**
+     * Messages are acknowledged as soon as the server sends them. Clients do not need to ack.
+     */
     None("none"),
+    /**
+     * All messages with a sequence number less than the message acked are also acknowledged. E.g. reading a batch of messages 1 .. 100. Ack on message 100 will acknowledge 1 .. 99 as well.
+     */
     All("all"),
+    /**
+     * Each message must be acknowledged individually. Message can be acked out of sequence and create gaps of unacknowledged messages in the consumer.
+     */
     Explicit("explicit");
 
     private String policy;

--- a/src/main/java/io/nats/client/api/AckPolicy.java
+++ b/src/main/java/io/nats/client/api/AckPolicy.java
@@ -33,7 +33,7 @@ public enum AckPolicy {
      */
     Explicit("explicit");
 
-    private String policy;
+    private final String policy;
 
     AckPolicy(String p) {
         policy = p;

--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -13,6 +13,8 @@
 
 package io.nats.client.api;
 
+import io.nats.client.Connection;
+import io.nats.client.JetStream;
 import io.nats.client.PullSubscribeOptions;
 import io.nats.client.PushSubscribeOptions;
 import io.nats.client.support.*;
@@ -32,6 +34,8 @@ import static io.nats.client.support.Validator.*;
  * The ConsumerConfiguration class specifies the configuration for creating a JetStream consumer on the client and
  * if necessary the server.
  * Options are created using a ConsumerConfiguration.Builder.
+ * <p>ConsumerConfiguration is intended to be used with  {@link io.nats.client.JetStreamManagement#createConsumer(String, ConsumerConfiguration) JetStreamManagement.createConsumer()}.
+ * <P> By default this will create a <b>pull consumer</b> unless {@link ConsumerConfiguration.Builder#deliverSubject(String) ConsumerConfiguration.Builder.deliverSubject(String) } is set.
  */
 public class ConsumerConfiguration implements JsonSerializable {
     @Deprecated
@@ -159,7 +163,8 @@ public class ConsumerConfiguration implements JsonSerializable {
      * Returns a JSON representation of this consumer configuration.
      * @return json consumer configuration json string
      */
-    public String toJson() {
+    @Override
+	public String toJson() {
         StringBuilder sb = beginJson();
         JsonUtils.addField(sb, DESCRIPTION, description);
         JsonUtils.addField(sb, DURABLE_NAME, durable);
@@ -816,6 +821,7 @@ public class ConsumerConfiguration implements JsonSerializable {
 
         /**
          * Sets the subject to deliver messages to.
+         * <p> By setting the deliverySubject this configuration will create a <b>push consumer</b>. When left empty or set to NULL a pull consumer will be created.
          * @param subject the subject.
          * @return the builder
          */

--- a/src/main/java/io/nats/client/api/ConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/ConsumerConfiguration.java
@@ -13,8 +13,6 @@
 
 package io.nats.client.api;
 
-import io.nats.client.Connection;
-import io.nats.client.JetStream;
 import io.nats.client.PullSubscribeOptions;
 import io.nats.client.PushSubscribeOptions;
 import io.nats.client.support.*;

--- a/src/main/java/io/nats/client/api/ConsumerPauseRequest.java
+++ b/src/main/java/io/nats/client/api/ConsumerPauseRequest.java
@@ -14,15 +14,11 @@
 package io.nats.client.api;
 
 import io.nats.client.support.JsonSerializable;
-import io.nats.client.support.JsonUtils;
+
 import java.time.ZonedDateTime;
 
-import static io.nats.client.support.ApiConstants.CONFIG;
 import static io.nats.client.support.ApiConstants.PAUSE_UNTIL;
-import static io.nats.client.support.ApiConstants.STREAM_NAME;
-import static io.nats.client.support.JsonUtils.addField;
-import static io.nats.client.support.JsonUtils.beginJson;
-import static io.nats.client.support.JsonUtils.endJson;
+import static io.nats.client.support.JsonUtils.*;
 
 /**
  * Object used to make a request to pause a consumer. Used Internally

--- a/src/main/java/io/nats/client/api/ConsumerPauseResponse.java
+++ b/src/main/java/io/nats/client/api/ConsumerPauseResponse.java
@@ -22,7 +22,6 @@ import static io.nats.client.support.ApiConstants.PAUSE_REMAINING;
 import static io.nats.client.support.ApiConstants.PAUSE_UNTIL;
 import static io.nats.client.support.JsonValueUtils.readBoolean;
 import static io.nats.client.support.JsonValueUtils.readDate;
-import static io.nats.client.support.JsonValueUtils.readLong;
 import static io.nats.client.support.JsonValueUtils.readNanos;
 
 public class ConsumerPauseResponse extends ApiResponse<ConsumerPauseResponse> {

--- a/src/main/java/io/nats/client/api/KeyResult.java
+++ b/src/main/java/io/nats/client/api/KeyResult.java
@@ -15,21 +15,23 @@ package io.nats.client.api;
 public class KeyResult {
 
     private final String key;
-    private final Exception e;
+    private final Exception exception;
 
     public KeyResult() {
-        this.key = null;
-        this.e = null;
+        this(null, null);
     }
 
     public KeyResult(String key) {
-        this.key = key;
-        this.e = null;
+        this(key, null);
     }
 
-    public KeyResult(Exception e) {
-        this.key = null;
-        this.e = e;
+    public KeyResult(Exception exception) {
+        this(null, exception);
+    }
+
+    private KeyResult(String key, Exception exception) {
+        this.key = key;
+        this.exception = exception;
     }
 
     public String getKey() {
@@ -37,7 +39,7 @@ public class KeyResult {
     }
 
     public Exception getException() {
-        return e;
+        return exception;
     }
 
     public boolean isKey() {
@@ -45,7 +47,7 @@ public class KeyResult {
     }
 
     public boolean isException() {
-        return e != null;
+        return exception != null;
     }
 
     public boolean isDone() {

--- a/src/main/java/io/nats/client/api/ReplayPolicy.java
+++ b/src/main/java/io/nats/client/api/ReplayPolicy.java
@@ -23,7 +23,7 @@ public enum ReplayPolicy {
     Instant("instant"),
     Original("original");
 
-    private String policy;
+    private final String policy;
 
     ReplayPolicy(String p) {
         this.policy = p;

--- a/src/main/java/io/nats/client/impl/FileAuthHandler.java
+++ b/src/main/java/io/nats/client/impl/FileAuthHandler.java
@@ -22,6 +22,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 class FileAuthHandler implements AuthHandler {
     private String jwtFile;
@@ -121,9 +122,7 @@ class FileAuthHandler implements AuthHandler {
             for (int i=0; i<chars.capacity();i++) {
                 chars.put('\0');
             }
-            for (int i=0;i<data.length;i++) {
-                data[i] = 0;
-            }
+            Arrays.fill(data, (byte) 0);
         } else {
             byte[] data = Files.readAllBytes(Paths.get(this.nkeyFile));
             ByteBuffer bb = ByteBuffer.wrap(data);
@@ -134,9 +133,7 @@ class FileAuthHandler implements AuthHandler {
             for (int i=0; i<chars.capacity();i++) {
                 chars.put('\0');
             }
-            for (int i=0;i<data.length;i++) {
-                data[i] = 0;
-            }
+            Arrays.fill(data, (byte) 0);
         }
 
         return keyChars;
@@ -211,9 +208,7 @@ class FileAuthHandler implements AuthHandler {
                 chars.put('\0');
             }
             bb.clear();
-            for (int i=0;i<data.length;i++) {
-                data[i] = 0;
-            }
+            Arrays.fill(data, (byte) 0);
 
             return jwtChars;
         } catch (Exception exp) {

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -36,7 +36,7 @@ class NatsConnectionReader implements Runnable {
         PARSE_PROTO,
         GATHER_HEADERS,
         GATHER_DATA
-    };
+    }
 
     private final NatsConnection connection;
 

--- a/src/main/java/io/nats/client/impl/NatsConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumer.java
@@ -240,7 +240,7 @@ abstract class NatsConsumer implements Consumer {
     /**
      * Called during drain to tell the consumer to send appropriate unsub requests
      * to the connection.
-     * 
+     * <p>
      * A subscription will unsub itself, while a dispatcher will unsub all of its
      * subscriptions.
      */

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -304,7 +304,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
             return this;
         }
 
-        if (subject == null || subject.length() == 0) {
+        if (subject == null || subject.isEmpty()) {
             throw new IllegalArgumentException("Subject is required in unsubscribe");
         }
 

--- a/src/main/java/io/nats/client/impl/NatsJetStreamPullSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamPullSubscription.java
@@ -247,7 +247,7 @@ public class NatsJetStreamPullSubscription extends NatsJetStreamSubscription {
             return new Iterator<Message>() {
                 @Override
                 public boolean hasNext() {
-                    return buffered.size() > 0;
+                    return !buffered.isEmpty();
                 }
 
                 @Override

--- a/src/main/java/io/nats/client/impl/NatsWatchSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsWatchSubscription.java
@@ -85,7 +85,7 @@ public class NatsWatchSubscription<T> implements AutoCloseable {
     public void unsubscribe() {
         if (dispatcher != null) {
             dispatcher.unsubscribe(sub);
-            if (dispatcher.getSubscriptionHandlers().size() == 0) {
+            if (dispatcher.getSubscriptionHandlers().isEmpty()) {
                 dispatcher.connection.closeDispatcher(dispatcher);
                 dispatcher = null;
             }

--- a/src/main/java/io/nats/client/support/HttpRequest.java
+++ b/src/main/java/io/nats/client/support/HttpRequest.java
@@ -21,15 +21,15 @@ import static io.nats.client.support.NatsConstants.CRLF;
 
 /**
  * Encapsulate an HttpRequest, in Java 11 we could use this class:
- * https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html
- * 
+ * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html">https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpRequest.html</a>
+ * <p>
  * ...but we want to support older JVMs.
  */
 public class HttpRequest {
+    private final Headers headers = new Headers();
     private String method = "GET";
     private String uri = "/";
     private String version = "1.1";
-    private final Headers headers = new Headers();
 
     /**
      * @return the attached http headers, defaults to GET
@@ -48,7 +48,7 @@ public class HttpRequest {
     /**
      * Note that no validation is performed, but the method is trimmed of whitespace
      * and converted to all upper case.
-     * 
+     *
      * @param method is the new request method to use.
      * @return this for method chaining.
      */
@@ -62,7 +62,7 @@ public class HttpRequest {
 
     /**
      * This is the RAW URI, you may need to perform URL decoding the result.
-     * 
+     *
      * @return the "path" of the URI (in the RFC this is the request-URI)
      */
     public String getURI() {
@@ -72,7 +72,7 @@ public class HttpRequest {
     /**
      * This sets the RAW URI, you may need to perform URL encoding before passing
      * into this method.
-     * 
+     *
      * @param uri is the new "path" of the URI to use.
      * @return this for method chaining.
      */
@@ -94,7 +94,7 @@ public class HttpRequest {
     /**
      * Note that no validation is performed on the version. Probably only makes
      * sense to use "0.9", "1.0", "1.1", or "2".
-     * 
+     *
      * @param version is the new HTTP version to use.
      * @return this for method chaining.
      */

--- a/src/main/java/io/nats/client/support/JsonUtils.java
+++ b/src/main/java/io/nats/client/support/JsonUtils.java
@@ -109,7 +109,7 @@ public abstract class JsonUtils {
      * @param json raw json
      */
     public static void addRawJson(StringBuilder sb, String fname, String json) {
-        if (json != null && json.length() > 0) {
+        if (json != null && !json.isEmpty()) {
             sb.append(Q);
             jsonEncode(sb, fname);
             sb.append(QCOLON);
@@ -125,7 +125,7 @@ public abstract class JsonUtils {
      * @param value field value
      */
     public static void addField(StringBuilder sb, String fname, String value) {
-        if (value != null && value.length() > 0) {
+        if (value != null && !value.isEmpty()) {
             sb.append(Q);
             jsonEncode(sb, fname);
             sb.append(QCOLONQ);
@@ -291,7 +291,7 @@ public abstract class JsonUtils {
     }
 
     public static void addField(StringBuilder sb, String fname, Map<String, String> map) {
-        if (map != null && map.size() > 0) {
+        if (map != null && !map.isEmpty()) {
             addField(sb, fname, instance(map));
         }
     }
@@ -347,7 +347,7 @@ public abstract class JsonUtils {
      * @param strings field value
      */
     public static void addStrings(StringBuilder sb, String fname, List<String> strings) {
-        if (strings != null && strings.size() > 0) {
+        if (strings != null && !strings.isEmpty()) {
             _addStrings(sb, fname, strings);
         }
     }
@@ -379,7 +379,7 @@ public abstract class JsonUtils {
      * @param durations list of durations
      */
     public static void addDurations(StringBuilder sb, String fname, List<Duration> durations) {
-        if (durations != null && durations.size() > 0) {
+        if (durations != null && !durations.isEmpty()) {
             _addList(sb, fname, durations, (sbs, dur) -> sbs.append(dur.toNanos()));
         }
     }
@@ -401,7 +401,7 @@ public abstract class JsonUtils {
     }
 
     public static void addField(StringBuilder sb, String fname, Headers headers) {
-        if (headers != null && headers.size() > 0) {
+        if (headers != null && !headers.isEmpty()) {
             sb.append(Q);
             jsonEncode(sb, fname);
             sb.append("\":{");
@@ -777,7 +777,7 @@ public abstract class JsonUtils {
         String[] raw = arrayString.split(",");
         for (String s : raw) {
             String cleaned = s.trim().replace("\"", "");
-            if (cleaned.length() > 0) {
+            if (!cleaned.isEmpty()) {
                 list.add(jsonDecode(cleaned));
             }
         }

--- a/src/main/java/io/nats/client/support/JsonValue.java
+++ b/src/main/java/io/nats/client/support/JsonValue.java
@@ -22,7 +22,7 @@ import static io.nats.client.support.JsonUtils.*;
 public class JsonValue implements JsonSerializable {
 
     public enum Type {
-        STRING, BOOL, INTEGER, LONG, DOUBLE, FLOAT, BIG_DECIMAL, BIG_INTEGER, MAP, ARRAY, NULL;
+        STRING, BOOL, INTEGER, LONG, DOUBLE, FLOAT, BIG_DECIMAL, BIG_INTEGER, MAP, ARRAY, NULL
     }
 
     private static final char QUOTE = '"';

--- a/src/main/java/io/nats/client/support/JsonValueUtils.java
+++ b/src/main/java/io/nats/client/support/JsonValueUtils.java
@@ -54,7 +54,7 @@ public abstract class JsonValueUtils {
 
     public static Map<String, String> readStringStringMap(JsonValue jv, String key) {
         JsonValue o = readObject(jv, key);
-        if (o.type == Type.MAP && o.map.size() > 0) {
+        if (o.type == Type.MAP && !o.map.isEmpty()) {
             Map<String, String> temp = new HashMap<>();
             for (String k : o.map.keySet()) {
                 String value = readString(o, k);
@@ -265,7 +265,7 @@ public abstract class JsonValueUtils {
         }
         if (o instanceof String) {
             String s = ((String)o).trim();
-            return s.length() == 0 ? new JsonValue() : new JsonValue(s);
+            return s.isEmpty() ? new JsonValue() : new JsonValue(s);
         }
         if (o instanceof Boolean) {
             return new JsonValue((Boolean)o);

--- a/src/main/java/io/nats/client/support/NatsKeyValueUtil.java
+++ b/src/main/java/io/nats/client/support/NatsKeyValueUtil.java
@@ -21,7 +21,7 @@ import static io.nats.client.support.NatsConstants.DOT;
 import static io.nats.client.support.NatsJetStreamConstants.ROLLUP_HDR;
 import static io.nats.client.support.NatsJetStreamConstants.ROLLUP_HDR_SUBJECT;
 
-public abstract class NatsKeyValueUtil {
+public final class NatsKeyValueUtil {
 
     private NatsKeyValueUtil() {} /* ensures cannot be constructed */
 

--- a/src/main/java/io/nats/client/support/WebSocket.java
+++ b/src/main/java/io/nats/client/support/WebSocket.java
@@ -96,7 +96,7 @@ public class WebSocket extends Socket {
             if (null == line) {
                 throw new IllegalStateException("Expected HTTP header to not exceed " + MAX_LINE_LEN);
             }
-            if ("".equals(line)) {
+            if (line.isEmpty()) {
                 break;
             }
             int colon = line.indexOf(':');

--- a/src/main/java/io/nats/client/support/WebsocketFrameHeader.java
+++ b/src/main/java/io/nats/client/support/WebsocketFrameHeader.java
@@ -25,7 +25,7 @@ public class WebsocketFrameHeader {
         PONG(10),
         UNKNOWN(0x10);
 
-        private int code;
+        private final int code;
 
         OpCode(int code) {
             this.code = code;

--- a/src/main/java/io/nats/client/support/WebsocketOutputStream.java
+++ b/src/main/java/io/nats/client/support/WebsocketOutputStream.java
@@ -27,14 +27,14 @@ public class WebsocketOutputStream extends OutputStream {
     /**
      * Minimize fragmenting, by using a 1440 buffer size. This buffer is used to
      * store the websocket header + payload for the first write.
-     *
+     * <p>
      * We are using this size since a typical MTU for ethernet is 1500 and the
      * TCP/IPv6 header consumes 60 bytes, thus by using 1440 we should minimize
      * the need for further fragmentation at the lower layers and yet minimize
      * the overhead associated with the fact that a write to the Socket (which
      * has NO_DELAY set on it) results in a single TCP/IPv6 datagram which has
      * a 60 byte overhead.
-     *
+     * <p>
      * Note that the effective payload is less due to the websocket frame overhead:
      * 4 bytes header/length + 4 bytes masking. Which would be a payload
      * size of 1432. This means any write which is larger than 1432 will be

--- a/src/main/java/io/nats/service/EndpointContext.java
+++ b/src/main/java/io/nats/service/EndpointContext.java
@@ -60,7 +60,7 @@ class EndpointContext {
         started = DateTimeUtils.gmtNow();
     }
 
-    public void onMessage(Message msg) throws InterruptedException {
+    public void onMessage(Message msg) {
         long start = System.nanoTime();
         ServiceMessage smsg = new ServiceMessage(msg);
         try {

--- a/src/test/java/io/nats/client/AuthTests.java
+++ b/src/test/java/io/nats/client/AuthTests.java
@@ -37,10 +37,10 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
-public class AuthTests extends TestBase {
+class AuthTests extends TestBase {
 
     @Test
-    public void testUserPass() throws Exception {
+    void testUserPass() throws Exception {
         String[] customArgs = { "--user", "stephen", "--pass", "password" };
         try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
             // See config file for user/pass
@@ -51,7 +51,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testEncodedPassword() throws Exception {
+    void testEncodedPassword() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/encoded_pass.conf", false)) {
             int port = ts.getPort();
             assertEncoded("space%20space", port);
@@ -92,7 +92,7 @@ public class AuthTests extends TestBase {
 
     @Test
     @EnabledOnOs({ WINDOWS })
-    public void testNeedsJsonEncoding() throws Exception {
+    void testNeedsJsonEncoding() throws Exception {
         assertNeedsJsonEncoding("\n");
         assertNeedsJsonEncoding("\b");
         assertNeedsJsonEncoding("\f");
@@ -117,7 +117,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testUserPassOnReconnect() throws Exception {
+    void testUserPassOnReconnect() throws Exception {
         ListenerForTesting listener = new ListenerForTesting();
         Connection nc;
         Subscription sub;
@@ -159,7 +159,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testUserBCryptPass() throws Exception {
+    void testUserBCryptPass() throws Exception {
         /*
          * go run mkpasswd.go -p password: password bcrypt hash:
          * $2a$11$1oJy/wZYNTxr9jNwMNwS3eUGhBpHT3On8CL9o7ey89mpgo88VG6ba
@@ -175,7 +175,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testUserPassInURL() throws Exception {
+    void testUserPassInURL() throws Exception {
         String[] customArgs = { "--user", "stephen", "--pass", "password" };
         try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
             // See config file for user/pass
@@ -186,7 +186,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testUserPassInURLOnReconnect() throws Exception {
+    void testUserPassInURLOnReconnect() throws Exception {
         ListenerForTesting listener = new ListenerForTesting();
         int port;
         Connection nc = null;
@@ -228,7 +228,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testUserPassInURLClusteredWithDifferentUser() throws Exception {
+    void testUserPassInURLClusteredWithDifferentUser() throws Exception {
         String[] customArgs1 = { "--user", "stephen", "--pass", "password" };
         String[] customArgs2 = { "--user", "alberto", "--pass", "casadecampo" };
         ListenerForTesting listener = new ListenerForTesting();
@@ -250,7 +250,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testUserPassInURLWithFallback() throws Exception {
+    void testUserPassInURLWithFallback() throws Exception {
         String[] customArgs1 = { "--user", "stephen", "--pass", "password" };
         String[] customArgs2 = { "--user", "alberto", "--pass", "casadecampo" };
         ListenerForTesting listener = new ListenerForTesting();
@@ -274,7 +274,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testTokenInURLClusteredWithDifferentUser() throws Exception {
+    void testTokenInURLClusteredWithDifferentUser() throws Exception {
         String[] customArgs1 = { "--auth", "token_one" };
         String[] customArgs2 = { "--auth", "token_two" };
         ListenerForTesting listener = new ListenerForTesting();
@@ -298,7 +298,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testTokenInURLWithFallback() throws Exception {
+    void testTokenInURLWithFallback() throws Exception {
         String[] customArgs1 = { "--auth", "token_one" };
         String[] customArgs2 = { "--auth", "token_two" };
         ListenerForTesting listener = new ListenerForTesting();
@@ -323,7 +323,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testToken() throws Exception {
+    void testToken() throws Exception {
         String[] customArgs = { "--auth", "derek" };
         try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
             // See config file for user/pass
@@ -334,7 +334,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testTokenInURL() throws Exception {
+    void testTokenInURL() throws Exception {
         String[] customArgs = { "--auth", "alberto" };
         try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
             // See config file for user/pass
@@ -345,7 +345,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testBadUserBadPass() {
+    void testBadUserBadPass() {
         assertThrows(AuthenticationException.class, () -> {
             String[] customArgs = { "--user", "stephen", "--pass", "password" };
             try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
@@ -358,7 +358,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testMissingUserPass() {
+    void testMissingUserPass() {
         assertThrows(AuthenticationException.class, () -> {
             String[] customArgs = { "--user", "wally", "--pass", "password" };
             try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
@@ -370,7 +370,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testBadToken() {
+    void testBadToken() {
         assertThrows(AuthenticationException.class, () -> {
             String[] customArgs = { "--auth", "colin" };
             try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
@@ -383,7 +383,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testMissingToken() {
+    void testMissingToken() {
         assertThrows(AuthenticationException.class, () -> {
             String[] customArgs = { "--auth", "ivan" };
             try (NatsTestServer ts = new NatsTestServer(customArgs, false)) {
@@ -418,7 +418,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testNKeyAuth() throws Exception {
+    void testNKeyAuth() throws Exception {
         NKey theKey = NKey.createUser(null);
         assertNotNull(theKey);
 
@@ -432,7 +432,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testStaticNKeyAuth() throws Exception {
+    void testStaticNKeyAuth() throws Exception {
         NKey theKey = NKey.createUser(null);
         assertNotNull(theKey);
 
@@ -453,7 +453,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testJWTAuthWithCredsFile() throws Exception {
+    void testJWTAuthWithCredsFile() throws Exception {
         // manual auth handler or credential path
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/operator.conf", false)) {
             Options options = new Options.Builder().server(ts.getURI()).maxReconnects(0)
@@ -483,7 +483,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testWsJWTAuthWithCredsFile() throws Exception {
+    void testWsJWTAuthWithCredsFile() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/ws_operator.conf", false)) {
             String uri = ts.getLocalhostUri("ws");
             Options options = new Options.Builder().server(uri).maxReconnects(0)
@@ -501,7 +501,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testWssJWTAuthWithCredsFile() throws Exception {
+    void testWssJWTAuthWithCredsFile() throws Exception {
         SSLContext ctx = SslTestingHelper.createTestSSLContext();
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/wss_operator.conf", false)) {
             String uri = ts.getLocalhostUri("wss");
@@ -512,7 +512,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testStaticJWTAuth() throws Exception {
+    void testStaticJWTAuth() throws Exception {
         // from src/test/resources/jwt_nkey/user.creds
         String jwt = "eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiI3UE1GTkc0R1c1WkE1NEg3N09TUUZKNkJNQURaSUQ2NTRTVk1XMkRFQVZINVIyUVU0MkhBIiwiaWF0IjoxNTY1ODg5ODk4LCJpc3MiOiJBQUhWU0k1NVlQTkJRWjVQN0Y2NzZDRkFPNFBIQlREWUZRSUVHVEtMUVRJUEVZUEZEVEpOSEhPNCIsIm5hbWUiOiJkZW1vIiwic3ViIjoiVUMzT01MSlhUWVBZN0ZUTVVZNUNaNExHRVdRSTNZUzZKVFZXU0VGRURBMk9MTEpZSVlaVFo3WTMiLCJ0eXBlIjoidXNlciIsIm5hdHMiOnsicHViIjp7fSwic3ViIjp7fX19.ROSJ7D9ETt9c8ZVHxsM4_FU2dBRLh5cNfb56MxPQth74HAxxtGMl0nn-9VVmWjXgFQn4JiIbwrGfFDBRMzxsAA";
         String nkey = "SUAFYHVVQVOIDOOQ4MTOCTLGNZCJ5PZ4HPV5WAPROGTEIOF672D3R7GBY4";
@@ -525,7 +525,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testBadAuthHandler() {
+    void testBadAuthHandler() {
         assertThrows(IOException.class, () -> {
             NKey theKey = NKey.createUser(null);
             assertNotNull(theKey);
@@ -543,7 +543,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testReconnectWithAuth() throws Exception {
+    void testReconnectWithAuth() throws Exception {
         ListenerForTesting listener = new ListenerForTesting();
 
         // Connect should fail on ts2
@@ -567,7 +567,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testCloseOnReconnectWithSameError() throws Exception {
+    void testCloseOnReconnectWithSameError() throws Exception {
         ListenerForTesting listener = new ListenerForTesting();
 
         // Connect should fail on ts1
@@ -590,7 +590,7 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testThatAuthErrorIsCleared() throws Exception {
+    void testThatAuthErrorIsCleared() throws Exception {
         // Connect should fail on ts1
         try (NatsTestServer ts1 = new NatsTestServer("src/test/resources/operator_noacct.conf", false);
              NatsTestServer ts2 = new NatsTestServer("src/test/resources/operator.conf", false)) {
@@ -640,29 +640,29 @@ public class AuthTests extends TestBase {
     }
 
     @Test
-    public void testReconnectAfterExpiration() throws Exception {
+    void testReconnectAfterExpiration() throws Exception {
         _testReconnectAfter("user authentication expired");
     }
 
     @Test
-    public void testReconnectAfterRevoked() throws Exception {
+    void testReconnectAfterRevoked() throws Exception {
         _testReconnectAfter("user authentication revoked");
     }
 
     @Test
-    public void testReconnectAfterAuthorizationViolation() throws Exception {
+    void testReconnectAfterAuthorizationViolation() throws Exception {
         _testReconnectAfter("authorization violation");
     }
 
     @Test
-    public void testReconnectAfterAccountAuthenticationExpired() throws Exception {
+    void testReconnectAfterAccountAuthenticationExpired() throws Exception {
         _testReconnectAfter("account authentication expired");
     }
 
     private static void _testReconnectAfter(String errText) throws Exception {
         ListenerForTesting listener = new ListenerForTesting();
 
-        CompletableFuture<Boolean> f = new CompletableFuture<Boolean>();
+        CompletableFuture<Boolean> f = new CompletableFuture<>();
 
         NatsServerProtocolMock.Customizer timeoutCustomizer = (ts, r, w) -> {
             f.join(); // wait until we are ready
@@ -702,7 +702,7 @@ public class AuthTests extends TestBase {
 
     @Disabled("This test flaps on CI, it must be that environment")
     @Test
-    public void testRealUserAuthenticationExpired() throws Exception {
+    void testRealUserAuthenticationExpired() throws Exception {
         CountDownLatch cdlConnected = new CountDownLatch(1);
         CountDownLatch cdlDisconnected = new CountDownLatch(1);
         CountDownLatch cdlReconnected = new CountDownLatch(1);

--- a/src/test/java/io/nats/client/EchoTests.java
+++ b/src/test/java/io/nats/client/EchoTests.java
@@ -65,7 +65,7 @@ public class EchoTests {
         try (NatsTestServer ts = new NatsTestServer()) {
             Options options = new Options.Builder().server(ts.getURI()).noReconnect().build();
             try (Connection nc1 = Nats.connect(options);
-                    Connection nc2 = Nats.connect(options);) {
+                    Connection nc2 = Nats.connect(options)) {
 
                 // Echo is on so both sub should get messages from both pub
                 Subscription sub1 = nc1.subscribe("test");
@@ -97,7 +97,7 @@ public class EchoTests {
         try (NatsTestServer ts = new NatsTestServer()) {
             Options options = new Options.Builder().server(ts.getURI()).noEcho().noReconnect().build();
             try (Connection nc1 = Nats.connect(options);
-                    Connection nc2 = Nats.connect(options);) {
+                    Connection nc2 = Nats.connect(options)) {
 
                 // Echo is on so both sub should get messages from both pub
                 Subscription sub1 = nc1.subscribe("test");

--- a/src/test/java/io/nats/client/FlushBenchmark.java
+++ b/src/test/java/io/nats/client/FlushBenchmark.java
@@ -17,7 +17,7 @@ import java.text.NumberFormat;
 
 
 public class FlushBenchmark {
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) {
         int flushes = 100_000;
 
         System.out.println("###");

--- a/src/test/java/io/nats/client/NKeyTests.java
+++ b/src/test/java/io/nats/client/NKeyTests.java
@@ -98,7 +98,7 @@ public class NKeyTests {
         DecodedSeed decoded = NKey.decodeSeed(encoded);
 
         assertEquals(NKey.Type.fromPrefix(decoded.prefix), NKey.Type.ACCOUNT);
-        assertTrue(Arrays.equals(bytes, decoded.bytes));
+        assertArrayEquals(bytes, decoded.bytes);
     }
 
     @Test
@@ -109,19 +109,19 @@ public class NKeyTests {
 
         char[] encoded = NKey.encode(NKey.Type.ACCOUNT, bytes);
         byte[] decoded = NKey.decode(NKey.Type.ACCOUNT, encoded, false);
-        assertTrue(Arrays.equals(bytes, decoded));
+        assertArrayEquals(bytes, decoded);
 
         encoded = NKey.encode(NKey.Type.USER, bytes);
         decoded = NKey.decode(NKey.Type.USER, encoded, false);
-        assertTrue(Arrays.equals(bytes, decoded));
+        assertArrayEquals(bytes, decoded);
 
         encoded = NKey.encode(NKey.Type.SERVER, bytes);
         decoded = NKey.decode(NKey.Type.SERVER, encoded, false);
-        assertTrue(Arrays.equals(bytes, decoded));
+        assertArrayEquals(bytes, decoded);
 
         encoded = NKey.encode(NKey.Type.CLUSTER, bytes);
         decoded = NKey.decode(NKey.Type.CLUSTER, encoded, false);
-        assertTrue(Arrays.equals(bytes, decoded));
+        assertArrayEquals(bytes, decoded);
     }
 
     @Test
@@ -437,8 +437,8 @@ public class NKeyTests {
         char[] seed = theKey.getSeed();
         assertEquals(NKey.fromSeed(seed), NKey.fromSeed(seed));
         assertEquals(NKey.fromSeed(seed).hashCode(), NKey.fromSeed(seed).hashCode());
-        assertTrue(Arrays.equals(NKey.fromSeed(seed).getPublicKey(), NKey.fromSeed(seed).getPublicKey()));
-        assertTrue(Arrays.equals(NKey.fromSeed(seed).getPrivateKey(), NKey.fromSeed(seed).getPrivateKey()));
+        assertArrayEquals(NKey.fromSeed(seed).getPublicKey(), NKey.fromSeed(seed).getPublicKey());
+        assertArrayEquals(NKey.fromSeed(seed).getPrivateKey(), NKey.fromSeed(seed).getPrivateKey());
 
         assertTrue(seed[0] == 'S' && seed[1] == 'A');
 

--- a/src/test/java/io/nats/client/NUIDBenchmarks.java
+++ b/src/test/java/io/nats/client/NUIDBenchmarks.java
@@ -18,7 +18,7 @@ import java.text.NumberFormat;
 
 public class NUIDBenchmarks {
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         benchmarkGlobalNUIDSpeed();
         System.out.println();
         benchmarkNUIDSpeed();

--- a/src/test/java/io/nats/client/NatsServerProtocolMock.java
+++ b/src/test/java/io/nats/client/NatsServerProtocolMock.java
@@ -49,7 +49,7 @@ public class NatsServerProtocolMock implements Closeable{
     }
 
     public interface Customizer {
-        public void customizeTest(NatsServerProtocolMock ts, BufferedReader reader, PrintWriter writer);
+        void customizeTest(NatsServerProtocolMock ts, BufferedReader reader, PrintWriter writer);
     }
 
     private int port;
@@ -105,7 +105,7 @@ public class NatsServerProtocolMock implements Closeable{
     private void start() {
         this.progress = Progress.NO_CLIENT;
         this.waitForIt = new CompletableFuture<>();
-        Thread t = new Thread(() -> {accept();});
+        Thread t = new Thread(this::accept);
         t.start();
         try {
             Thread.sleep(100);

--- a/src/test/java/io/nats/client/PublishBenchmarkWithStats.java
+++ b/src/test/java/io/nats/client/PublishBenchmarkWithStats.java
@@ -15,12 +15,13 @@ package io.nats.client;
 
 import java.text.NumberFormat;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
 
 public class PublishBenchmarkWithStats {
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException {
         int threads = 1;
         int msgsPerThread = 5_000_000;
         int messageSize = 256;
@@ -36,9 +37,7 @@ public class PublishBenchmarkWithStats {
         System.out.println("###");
         byte[] body = new byte[messageSize];
 
-        for(int i=0; i<messageSize; i++) {
-            body[i] = 1;
-        }
+        Arrays.fill(body, (byte) 1);
 
         try {
             Options options = new Options.Builder().server(Options.DEFAULT_URL).turnOnAdvancedStats().build();

--- a/src/test/java/io/nats/client/PublishOptionsTests.java
+++ b/src/test/java/io/nats/client/PublishOptionsTests.java
@@ -22,10 +22,10 @@ import java.util.Properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class PublishOptionsTests extends TestBase {
+class PublishOptionsTests extends TestBase {
 
     @Test
-    public void testBuilder() {
+    void testBuilder() {
         PublishOptions.Builder builder = PublishOptions.builder();
         PublishOptions po = builder.build();
         assertEquals(PublishOptions.UNSET_STREAM, po.getStream(), "default stream");
@@ -70,7 +70,7 @@ public class PublishOptionsTests extends TestBase {
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         Properties p = new Properties();
         p.setProperty(PublishOptions.PROP_PUBLISH_TIMEOUT, "PT20M");
         p.setProperty(PublishOptions.PROP_STREAM_NAME, STREAM);

--- a/src/test/java/io/nats/client/PublishTests.java
+++ b/src/test/java/io/nats/client/PublishTests.java
@@ -32,9 +32,9 @@ import static io.nats.client.utils.ResourceUtils.dataAsLines;
 import static io.nats.client.utils.TestBase.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class PublishTests {
+class PublishTests {
     @Test
-    public void throwsIfClosedOnPublish() {
+    void throwsIfClosedOnPublish() {
         assertThrows(IllegalStateException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer(false);
                         Connection nc = Nats.connect(ts.getURI())) {
@@ -46,7 +46,7 @@ public class PublishTests {
     }
 
     @Test
-    public void throwsIfClosedOnFlush() {
+    void throwsIfClosedOnFlush() {
         assertThrows(TimeoutException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer(false);
                         Connection nc = Nats.connect(ts.getURI())) {
@@ -58,7 +58,7 @@ public class PublishTests {
     }
 
     @Test
-    public void testThrowsWithoutSubject() {
+    void testThrowsWithoutSubject() {
         assertThrows(IllegalArgumentException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer(false);
                         Connection nc = Nats.connect(ts.getURI())) {
@@ -69,7 +69,7 @@ public class PublishTests {
     }
 
     @Test
-    public void testThrowsIfTooBig() throws Exception {
+    void testThrowsIfTooBig() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/max_payload.conf", false, false))
         {
             Connection nc = Nats.connect(ts.getURI());
@@ -108,7 +108,7 @@ public class PublishTests {
     }
 
     @Test
-    public void testThrowsIfheadersNotSupported() {
+    void testThrowsIfheadersNotSupported() {
         assertThrows(IllegalArgumentException.class, () -> {
             String customInfo = "{\"server_id\":\"test\", \"version\":\"9.9.99\"}";
 
@@ -126,22 +126,22 @@ public class PublishTests {
     }
 
     @Test
-    public void testEmptyPublish() throws Exception {
+    void testEmptyPublish() throws Exception {
         runSimplePublishTest("testsubemptybody", null, null, "");
     }
 
     @Test
-    public void testEmptyByDefaultPublish() throws Exception {
+    void testEmptyByDefaultPublish() throws Exception {
         runSimplePublishTest("testsubemptybody", null, null, null);
     }
 
     @Test
-    public void testNoReplyPublish() throws Exception {
+    void testNoReplyPublish() throws Exception {
         runSimplePublishTest("testsub", null, null, "This is the message.");
     }
 
     @Test
-    public void testReplyToInPublish() throws Exception {
+    void testReplyToInPublish() throws Exception {
         runSimplePublishTest("testsubforreply", "replyTo", null, "This is the message to reply to.");
         runSimplePublishTest("testsubforreply", "replyTo", new Headers().add("key", "value"), "This is the message to reply to.");
     }
@@ -234,7 +234,7 @@ public class PublishTests {
     }
 
     @Test
-    public void testMaxPayload() throws Exception {
+    void testMaxPayload() throws Exception {
         runInServer(standardOptionsBuilder().noReconnect(), nc -> {
             int maxPayload = (int)nc.getServerInfo().getMaxPayload();
             nc.publish("mptest", new byte[maxPayload-1]);
@@ -265,7 +265,7 @@ public class PublishTests {
     }
 
     @Test
-    public void testUtf8Subjects() throws Exception {
+    void testUtf8Subjects() throws Exception {
         String subject = dataAsLines("utf8-test-strings.txt").get(0);
         String jsSubject = variant() + "-" + subject; // just to have a different;
 

--- a/src/test/java/io/nats/client/ReconnectCheck.java
+++ b/src/test/java/io/nats/client/ReconnectCheck.java
@@ -18,12 +18,12 @@ public class ReconnectCheck {
             long receivedId = Long.parseLong(new String(m.getData()));
 
             if (receivedId < lastReceivedId) {
-                System.out.println(String.format("##### Tid: %d, Received stale data: got %d, last received %d", Thread.currentThread().getId(), receivedId, lastReceivedId));
+                System.out.printf("##### Tid: %d, Received stale data: got %d, last received %d%n", Thread.currentThread().getId(), receivedId, lastReceivedId);
             }
             lastReceivedId = receivedId;
 
             if (received++ % 1_000_000 == 0) {
-                System.out.println(String.format("Tid: %d, Received %d messages", Thread.currentThread().getId(), received));
+                System.out.printf("Tid: %d, Received %d messages%n", Thread.currentThread().getId(), received);
             }
         });
 
@@ -35,7 +35,7 @@ public class ReconnectCheck {
             for (int i = 0; i < 100_000; i++) {
                 natsOut.publish("foo", ("" + id++).getBytes());
                 if (published++ % 1_000_000 == 0) {
-                    System.out.println(String.format("Tid: %d, Published %d messages.", Thread.currentThread().getId(), published));
+                    System.out.printf("Tid: %d, Published %d messages.%n", Thread.currentThread().getId(), published);
                 }
             }
             Thread.sleep(1);
@@ -49,22 +49,21 @@ public class ReconnectCheck {
                 .connectionTimeout(Duration.ofSeconds(5));
         natsOptions.pingInterval(Duration.ofMillis(100));
         natsOptions.connectionListener((conn, e) ->
-                System.out.println(String.format("Tid: %d, %s, NATS: connection event - %s, connected url: %s. servers: %s ", Thread.currentThread().getId(), name, e, conn.getConnectedUrl(), conn.getServers())
-        ));
+                System.out.printf("Tid: %d, %s, NATS: connection event - %s, connected url: %s. servers: %s %n", Thread.currentThread().getId(), name, e, conn.getConnectedUrl(), conn.getServers()));
         natsOptions.errorListener(new ErrorListener() {
             @Override
             public void slowConsumerDetected(Connection conn, Consumer consumer) {
-                System.out.println(String.format("Tid: %d, %s, %s: Slow Consumer", Thread.currentThread().getId(), name, conn.getConnectedUrl()));
+                System.out.printf("Tid: %d, %s, %s: Slow Consumer%n", Thread.currentThread().getId(), name, conn.getConnectedUrl());
             }
 
             @Override
             public void exceptionOccurred(Connection conn, Exception exp) {
-                System.out.println(String.format("Tid: %d, %s, Nats '%s' exception: %s", Thread.currentThread().getId(), name, conn.getConnectedUrl(), exp.toString()));
+                System.out.printf("Tid: %d, %s, Nats '%s' exception: %s%n", Thread.currentThread().getId(), name, conn.getConnectedUrl(), exp.toString());
             }
 
             @Override
             public void errorOccurred(Connection conn, String error) {
-                System.out.println(String.format("Tid: %d, %s, Nats '%s': Error %s", Thread.currentThread().getId(), name, conn.getConnectedUrl(), error.toString()));
+                System.out.printf("Tid: %d, %s, Nats '%s': Error %s%n", Thread.currentThread().getId(), name, conn.getConnectedUrl(), error);
             }
         });
 

--- a/src/test/java/io/nats/client/RequestBenchmarkWithStats.java
+++ b/src/test/java/io/nats/client/RequestBenchmarkWithStats.java
@@ -15,6 +15,7 @@ package io.nats.client;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -23,7 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 
 public class RequestBenchmarkWithStats {
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException {
         int threads = 1;
         int msgsPerThread = 5_000_000;
         int messageSize = 256;
@@ -41,9 +42,7 @@ public class RequestBenchmarkWithStats {
         System.out.println("###");
 
         byte[] body = new byte[messageSize];
-        for (int i = 0; i < messageSize; i++) {
-            body[i] = 1;
-        }
+        Arrays.fill(body, (byte) 1);
 
         try {
             Options o = new Options.Builder().
@@ -143,7 +142,7 @@ public class RequestBenchmarkWithStats {
             System.out.println("####################################");
             System.out.println("### Dispatcher connection stats ####");
             System.out.println("####################################");
-            System.out.println("");
+            System.out.println();
             System.out.print(handlerC.getStatistics().toString());
         } catch (Exception ex) {
             System.out.println("Exception running benchmark.");

--- a/src/test/java/io/nats/client/RequestTests.java
+++ b/src/test/java/io/nats/client/RequestTests.java
@@ -24,23 +24,22 @@ import java.util.concurrent.ExecutionException;
 
 import static io.nats.client.utils.TestBase.standardConnection;
 import static io.nats.client.utils.TestBase.subject;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
-public class RequestTests {
+class RequestTests {
 
     @Test
-    public void testRequestNoResponder() throws Exception {
+    void testRequestNoResponder() throws Exception {
         try (NatsTestServer ts = new NatsTestServer(false, true)) {
             Options optCancel = Options.builder().server(ts.getURI()).errorListener(new ListenerForTesting()).build();
             Options optReport = Options.builder().server(ts.getURI()).reportNoResponders().errorListener(new ListenerForTesting()).build();
             try (Connection ncCancel = standardConnection(optCancel);
-                 Connection ncReport = standardConnection(optReport);
+                 Connection ncReport = standardConnection(optReport)
             )
             {
                 assertThrows(CancellationException.class, () -> ncCancel.request(subject(999), null).get());
                 ExecutionException ee = assertThrows(ExecutionException.class, () -> ncReport.request(subject(999), null).get());
-                assertTrue(ee.getCause() instanceof JetStreamStatusException);
+                assertInstanceOf(JetStreamStatusException.class, ee.getCause());
                 assertTrue(ee.getMessage().contains("503 No Responders Available For Request"));
 
                 ncCancel.jetStreamManagement().addStream(

--- a/src/test/java/io/nats/client/SslTestingHelper.java
+++ b/src/test/java/io/nats/client/SslTestingHelper.java
@@ -23,10 +23,10 @@ import java.security.SecureRandom;
 import java.util.Properties;
 
 public class SslTestingHelper {
-    public static String KEYSTORE_PATH = "src/test/resources/keystore.jks";
-    public static String TRUSTSTORE_PATH = "src/test/resources/truststore.jks";
-    public static String PASSWORD = "password";
-    public static char[] PASSWORD_CHARS = PASSWORD.toCharArray();
+    public static final String KEYSTORE_PATH = "src/test/resources/keystore.jks";
+    public static final String TRUSTSTORE_PATH = "src/test/resources/truststore.jks";
+    public static final String PASSWORD = "password";
+    public static final char[] PASSWORD_CHARS = PASSWORD.toCharArray();
 
     public static KeyStore loadKeystore(String path) throws Exception {
         return SSLUtils.loadKeystore(path, PASSWORD_CHARS);

--- a/src/test/java/io/nats/client/SubscriberTests.java
+++ b/src/test/java/io/nats/client/SubscriberTests.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 
 import static io.nats.client.utils.TestBase.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -162,7 +161,7 @@ public class SubscriberTests {
     }
 
     @Test
-    public void testQueueSubscribers() throws Exception, TimeoutException {
+    public void testQueueSubscribers() throws Exception {
         try (NatsTestServer ts = new NatsTestServer(false);
                     Connection nc = Nats.connect(ts.getURI())) {
             standardConnectionWait(nc);

--- a/src/test/java/io/nats/client/api/ConsumerConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/ConsumerConfigurationTests.java
@@ -38,7 +38,7 @@ public class ConsumerConfigurationTests extends TestBase {
     public void testBuilder() throws Exception {
         ZonedDateTime zdt = ZonedDateTime.of(2012, 1, 12, 6, 30, 1, 500, DateTimeUtils.ZONE_ID_GMT);
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("meta-foo", "meta-bar");
+        metadata.put(META_KEY, META_VALUE);
 
         ConsumerConfiguration.Builder builder = ConsumerConfiguration.builder()
             .ackPolicy(AckPolicy.Explicit)
@@ -272,7 +272,7 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(Duration.ofSeconds(2), c.getBackoff().get(1));
         assertEquals(Duration.ofSeconds(3), c.getBackoff().get(2));
         assertEquals(1, c.getMetadata().size());
-        assertEquals("meta-bar", c.getMetadata().get("meta-foo"));
+        assertEquals(META_VALUE, c.getMetadata().get(META_KEY));
     }
 
     @Test
@@ -311,7 +311,7 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(Duration.ofSeconds(2), c.getBackoff().get(1));
         assertEquals(Duration.ofSeconds(3), c.getBackoff().get(2));
         assertEquals(1, c.getMetadata().size());
-        assertEquals("meta-bar", c.getMetadata().get("meta-foo"));
+        assertEquals(META_VALUE, c.getMetadata().get(META_KEY));
 
         assertDefaultCc(new ConsumerConfiguration(ConsumerConfiguration.builder().jsonValue(JsonValue.EMPTY_MAP).build()));
     }

--- a/src/test/java/io/nats/client/api/ConsumerConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/ConsumerConfigurationTests.java
@@ -378,7 +378,7 @@ public class ConsumerConfigurationTests extends TestBase {
         assertEquals(ULONG_UNSET, ConsumerConfiguration.normalizeUlong(-1L));
 
         //noinspection ConstantConditions
-        assertNull(ConsumerConfiguration.normalize((Duration) null));
+        assertNull(ConsumerConfiguration.normalize(null));
         assertEquals(Duration.ofNanos(1), ConsumerConfiguration.normalize(Duration.ofNanos(1)));
         assertEquals(DURATION_UNSET, ConsumerConfiguration.normalize(DURATION_UNSET));
         assertEquals(DURATION_UNSET, ConsumerConfiguration.normalize(Duration.ZERO));

--- a/src/test/java/io/nats/client/api/KeyResultTest.java
+++ b/src/test/java/io/nats/client/api/KeyResultTest.java
@@ -1,0 +1,32 @@
+package io.nats.client.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KeyResultTest {
+    @Test
+    void testNoArgsConstructor() {
+        KeyResult actual = new KeyResult();
+
+        assertNull(actual.getKey());
+        assertNull(actual.getException());
+    }
+
+    @Test
+    void testKeyArg() {
+        KeyResult actual = new KeyResult("key");
+
+        assertEquals("key", actual.getKey());
+        assertNull(actual.getException());
+    }
+
+    @Test
+    void testExceptionArg() {
+        Exception exception = new Exception("message");
+        KeyResult actual = new KeyResult(exception);
+
+        assertNull(actual.getKey());
+        assertSame(exception, actual.getException());
+    }
+}

--- a/src/test/java/io/nats/client/api/StreamConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/StreamConfigurationTests.java
@@ -635,7 +635,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
     @Test
     public void testConsumerLimits() {
         ConsumerLimits cl = ConsumerLimits.builder().build();
-        assertEquals(null, cl.getInactiveThreshold());
+        assertNull(cl.getInactiveThreshold());
         assertEquals(INTEGER_UNSET, cl.getMaxAckPending());
 
         cl = ConsumerLimits.builder().inactiveThreshold(Duration.ofMillis(0)).build();

--- a/src/test/java/io/nats/client/api/StreamConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/StreamConfigurationTests.java
@@ -150,7 +150,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
         // copy constructor
         validate(StreamConfiguration.builder(testSc).build(), false);
 
-        Map<String, String> metaData = new HashMap<>(); metaData.put("meta-foo", "meta-bar");
+        Map<String, String> metaData = new HashMap<>(); metaData.put(META_KEY, META_VALUE);
 
         // builder
         StreamConfiguration.Builder builder = StreamConfiguration.builder()
@@ -543,7 +543,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
             validateSource(sc.getSources().get(1), 1, zdt);
 
             assertEquals(1, sc.getMetadata().size());
-            assertEquals("meta-bar", sc.getMetadata().get("meta-foo"));
+            assertEquals(META_VALUE, sc.getMetadata().get(META_KEY));
             assertEquals(82942, sc.getFirstSequence());
 
             assertSame(S2, sc.getCompressionOption());

--- a/src/test/java/io/nats/client/impl/AuthAndConnectTests.java
+++ b/src/test/java/io/nats/client/impl/AuthAndConnectTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import static io.nats.client.utils.TestBase.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AuthAndConnectTests {

--- a/src/test/java/io/nats/client/impl/AuthHandlerTests.java
+++ b/src/test/java/io/nats/client/impl/AuthHandlerTests.java
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.StandardCharsets;
 
 import static io.nats.client.utils.ResourceUtils.resourceAsString;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AuthHandlerTests {
 
@@ -32,7 +31,7 @@ public class AuthHandlerTests {
     @Test
     public void testCredsFile() throws Exception {
         AuthHandler auth = Nats.credentials("src/test/resources/jwt_nkey/test.creds");
-        assertTrue(auth instanceof FileAuthHandler);
+        assertInstanceOf(FileAuthHandler.class, auth);
         NKey key = NKey.fromSeed(SEED.toCharArray());
         byte[] test = "hello world".getBytes(StandardCharsets.UTF_8);
 
@@ -47,7 +46,7 @@ public class AuthHandlerTests {
         String creds = resourceAsString("jwt_nkey/test.creds");
 
         AuthHandler auth = Nats.staticCredentials(creds.getBytes(StandardCharsets.UTF_8));
-        assertTrue(auth instanceof MemoryAuthHandler);
+        assertInstanceOf(MemoryAuthHandler.class, auth);
         NKey key = NKey.fromSeed(SEED.toCharArray());
         byte[] test = "hello world".getBytes(StandardCharsets.UTF_8);
 

--- a/src/test/java/io/nats/client/impl/DispatcherTests.java
+++ b/src/test/java/io/nats/client/impl/DispatcherTests.java
@@ -334,7 +334,7 @@ public class DispatcherTests {
             Message msg = msgFuture.get(500, TimeUnit.MILLISECONDS);
             assertNotNull(msg);
 
-            assertEquals(2, ((NatsStatistics)(nc.getStatistics())).getFlushCounter());
+            assertEquals(2, nc.getStatistics().getFlushCounter());
         }
     }
 
@@ -576,7 +576,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe(null);
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -589,7 +589,7 @@ public class DispatcherTests {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
 
                 d.subscribe("");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -601,7 +601,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe("subject", "");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -613,7 +613,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe(null, "quque");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -625,7 +625,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe("", "quque");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -637,7 +637,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 nc.close();
                 nc.createDispatcher((msg) -> {});
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -650,20 +650,20 @@ public class DispatcherTests {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 nc.close();
                 d.subscribe("subject");
-                assertFalse(true);
+                fail();
             }
         });
     }
 
     @Test
-    public void testThrowOnSubscribeWhenClosed() throws IOException, InterruptedException, TimeoutException {
+    public void testThrowOnSubscribeWhenClosed() {
         assertThrows(IllegalStateException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer(false);
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 nc.closeDispatcher(d);
                 d.subscribe("foo");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -677,7 +677,7 @@ public class DispatcherTests {
                 d.subscribe("foo");
                 nc.closeDispatcher(d);
                 d.unsubscribe("foo");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -690,7 +690,7 @@ public class DispatcherTests {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 nc.closeDispatcher(d);
                 nc.closeDispatcher(d);
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -703,7 +703,7 @@ public class DispatcherTests {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 nc.close();
                 nc.closeDispatcher(d);
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -821,7 +821,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe("", (msg) -> {});
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -833,7 +833,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe("test", (MessageHandler)null);
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -844,8 +844,8 @@ public class DispatcherTests {
             try (NatsTestServer ts = new NatsTestServer(false);
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
-                d.subscribe("test", "queue", (MessageHandler)null);
-                assertFalse(true);
+                d.subscribe("test", "queue", null);
+                fail();
             }
         });
     }
@@ -857,7 +857,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe("subject", "", (msg) -> {});
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -869,7 +869,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe(null, "quque", (msg) -> {});
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -881,7 +881,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.subscribe("", "quque", (msg) -> {});
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -893,7 +893,7 @@ public class DispatcherTests {
                         Connection nc = Nats.connect(ts.getURI())) {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 d.unsubscribe("");
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -907,7 +907,7 @@ public class DispatcherTests {
                 Subscription sub = d.subscribe("subject", (msg) -> {});
                 nc.closeDispatcher(d);
                 d.unsubscribe(sub);
-                assertFalse(true);
+                fail();
             }
         });
     }
@@ -920,7 +920,7 @@ public class DispatcherTests {
                 Dispatcher d = nc.createDispatcher((msg) -> {});
                 Subscription sub2 = nc.subscribe("test");
                 d.unsubscribe(sub2);
-                assertFalse(true);
+                fail();
             }
         });
     }

--- a/src/test/java/io/nats/client/impl/InfoHandlerTests.java
+++ b/src/test/java/io/nats/client/impl/InfoHandlerTests.java
@@ -95,7 +95,7 @@ public class InfoHandlerTests {
                 assertEquals("myid", ((NatsConnection) nc).getInfo().getServerId(), "got custom info");
                 sendInfo.complete(Boolean.TRUE);
 
-                assertTrue(gotPong.get().booleanValue(), "Got pong."); // Server round tripped so we should have new info
+                assertTrue(gotPong.get(), "Got pong."); // Server round tripped so we should have new info
                 assertEquals("replacement", ((NatsConnection) nc).getInfo().getServerId(), "got replacement info");
             } finally {
                 nc.close();
@@ -166,7 +166,7 @@ public class InfoHandlerTests {
                 assertEquals("myid", ((NatsConnection) nc).getInfo().getServerId(), "got custom info");
                 sendInfo.complete(Boolean.TRUE);
 
-                assertTrue(gotPong.get().booleanValue(), "Got pong."); // Server round tripped so we should have new info
+                assertTrue(gotPong.get(), "Got pong."); // Server round tripped so we should have new info
                 assertEquals("replacement", ((NatsConnection) nc).getInfo().getServerId(), "got replacement info");
             } finally {
                 nc.close();

--- a/src/test/java/io/nats/client/impl/JetStreamGeneralTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamGeneralTests.java
@@ -806,7 +806,6 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
     public void testSubscribeDurableConsumerMustMatch() throws Exception {
         jsServer.run(nc -> {
             JetStream js = nc.jetStream();
-            JetStreamManagement jsm = nc.jetStreamManagement();
 
             String stream = stream();
             String subject = subject();
@@ -879,7 +878,7 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
             Map<String, String> metadataA = new HashMap<>(); metadataA.put("a", "A");
             Map<String, String> metadataB = new HashMap<>(); metadataB.put("b", "B");
 
-            if (nc.getServerInfo().isNewerVersionThan("2.9.99")) {
+            if (atLeast2_10()) {
                 // metadata server null versus new not null
                 nc.jetStreamManagement().addOrUpdateConsumer(stream, pushDurableBuilder(subject, uname, deliver).build());
                 changeExPush(js, subject, pushDurableBuilder(subject, uname, deliver).metadata(metadataA), "metadata");
@@ -891,8 +890,10 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
                 // metadata server not null versus new not null but different
                 changeExPush(js, subject, pushDurableBuilder(subject, uname, deliver).metadata(metadataB), "metadata");
 
-                // metadata server not null versus new not null and same
-                changeOkPush(js, subject, pushDurableBuilder(subject, uname, deliver).metadata(metadataA));
+                if (before2_11()) {
+                    // metadata server not null versus new not null and same
+                    changeOkPush(js, subject, pushDurableBuilder(subject, uname, deliver).metadata(metadataA));
+                }
             }
         });
     }

--- a/src/test/java/io/nats/client/impl/JetStreamGeneralTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamGeneralTests.java
@@ -228,9 +228,9 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
             Dispatcher d = nc.createDispatcher();
 
             js.subscribe(tsc.subject(), (PushSubscribeOptions)null);
-            js.subscribe(tsc.subject(), null, (PushSubscribeOptions)null); // queue name is not required, just a weird way to call this api
-            js.subscribe(tsc.subject(), d, m -> {}, false, (PushSubscribeOptions)null);
-            js.subscribe(tsc.subject(), null, d, m -> {}, false, (PushSubscribeOptions)null); // queue name is not required, just a weird way to call this api
+            js.subscribe(tsc.subject(), null, null); // queue name is not required, just a weird way to call this api
+            js.subscribe(tsc.subject(), d, m -> {}, false, null);
+            js.subscribe(tsc.subject(), null, d, m -> {}, false, null); // queue name is not required, just a weird way to call this api
 
             PushSubscribeOptions pso = ConsumerConfiguration.builder().filterSubject(tsc.subject()).buildPushSubscribeOptions();
             js.subscribe(null, pso);
@@ -248,9 +248,9 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
 
             assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, (PushSubscribeOptions)null));
             assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, (PushSubscribeOptions)null));
-            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, null, (PushSubscribeOptions)null));
-            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, d, m -> {}, false, (PushSubscribeOptions)null));
-            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, null, d, m -> {}, false, (PushSubscribeOptions)null));
+            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, null, null));
+            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, d, m -> {}, false, null));
+            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, null, d, m -> {}, false, null));
 
             PullSubscribeOptions lso = ConsumerConfiguration.builder().filterSubject(tsc.subject()).buildPullSubscribeOptions();
             js.subscribe(null, lso);
@@ -261,7 +261,7 @@ public class JetStreamGeneralTests extends JetStreamTestBase {
             assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, d, m -> {}, lsoF));
 
             assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, (PullSubscribeOptions)null));
-            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, d, m -> {}, (PullSubscribeOptions)null));
+            assertThrows(IllegalArgumentException.class, () -> js.subscribe(null, d, m -> {}, null));
         });
     }
 

--- a/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
@@ -107,7 +107,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
     @Test
     public void testStreamMetadata() throws Exception {
         jsServer.run(nc -> {
-            Map<String, String> metaData = new HashMap<>(); metaData.put("meta-foo", "meta-bar");
+            Map<String, String> metaData = new HashMap<>(); metaData.put(META_KEY, META_VALUE);
             JetStreamManagement jsm = nc.jetStreamManagement();
 
             StreamConfiguration sc = StreamConfiguration.builder()
@@ -119,14 +119,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
 
             StreamInfo si = jsm.addStream(sc);
             assertNotNull(si.getConfiguration());
-            sc = si.getConfiguration();
-            if (nc.getServerInfo().isSameOrNewerThanVersion("2.10")) {
-                assertEquals(1, sc.getMetadata().size());
-                assertEquals("meta-bar", sc.getMetadata().get("meta-foo"));
-            }
-            else {
-                assertNull(sc.getMetadata());
-            }
+            assertMetaData(si.getConfiguration().getMetadata());
         });
     }
 
@@ -1009,7 +1002,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
     @Test
     public void testConsumerMetadata() throws Exception {
         jsServer.run(nc -> {
-            Map<String, String> metaData = new HashMap<>(); metaData.put("meta-foo", "meta-bar");
+            Map<String, String> metaData = new HashMap<>(); metaData.put(META_KEY, META_VALUE);
             JetStreamManagement jsm = nc.jetStreamManagement();
             TestingStreamContainer tsc = new TestingStreamContainer(jsm);
 
@@ -1019,14 +1012,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
                 .build();
 
             ConsumerInfo ci = jsm.addOrUpdateConsumer(tsc.stream, cc);
-            if (nc.getServerInfo().isSameOrNewerThanVersion("2.10")) {
-                assertEquals(1, ci.getConsumerConfiguration().getMetadata().size());
-                assertEquals("meta-bar", ci.getConsumerConfiguration().getMetadata().get("meta-foo"));
-            }
-            else {
-                assertNotNull(ci.getConsumerConfiguration().getMetadata());
-                assertEquals(0, ci.getConsumerConfiguration().getMetadata().size());
-            }
+            assertMetaData(ci.getConsumerConfiguration().getMetadata());
         });
     }
 

--- a/src/test/java/io/nats/client/impl/JetStreamPubTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamPubTests.java
@@ -216,14 +216,14 @@ public class JetStreamPubTests extends JetStreamTestBase {
 
     private void assertFutureIOException(CompletableFuture<PublishAck> future) {
         ExecutionException ee = assertThrows(ExecutionException.class, future::get);
-        assertTrue(ee.getCause() instanceof RuntimeException);
-        assertTrue(ee.getCause().getCause() instanceof IOException);
+        assertInstanceOf(RuntimeException.class, ee.getCause());
+        assertInstanceOf(IOException.class, ee.getCause().getCause());
     }
 
     private void assertFutureJetStreamApiException(CompletableFuture<PublishAck> future) {
         ExecutionException ee = assertThrows(ExecutionException.class, future::get);
-        assertTrue(ee.getCause() instanceof RuntimeException);
-        assertTrue(ee.getCause().getCause() instanceof JetStreamApiException);
+        assertInstanceOf(RuntimeException.class, ee.getCause());
+        assertInstanceOf(JetStreamApiException.class, ee.getCause().getCause());
     }
 
     @Test

--- a/src/test/java/io/nats/client/impl/JetStreamPushAsyncTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamPushAsyncTests.java
@@ -327,7 +327,7 @@ public class JetStreamPushAsyncTests extends JetStreamTestBase {
         public List<Message> messages = new ArrayList<>();
 
         @Override
-        public void onMessage(Message msg) throws InterruptedException {
+        public void onMessage(Message msg) {
             messages.add(msg);
         }
     }

--- a/src/test/java/io/nats/client/impl/KeyValueTests.java
+++ b/src/test/java/io/nats/client/impl/KeyValueTests.java
@@ -794,7 +794,7 @@ public class KeyValueTests extends JetStreamTestBase {
         for (int x = 0; x < apiHistory.size(); x++) {
             Object o = manualHistory.get(x);
             if (o instanceof KeyValueOperation) {
-                assertEquals((KeyValueOperation)o, apiHistory.get(x).getOperation());
+                assertEquals(o, apiHistory.get(x).getOperation());
             }
             else {
                 assertKvEquals((KeyValueEntry)o, apiHistory.get(x));
@@ -1461,7 +1461,7 @@ public class KeyValueTests extends JetStreamTestBase {
     }
 
     @Test
-    public void testMirrorSourceBuilderPrefixConversion() throws Exception {
+    public void testMirrorSourceBuilderPrefixConversion() {
         String bucket = bucket();
         String name = variant();
         String kvName = "KV_" + name;

--- a/src/test/java/io/nats/client/impl/KeyValueTests.java
+++ b/src/test/java/io/nats/client/impl/KeyValueTests.java
@@ -53,7 +53,7 @@ public class KeyValueTests extends JetStreamTestBase {
             nc.keyValueManagement(KeyValueOptions.builder(DEFAULT_JS_OPTIONS).build()); // coverage
 
             Map<String, String> metadata = new HashMap<>();
-            metadata.put("meta-foo", "meta-bar");
+            metadata.put(META_KEY, META_VALUE);
 
             // create the bucket
             String bucket = bucket();
@@ -338,10 +338,7 @@ public class KeyValueTests extends JetStreamTestBase {
         assertTrue(status.toString().contains(bucket));
         assertTrue(status.toString().contains(desc));
 
-        if (atLeast2_10()) {
-            assertEquals(1, status.getMetadata().size());
-            assertEquals("meta-bar", status.getMetadata().get("meta-foo"));
-        }
+        assertMetaData(status.getMetadata());
     }
 
     @Test

--- a/src/test/java/io/nats/client/impl/MessageManagerTests.java
+++ b/src/test/java/io/nats/client/impl/MessageManagerTests.java
@@ -414,7 +414,7 @@ public class MessageManagerTests extends JetStreamTestBase {
             return (PushMessageManager)mm;
         }
         return null;
-    };
+    }
 
     private void _received_time_no(JetStream js, JetStreamManagement jsm, String stream, String subject, JetStreamSubscription sub) throws IOException, JetStreamApiException, InterruptedException {
         js.publish(subject, dataBytes(0));

--- a/src/test/java/io/nats/client/impl/MessageProtocolCreationBenchmark.java
+++ b/src/test/java/io/nats/client/impl/MessageProtocolCreationBenchmark.java
@@ -18,7 +18,7 @@ import java.text.NumberFormat;
 import static io.nats.client.support.NatsConstants.EMPTY_BODY;
 
 public class MessageProtocolCreationBenchmark {
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) {
         int warmup = 1_000_000;
         int msgCount = 50_000_000;
 

--- a/src/test/java/io/nats/client/impl/MessageQueueBenchmark.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueBenchmark.java
@@ -20,7 +20,7 @@ import java.util.concurrent.CompletableFuture;
 public class MessageQueueBenchmark {
     static final Duration REQUEST_CLEANUP_INTERVAL = Duration.ofSeconds(5);
     
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException {
         int msgCount = 10_000_000;
         NatsMessage[] msgs = new NatsMessage[msgCount];
         long start, end;

--- a/src/test/java/io/nats/client/impl/MessageQueueTests.java
+++ b/src/test/java/io/nats/client/impl/MessageQueueTests.java
@@ -382,7 +382,7 @@ public class MessageQueueTests {
                 for (int j=0;j<msgPerThread;j++) {
                     q.push(new ProtocolMessage(PING));
                     sent.incrementAndGet();
-                };
+                }
             });
             t.start();
         }
@@ -484,7 +484,7 @@ public class MessageQueueTests {
     }
 
     @Test
-    public void testFilterTail() throws InterruptedException, UnsupportedEncodingException {
+    public void testFilterTail() throws InterruptedException {
         MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
@@ -508,7 +508,7 @@ public class MessageQueueTests {
     }
 
     @Test
-    public void testFilterHead() throws InterruptedException, UnsupportedEncodingException {
+    public void testFilterHead() throws InterruptedException {
         MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);
@@ -532,7 +532,7 @@ public class MessageQueueTests {
     }
 
     @Test
-    public void testFilterMiddle() throws InterruptedException, UnsupportedEncodingException {
+    public void testFilterMiddle() throws InterruptedException{
         MessageQueue q = new MessageQueue(true, REQUEST_CLEANUP_INTERVAL);
         NatsMessage msg1 = new ProtocolMessage(ONE);
         NatsMessage msg2 = new ProtocolMessage(TWO);

--- a/src/test/java/io/nats/client/impl/NatsStatisticsTests.java
+++ b/src/test/java/io/nats/client/impl/NatsStatisticsTests.java
@@ -48,7 +48,7 @@ public class NatsStatisticsTests {
             String str = nc.getStatistics().toString();
             assertNotNull(msg);
             assertNotNull(str);
-            assertTrue(str.length() > 0);
+            assertFalse(str.isEmpty());
             assertTrue(str.contains("### Connection ###"));
             assertTrue(str.contains("Socket Writes"));
         }

--- a/src/test/java/io/nats/client/impl/ObjectStoreTests.java
+++ b/src/test/java/io/nats/client/impl/ObjectStoreTests.java
@@ -41,7 +41,7 @@ public class ObjectStoreTests extends JetStreamTestBase {
             nc.objectStoreManagement(ObjectStoreOptions.builder(DEFAULT_JS_OPTIONS).build()); // coverage
 
             Map<String, String> metadata = new HashMap<>();
-            metadata.put("meta-foo", "meta-bar");
+            metadata.put(META_KEY, META_VALUE);
 
             String bucket = bucket();
             String desc = variant();
@@ -174,10 +174,7 @@ public class ObjectStoreTests extends JetStreamTestBase {
         assertEquals("JetStream", status.getBackingStore());
         assertNotNull(status.toString()); // coverage
 
-        if (atLeast2_10()) {
-            assertEquals(1, status.getMetadata().size());
-            assertEquals("meta-bar", status.getMetadata().get("meta-foo"));
-        }
+        assertMetaData(status.getMetadata());
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/io/nats/client/impl/ParseTesting.java
+++ b/src/test/java/io/nats/client/impl/ParseTesting.java
@@ -29,7 +29,7 @@ public class ParseTesting {
             + "\"auth_required\":false" + "," + "\"port\": 7777" + "," + "\"max_payload\":100000000000" + ","
             + "\"connect_urls\":[\"one\", \"two\"]" + "}";
 
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException {
         int iterations = 1_000_000;
 
         System.out.println("###");

--- a/src/test/java/io/nats/client/impl/PingTests.java
+++ b/src/test/java/io/nats/client/impl/PingTests.java
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class PingTests {
     @Test
-    public void testHandlingPing() throws Exception,ExecutionException {
+    public void testHandlingPing() throws Exception {
         CompletableFuture<Boolean> gotPong = new CompletableFuture<>();
 
         NatsServerProtocolMock.Customizer pingPongCustomizer = (ts, r,w) -> {
@@ -220,7 +220,7 @@ public class PingTests {
 
 
     @Test
-    public void testMessagesDelayPings() throws Exception, ExecutionException, TimeoutException {
+    public void testMessagesDelayPings() throws Exception {
         try (NatsTestServer ts = new NatsTestServer(false)) {
             Options options = new Options.Builder().server(ts.getURI()).
                                     pingInterval(Duration.ofMillis(200)).build();

--- a/src/test/java/io/nats/client/impl/RequestTests.java
+++ b/src/test/java/io/nats/client/impl/RequestTests.java
@@ -48,7 +48,7 @@ public class RequestTests extends TestBase {
             Future<Message> incoming = nc.request("subject", null);
             Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-            assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+            assertEquals(0, nc.getStatistics().getOutstandingRequests());
             assertNotNull(msg);
             assertEquals(0, msg.getData().length);
             assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -56,7 +56,7 @@ public class RequestTests extends TestBase {
             incoming = nc.request("subject", new Headers().put("foo", "bar"), null);
             msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-            assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+            assertEquals(0, nc.getStatistics().getOutstandingRequests());
             assertNotNull(msg);
             assertEquals(0, msg.getData().length);
             assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -119,7 +119,7 @@ public class RequestTests extends TestBase {
             Future<Message> incoming = nc.request("subject", null);
             Message msg = incoming.get(5000, TimeUnit.MILLISECONDS);
 
-            assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+            assertEquals(0, nc.getStatistics().getOutstandingRequests());
             assertNotNull(msg);
             assertEquals(0, msg.getData().length);
             assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -138,7 +138,7 @@ public class RequestTests extends TestBase {
 
             Message msg = nc.request("subject", null, Duration.ofMillis(1000));
 
-            assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+            assertEquals(0, nc.getStatistics().getOutstandingRequests());
             assertNotNull(msg);
             assertEquals(0, msg.getData().length);
             assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -158,7 +158,7 @@ public class RequestTests extends TestBase {
                 Future<Message> incoming = nc.request("subject", new byte[11]);
                 Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
                 assertNotNull(msg);
                 assertEquals(7, msg.getData().length);
                 assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -251,7 +251,7 @@ public class RequestTests extends TestBase {
             Future<Message> incoming = nc.request("subject", null);
             Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-            assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+            assertEquals(0, nc.getStatistics().getOutstandingRequests());
             assertNotNull(msg);
             assertEquals(0, msg.getData().length);
             assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -272,7 +272,7 @@ public class RequestTests extends TestBase {
                 assertThrows(TimeoutException.class,
                         () -> nc.request("subject", null).get(100, TimeUnit.MILLISECONDS));
 
-                assertEquals(1, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(1, nc.getStatistics().getOutstandingRequests());
             } finally {
                 nc.close();
                 assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -299,7 +299,7 @@ public class RequestTests extends TestBase {
                 Thread.sleep(2 * cleanupInterval + Options.DEFAULT_CONNECTION_TIMEOUT.toMillis());
 
                 assertTrue(future.isCompletedExceptionally());
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
 
             } finally {
                 nc.close();
@@ -336,7 +336,7 @@ public class RequestTests extends TestBase {
 
                 Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
                 assertNotNull(msg);
                 assertEquals(0, msg.getData().length);
                 assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -345,7 +345,7 @@ public class RequestTests extends TestBase {
 
                 msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
                 assertNotNull(msg);
                 assertEquals(0, msg.getData().length);
                 assertTrue(msg.getSubject().indexOf('.') < msg.getSubject().lastIndexOf('.'));
@@ -405,7 +405,7 @@ public class RequestTests extends TestBase {
                 assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 assertThrows(CancellationException.class, () -> nc.request("subject", null).get(100, TimeUnit.MILLISECONDS));
 
-                assertEquals(0, ((NatsStatistics) nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
             } finally {
                 nc.close();
                 assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -424,7 +424,7 @@ public class RequestTests extends TestBase {
             try {
                 assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 assertThrows(CancellationException.class, () -> nc.requestWithTimeout("subject", null, Duration.ofMillis(100)).get(100, TimeUnit.MILLISECONDS));
-                assertEquals(0, ((NatsStatistics) nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
             } finally {
                 nc.close();
                 assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -446,7 +446,7 @@ public class RequestTests extends TestBase {
 
                 assertEquals(Connection.Status.CONNECTED, nc.getStatus(), "Connected Status");
                 assertThrows(TimeoutException.class, () -> nc.requestWithTimeout("subject", null, Duration.ofMillis(100)).get(100, TimeUnit.MILLISECONDS));
-                assertEquals(1, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(1, nc.getStatistics().getOutstandingRequests());
 
             } finally {
                 nc.close();
@@ -496,7 +496,7 @@ public class RequestTests extends TestBase {
                 long timeout = 10 * cleanupInterval;
 
                 sleep(sleep);
-                assertTrueByTimeout(timeout, () -> ((NatsStatistics)nc.getStatistics()).getOutstandingRequests() == 0);
+                assertTrueByTimeout(timeout, () -> nc.getStatistics().getOutstandingRequests() == 0);
 
                 // Make sure it is still running
                 incoming = nc.request("subject", null);
@@ -507,7 +507,7 @@ public class RequestTests extends TestBase {
                 incoming.cancel(true);
 
                 sleep(sleep);
-                assertTrueByTimeout(timeout, () -> ((NatsStatistics)nc.getStatistics()).getOutstandingRequests() == 0);
+                assertTrueByTimeout(timeout, () -> nc.getStatistics().getOutstandingRequests() == 0);
             } finally {
                 nc.close();
                 assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -542,7 +542,7 @@ public class RequestTests extends TestBase {
                 }
 
                 assertTrue((end-start) > 2 * cleanupInterval * 1_000_000);
-                assertTrue(0 >= ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertTrue(0 >= nc.getStatistics().getOutstandingRequests());
             } finally {
                 nc.close();
                 assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -574,7 +574,7 @@ public class RequestTests extends TestBase {
                         assertEquals(1, msg.getData().length);
                     }
         
-                    assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                    assertEquals(0, nc.getStatistics().getOutstandingRequests());
                 } finally {
                     nc.close();
                     assertEquals(Connection.Status.CLOSED, nc.getStatus(), "Closed Status");
@@ -596,7 +596,7 @@ public class RequestTests extends TestBase {
                 Future<Message> incoming = nc.request("subject", null);
                 Message msg = incoming.get(500, TimeUnit.MILLISECONDS);
 
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
                 assertNotNull(msg);
                 assertEquals(0, msg.getData().length);
                 assertEquals(msg.getSubject().indexOf('.'), msg.getSubject().lastIndexOf('.'));
@@ -634,7 +634,7 @@ public class RequestTests extends TestBase {
                     exp.printStackTrace();
                 }
 
-                assertEquals(0, ((NatsStatistics)nc.getStatistics()).getOutstandingRequests());
+                assertEquals(0, nc.getStatistics().getOutstandingRequests());
                 assertNotNull(msg);
                 assertEquals(messageSize, msg.getData().length);
             } finally {
@@ -726,7 +726,7 @@ public class RequestTests extends TestBase {
         assertTrue(ftot.useTimeoutException());
         ftot.cancelTimedOut();
         ExecutionException ee = assertThrows(ExecutionException.class, ftot::get);
-        assertTrue(ee.getCause() instanceof TimeoutException);
+        assertInstanceOf(TimeoutException.class, ee.getCause());
     }
 
     @Test

--- a/src/test/java/io/nats/client/impl/SimplificationTests.java
+++ b/src/test/java/io/nats/client/impl/SimplificationTests.java
@@ -283,7 +283,7 @@ public class SimplificationTests extends JetStreamTestBase {
             // coverage
             IterableConsumer consumer = consumerContext.iterate(ConsumeOptions.DEFAULT_CONSUME_OPTIONS);
             consumer.close();
-            assertThrows(IllegalArgumentException.class, () -> consumerContext.iterate((ConsumeOptions)null));
+            assertThrows(IllegalArgumentException.class, () -> consumerContext.iterate(null));
         });
     }
 

--- a/src/test/java/io/nats/client/impl/TLSConnectTests.java
+++ b/src/test/java/io/nats/client/impl/TLSConnectTests.java
@@ -33,7 +33,7 @@ import static io.nats.client.Options.PROP_SSL_CONTEXT_FACTORY_CLASS;
 import static io.nats.client.utils.TestBase.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TLSConnectTests {
+class TLSConnectTests {
 
     private String convertToProtocol(String proto, NatsTestServer... servers) {
         StringBuilder sb = new StringBuilder();
@@ -82,7 +82,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testSimpleTLSConnection() throws Exception {
+    void testSimpleTLSConnection() throws Exception {
         //System.setProperty("javax.net.debug", "all");
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             String servers = ts.getURI();
@@ -94,7 +94,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testSimpleTlsFirstConnection() throws Exception {
+    void testSimpleTlsFirstConnection() throws Exception {
         if (TestBase.atLeast2_10_3(ensureRunServerInfo())) {
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls_first.conf", false)) {
                 String servers = ts.getURI();
@@ -110,7 +110,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testSimpleUrlTLSConnection() throws Exception {
+    void testSimpleUrlTLSConnection() throws Exception {
         //System.setProperty("javax.net.debug", "all");
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             String servers = convertToProtocol("tls", ts);
@@ -122,7 +122,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testMultipleUrlTLSConnectionSetContext() throws Exception {
+    void testMultipleUrlTLSConnectionSetContext() throws Exception {
         //System.setProperty("javax.net.debug", "all");
         try (NatsTestServer server1 = new NatsTestServer("src/test/resources/tls.conf", false);
              NatsTestServer server2 = new NatsTestServer("src/test/resources/tls.conf", false);
@@ -136,7 +136,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testSimpleIPTLSConnection() throws Exception {
+    void testSimpleIPTLSConnection() throws Exception {
         //System.setProperty("javax.net.debug", "all");
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             String servers = "127.0.0.1:" + ts.getPort();
@@ -148,7 +148,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testVerifiedTLSConnection() throws Exception {
+    void testVerifiedTLSConnection() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", false)) {
             String servers = ts.getURI();
             assertCanConnectAndPubSub(createTestOptionsManually(servers));
@@ -159,7 +159,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testOpenTLSConnection() throws Exception {
+    void testOpenTLSConnection() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             String servers = ts.getURI();
             Options options = new Options.Builder()
@@ -178,7 +178,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testURISchemeTLSConnection() throws Exception {
+    void testURISchemeTLSConnection() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", false)) {
             String servers = "tls://localhost:"+ts.getPort();
             assertCanConnectAndPubSub(createTestOptionsManually(servers));
@@ -189,7 +189,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testURISchemeIPTLSConnection() throws Exception {
+    void testURISchemeIPTLSConnection() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", false)) {
             String servers = "tls://127.0.0.1:"+ts.getPort();
             assertCanConnectAndPubSub(createTestOptionsManually(servers));
@@ -200,7 +200,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testURISchemeOpenTLSConnection() throws Exception {
+    void testURISchemeOpenTLSConnection() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             String servers = convertToProtocol("opentls", ts);
             Options options = new Options.Builder()
@@ -219,7 +219,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testMultipleUrlOpenTLSConnection() throws Exception {
+    void testMultipleUrlOpenTLSConnection() throws Exception {
         //System.setProperty("javax.net.debug", "all");
         try (NatsTestServer server1 = new NatsTestServer("src/test/resources/tls.conf", false);
              NatsTestServer server2 = new NatsTestServer("src/test/resources/tls.conf", false);
@@ -241,7 +241,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testTLSMessageFlow() throws Exception {
+    void testTLSMessageFlow() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", false)) {
             SSLContext ctx = SslTestingHelper.createTestSSLContext();
             int msgCount = 100;
@@ -268,7 +268,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testTLSOnReconnect() throws InterruptedException, Exception {
+    void testTLSOnReconnect() throws Exception {
         Connection nc;
         ListenerForTesting listener = new ListenerForTesting();
         int port = NatsTestServer.nextPort();
@@ -301,7 +301,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testDisconnectOnUpgrade() {
+    void testDisconnectOnUpgrade() {
         assertThrows(IOException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", false)) {
                 SSLContext ctx = SslTestingHelper.createTestSSLContext();
@@ -317,7 +317,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testServerSecureClientNotMismatch() {
+    void testServerSecureClientNotMismatch() {
         assertThrows(IOException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tlsverify.conf", false)) {
                 Options options = new Options.Builder().
@@ -330,7 +330,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testClientSecureServerNotMismatch() {
+    void testClientSecureServerNotMismatch() {
         assertThrows(IOException.class, () -> {
             try (NatsTestServer ts = new NatsTestServer()) {
                 SSLContext ctx = SslTestingHelper.createTestSSLContext();
@@ -345,7 +345,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testClientServerCertMismatch() {
+    void testClientServerCertMismatch() {
         AtomicReference<Exception> listenedException = new AtomicReference<>();
         ErrorListener el = new ErrorListener() {
             @Override
@@ -373,7 +373,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testSSLContextFactoryPropertiesPassOnCorrectly() throws NoSuchAlgorithmException {
+    void testSSLContextFactoryPropertiesPassOnCorrectly() throws NoSuchAlgorithmException {
         SSLContextFactoryForTesting factory = new SSLContextFactoryForTesting();
         new Options.Builder()
             .sslContextFactory(factory)
@@ -446,7 +446,7 @@ public class TLSConnectTests {
     */
 
     @Test
-    public void testProxyTlsFirst() throws Exception {
+    void testProxyTlsFirst() throws Exception {
         if (TestBase.atLeast2_10_3(ensureRunServerInfo())) {
             try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls_first.conf", false)) {
                 // 1. client tls first | secure proxy | server insecure -> connects
@@ -468,7 +468,7 @@ public class TLSConnectTests {
     }
 
     @Test
-    public void testProxyNotTlsFirst() throws Exception {
+    void testProxyNotTlsFirst() throws Exception {
         try (NatsTestServer ts = new NatsTestServer("src/test/resources/tls.conf", false)) {
             // 4. client regular secure | secure proxy | server insecure -> mismatch exception
             ListenerForTesting listener = new ListenerForTesting();

--- a/src/test/java/io/nats/client/support/JwtUtilsTests.java
+++ b/src/test/java/io/nats/client/support/JwtUtilsTests.java
@@ -169,12 +169,12 @@ public class JwtUtilsTests {
     public void issueUserJWTSuccessCustom() throws Exception {
         UserClaim userClaim = new UserClaim("ACXZRALIL22WRETDRXYKOYDB7XC3E7MBSVUSUMFACO6OM5VPRNFMOOO6")
             .pub(new Permission()
-                .allow(new String[] {"pub-allow-subject"})
-                .deny(new String[] {"pub-deny-subject"}))
+                .allow("pub-allow-subject")
+                .deny("pub-deny-subject"))
             .sub(new Permission()
-                .allow(new String[] {"sub-allow-subject"})
-                .deny(new String[] {"sub-deny-subject"}))
-            .tags(new String[]{"tag1", "tag\\two"});
+                .allow("sub-allow-subject")
+                .deny("sub-deny-subject"))
+            .tags("tag1", "tag\\two");
 
         String jwt = issueUserJWT(SIGNING_KEY, new String(USER_KEY.getPublicKey()), "custom", null, 1633043378, userClaim);
         String claimBody = getClaimBody(jwt);

--- a/src/test/java/io/nats/client/support/WebsocketSupportClassesTests.java
+++ b/src/test/java/io/nats/client/support/WebsocketSupportClassesTests.java
@@ -259,7 +259,7 @@ public class WebsocketSupportClassesTests {
 
     @FunctionalInterface
     interface OutputStreamWrite {
-        public void write(OutputStream out) throws IOException;
+        void write(OutputStream out) throws IOException;
     }
 
     private void testWithWriter(OutputStreamWrite writer, String msgStartsWith) throws Exception {

--- a/src/test/java/io/nats/client/utils/RunProxy.java
+++ b/src/test/java/io/nats/client/utils/RunProxy.java
@@ -145,7 +145,7 @@ public class RunProxy implements Runnable {
                 System.err.println("Premature close...");
                 return null;
             }
-            if ("".equals(line)) {
+            if (line.isEmpty()) {
                 break;
             }
         }

--- a/src/test/java/io/nats/client/utils/TestBase.java
+++ b/src/test/java/io/nats/client/utils/TestBase.java
@@ -80,7 +80,7 @@ public class TestBase {
     public static final long MEDIUM_FLUSH_TIMEOUT_MS = 5000;
     public static final long LONG_TIMEOUT_MS = 15000;
 
-    public static String[] BAD_SUBJECTS_OR_QUEUES = new String[] {
+    public static final String[] BAD_SUBJECTS_OR_QUEUES = new String[] {
         HAS_SPACE, HAS_CR, HAS_LF, HAS_TAB, STARTS_SPACE, ENDS_SPACE, null, EMPTY
     };
 
@@ -269,7 +269,7 @@ public class TestBase {
 
         @Override
         public void close() throws Exception {
-            try { nc.close(); } catch (Exception ignore) {};
+            try { nc.close(); } catch (Exception ignore) {}
             super.close();
         }
 
@@ -685,7 +685,7 @@ public class TestBase {
             }
             sb.append(o);
         }
-        System.out.println(sb.toString());
+        System.out.println(sb);
     }
 
     // ----------------------------------------------------------------------------------------------------

--- a/src/test/java/io/nats/client/utils/TestBase.java
+++ b/src/test/java/io/nats/client/utils/TestBase.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Supplier;
@@ -44,9 +45,9 @@ public class TestBase {
     public static final String STARTS_WITH_DOT     = ".starts-with-dot";
     public static final String ENDS_WITH_DOT       = "ends-with-dot.";
     public static final String ENDS_WITH_DOT_SPACE = "ends-with-space. ";
-    public static final String ENDS_WITH_CR       = "ends-with-space.\r";
-    public static final String ENDS_WITH_LF       = "ends-with-space.\n";
-    public static final String ENDS_WITH_TAB      = "ends-with-space.\t";
+    public static final String ENDS_WITH_CR        = "ends-with-space.\r";
+    public static final String ENDS_WITH_LF        = "ends-with-space.\n";
+    public static final String ENDS_WITH_TAB       = "ends-with-space.\t";
     public static final String STAR_NOT_SEGMENT    = "star*not*segment";
     public static final String GT_NOT_SEGMENT      = "gt>not>segment";
     public static final String EMPTY_SEGMENT       = "blah..blah";
@@ -69,6 +70,9 @@ public class TestBase {
     public static final String HAS_BACK_SLASH = "has\\back\\slash";
     public static final String HAS_EQUALS     = "has=equals";
     public static final String HAS_TIC        = "has`tic";
+
+    public static final String META_KEY   = "meta-test-key";
+    public static final String META_VALUE = "meta-test-value";
 
     public static final long STANDARD_CONNECTION_WAIT_MS = 5000;
     public static final long LONG_CONNECTION_WAIT_MS = 7500;
@@ -122,7 +126,7 @@ public class TestBase {
     }
 
     public static boolean atLeast2_10() {
-        return RUN_SERVER_INFO.isNewerVersionThan("2.9.99");
+        return atLeast2_10(RUN_SERVER_INFO);
     }
 
     public static boolean atLeast2_10(ServerInfo si) {
@@ -133,8 +137,20 @@ public class TestBase {
         return si.isSameOrNewerThanVersion("2.10.3");
     }
 
+    public static boolean atLeast2_11() {
+        return atLeast2_11(RUN_SERVER_INFO);
+    }
+
     public static boolean atLeast2_11(ServerInfo si) {
         return si.isNewerVersionThan("2.10.99");
+    }
+
+    public static boolean before2_11() {
+        return before2_11(RUN_SERVER_INFO);
+    }
+
+    public static boolean before2_11(ServerInfo si) {
+        return si.isOlderThanVersion("2.11");
     }
 
     public static void runInServer(InServerTest inServerTest) throws Exception {
@@ -813,6 +829,22 @@ public class TestBase {
         }
         else if (error.getKind() == KIND_ILLEGAL_STATE) {
             assertInstanceOf(IllegalStateException.class, e);
+        }
+    }
+
+    public static void assertMetaData(Map<String, String> metadata) {
+        if (atLeast2_10()) {
+            if (before2_11()) {
+                assertEquals(1, metadata.size());
+            }
+            else {
+                assertTrue(metadata.size() > 1);
+            }
+            assertEquals(META_VALUE, metadata.get(META_KEY));
+        }
+        else {
+            assertNotNull(metadata);
+            assertEquals(0, metadata.size());
         }
     }
 }

--- a/src/test/java/io/nats/compatibility/README.md
+++ b/src/test/java/io/nats/compatibility/README.md
@@ -34,10 +34,8 @@ client-compatibility suite object-store
 You can supply the url for the server in two ways. If not supplied, the program will assume `nats://localhost:4222`
 
 1. The program first checks the command line
-```shell
-> java -cp ... io.nats.compatibility.ClientCompatibilityMain nats://myhost:4333
-```
-
+    ```shell
+    > java -cp ... io.nats.compatibility.ClientCompatibilityMain nats://myhost:4333
+    ```
 2. If there is no url on the command line, it checks the NATS_URL environment variable.
-
 3. If it's not provided in arguments or environment, the default is used.

--- a/src/test/java/io/nats/service/ServiceTests.java
+++ b/src/test/java/io/nats/service/ServiceTests.java
@@ -196,7 +196,7 @@ public class ServiceTests extends JetStreamTestBase {
                 Discovery discovery = new Discovery(clientNc, 500, 5);
 
                 // ping discovery
-                Verifier pingVerifier = (expected, response) -> assertTrue(response instanceof PingResponse);
+                Verifier pingVerifier = (expected, response) -> assertInstanceOf(PingResponse.class, response);
                 verifyDiscovery(discovery.ping(), pingVerifier, pingResponse1, pingResponse2);
                 verifyDiscovery(discovery.ping(SERVICE_NAME_1), pingVerifier, pingResponse1);
                 verifyDiscovery(discovery.ping(SERVICE_NAME_2), pingVerifier, pingResponse2);
@@ -206,7 +206,7 @@ public class ServiceTests extends JetStreamTestBase {
 
                 // info discovery
                 Verifier infoVerifier = (expected, response) -> {
-                    assertTrue(response instanceof InfoResponse);
+                    assertInstanceOf(InfoResponse.class, response);
                     InfoResponse exp = (InfoResponse) expected;
                     InfoResponse r = (InfoResponse) response;
                     assertEquals(exp.getDescription(), r.getDescription());
@@ -221,7 +221,7 @@ public class ServiceTests extends JetStreamTestBase {
 
                 // stats discovery
                 Verifier statsVerifier = (expected, response) -> {
-                    assertTrue(response instanceof StatsResponse);
+                    assertInstanceOf(StatsResponse.class, response);
                     StatsResponse exp = (StatsResponse) expected;
                     StatsResponse sr = (StatsResponse) response;
                     assertEquals(exp.getStarted(), sr.getStarted());

--- a/src/test/resources/data/ConsumerConfiguration.json
+++ b/src/test/resources/data/ConsumerConfiguration.json
@@ -26,5 +26,5 @@
   "backoff": [1000000000, 2000000000, 3000000000],
   "num_replicas": 5,
   "mem_storage": true,
-  "metadata":{"meta-foo":"meta-bar"}
+  "metadata":{"meta-test-key":"meta-test-value"}
 }

--- a/src/test/resources/data/StreamConfiguration.json
+++ b/src/test/resources/data/StreamConfiguration.json
@@ -23,7 +23,7 @@
   "allow_rollup_hdrs": true,
   "allow_direct": true,
   "mirror_direct": true,
-  "metadata":{"meta-foo":"meta-bar"},
+  "metadata":{"meta-test-key":"meta-test-value"},
   "first_seq": 82942,
   "placement": {
     "cluster": "clstr",


### PR DESCRIPTION
Several cleanups

- corrected some JavaDocs
- removed not needed casts
- usage of the diamond operator
- usage of constructor chaining in KeyResult; new test added
- deleted Exceptions, that are not thrown, from method signatures
- idiomatic use of isEmpty()
- idiomatic use of array brackets
- deleted not needed imports
- usage of better fitting JUnit assertions
- fail() instead of assertFalse(true)
- ...