### PR TITLE
Add fix to abort unnecessary connection attempts

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -244,6 +244,7 @@ class NatsConnection implements Connection {
 
                 if (this.isAuthenticationError(err)) {
                     this.serverAuthErrors.put(resolved, err);
+                    keepGoing = false;
                 }
             }
         }


### PR DESCRIPTION
Currently, the client library is attempting to connect to all available servers in the client configuration. This is correct behavior e.g. in case of a technical issue.

In case of an authentication error however, the client library should not be required to retry a connection to another server as the authentication is going to fail again.