### PR TITLE
Docs - close() versus stop() in MessageConsumer

### DIFF
--- a/src/main/java/io/nats/client/JetStream.java
+++ b/src/main/java/io/nats/client/JetStream.java
@@ -73,9 +73,10 @@ import java.util.concurrent.CompletableFuture;
  *
  *  js.publish("foo.joe", "Hello World".getBytes());
  *
- *  //Wait a moment, then stop the MessageConsumer
+ *  //Wait a moment, then stop and close the MessageConsumer
  *  Thread.sleep(3000);
- *  mc.stop();
+ *  mc.stop();   //Stops pull requests
+ *  mc.close();  //Unsubcribes
  *
  *  </pre>
  *

--- a/src/main/java/io/nats/client/MessageConsumer.java
+++ b/src/main/java/io/nats/client/MessageConsumer.java
@@ -55,7 +55,7 @@ public interface MessageConsumer extends AutoCloseable {
      * Unsubscribe the underlying subject. Close will be lenient. In flight and buffered messages may still be delivered.
      */
     @Override
-	void close();
+	void close() throws Exception;
 
     /**
      * Stopped indicates whether consuming has been stopped. Can be stopped without being finished.

--- a/src/main/java/io/nats/client/MessageConsumer.java
+++ b/src/main/java/io/nats/client/MessageConsumer.java
@@ -46,10 +46,16 @@ public interface MessageConsumer extends AutoCloseable {
     ConsumerInfo getCachedConsumerInfo();
 
     /**
-     * Stop the MessageConsumer from asking for any more messages from the server.
+     * Use {@link close()} to unsubscribe. Stop will not unsubcribe or clean up resources.
      * The consumer will finish all pull request already in progress, but will not start any new ones.
      */
     void stop();
+
+    /**
+     * Unsubscribe the underlying subject. Close will be lenient. In flight and buffered messages may still be delivered.
+     */
+    @Override
+	void close();
 
     /**
      * Stopped indicates whether consuming has been stopped. Can be stopped without being finished.


### PR DESCRIPTION
It was unclear what stop() did versus close() - For non pull based consumers (Push or Ordered) stop() has no apparent effect at all. 