### PR TITLE
fix: properly propagate `MaxRequestBatch` error in pull subscriptions

### DIFF
--- a/src/main/java/io/nats/client/impl/PullMessageManager.java
+++ b/src/main/java/io/nats/client/impl/PullMessageManager.java
@@ -161,6 +161,11 @@ class PullMessageManager extends MessageManager {
             case CONFLICT_CODE:
                 // sometimes just a warning
                 String statMsg = status.getMessage();
+                //properly handle error & propagate
+                if (statMsg.startsWith("Exceeded MaxRequestBatch")) {
+                        conn.executeCallback((c, el) -> el.pullStatusError(c, sub, status));
+                    return STATUS_ERROR;
+                }
                 if (statMsg.startsWith("Exceeded Max")
                     || statMsg.equals(SERVER_SHUTDOWN)
                     || statMsg.equals(LEADERSHIP_CHANGE)


### PR DESCRIPTION
## Problem
The Java client currently suppresses the "Exceeded MaxRequestBatch" error by handling it as a warning in the generic "Exceeded Max" condition block. This leads to inconsistent behavior with other NATS clients (notably Go) and prevents proper error handling at the application level.

## Solution
Modified error handling in `PullMessageManager` to:
1. Specifically handle "Exceeded MaxRequestBatch" as an error condition
2. Properly propagate the error through `JetStreamStatusException`
3. Maintain existing warning handling for other "Exceeded Max" scenarios

### Changes
The `PullMessageManager.java` class is refactored to propagate the Message as proper error instead of suppressing as a warning.


## Impact & Backwards Compatibility
-  No API changes
- Behavior change: MaxRequestBatch errors now properly propagated
- Maintains existing warning handling for other conditions
- Consistent with Go client behavior

## Related Issues
Fixes #1269 

## Future Improvements
Handle other 409 conflicts as errors instead of warning.
