### PR TITLE
Replace net.i2p.crypto with BouncyCastle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.i2p.crypto:eddsa:0.3.0'
+    implementation 'org.bouncycastle:bcprov-lts8on:2.73.7'
+
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ repositories {
 dependencies {
     implementation 'org.bouncycastle:bcprov-lts8on:2.73.7'
 
-
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:2.0.0'
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.12.3'

--- a/dependencies.md
+++ b/dependencies.md
@@ -11,9 +11,9 @@ This file lists the dependencies used in this repository.
 
 #### Runtime Dependencies
 
-| Dependency                           | License                                 |
-|--------------------------------------|-----------------------------------------|
-| net.i2p.crypto:eddsa:0.3.0           | CC 1.0 Universal                        |
+| Dependency                            | License     |
+|---------------------------------------|-------------|
+| org.bouncycastle:bcprov-lts8on:2.73.7 | MIT License |
 
 #### Test Dependencies
 
@@ -22,15 +22,11 @@ This file lists the dependencies used in this repository.
 | io.nats:jnats-server-runner:1.2.5               | Apache 2.0 License                      |
 | org.apiguardian:apiguardian-api:1.1.0           | Apache 2.0 License                      |
 | org.junit.jupiter:junit-jupiter:5.9.0           | Eclipse Public License v2.0             |
-| org.junit:junit-bom:5.9.0                       | Eclipse Public License v2.0             |
 | org.junit.jupiter:junit-jupiter:5.9.0           | Eclipse Public License v2.0             |
 | org.junit.jupiter:junit-jupiter-api:5.9.0       | Eclipse Public License v2.0             |
 | org.junit.jupiter:junit-jupiter-api:5.9.0       | Eclipse Public License v2.0             |
 | org.junit.jupiter:junit-jupiter-engine:5.9.0    | Eclipse Public License v2.0             |
 | org.junit.jupiter:junit-jupiter-params:5.9.0    | Eclipse Public License v2.0             |
-| org.junit.platform:junit-platform-commons:1.9.0 | Eclipse Public License v2.0             |
-| org.junit.platform:junit-platform-engine:1.9.0  | Eclipse Public License v2.0             |
-| org.opentest4j:opentest4j:1.2.0                 | Apache 2.0 License                      |
 
 #### Build / Coverage Dependencies
 

--- a/src/main/java/io/nats/client/NKey.java
+++ b/src/main/java/io/nats/client/NKey.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 
 import static io.nats.client.support.Encoding.base32Decode;
 import static io.nats.client.support.Encoding.base32Encode;
-import static io.nats.client.support.RandomUtils.PRAND;
 import static io.nats.client.support.RandomUtils.SRAND;
 
 class DecodedSeed {
@@ -329,15 +328,14 @@ public class NKey {
         return retVal;
     }
 
-    public static NKey createPair(Type type, SecureRandom random)
-        throws IOException, NoSuchProviderException, NoSuchAlgorithmException {
+    private static NKey createPair(Type type, SecureRandom random) throws IOException {
+        byte[] seed = new byte[ED25519_SEED_SIZE];
         if (random == null) {
-            random = SRAND;
+            SRAND.nextBytes(seed);
         }
-
-        byte[] seed = new byte[32]; // NKey.ed25519.getCurve().getField().getb() / 8
-        random.nextBytes(seed);
-
+        else {
+            random.nextBytes(seed);
+        }
         return createPair(type, seed);
     }
 
@@ -358,11 +356,8 @@ public class NKey {
 
     /**
      * Create an Account NKey from the provided random number generator.
-     *
      * If no random is provided, SecureRandom() will be used to create one.
-     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -376,11 +371,8 @@ public class NKey {
 
     /**
      * Create a Cluster NKey from the provided random number generator.
-     *
      * If no random is provided, SecureRandom() will be used to create one.
-     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -394,11 +386,8 @@ public class NKey {
 
     /**
      * Create an Operator NKey from the provided random number generator.
-     *
      * If no random is provided, SecureRandom() will be used to create one.
-     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -412,11 +401,8 @@ public class NKey {
 
     /**
      * Create a Server NKey from the provided random number generator.
-     *
      * If no random is provided, SecureRandom() will be used to create one.
-     *
      * The new NKey contains the private seed, which should be saved in a secure location.
-     *
      * @param random A secure random provider
      * @return the new Nkey
      * @throws IOException if the seed cannot be encoded to a string
@@ -430,9 +416,7 @@ public class NKey {
 
     /**
      * Create a User NKey from the provided random number generator.
-     *
      * If no random is provided, SecureRandom() will be used to create one.
-     *
      * The new NKey contains the private seed, which should be saved in a secure location.
      *
      * @param random A secure random provider
@@ -448,7 +432,6 @@ public class NKey {
 
     /**
      * Create an NKey object from the encoded public key. This NKey can be used for verification but not for signing.
-     *
      * @param publicKey the string encoded public key
      * @return the new Nkey
      */
@@ -466,7 +449,6 @@ public class NKey {
 
     /**
      * Creates an NKey object from a string encoded seed. This NKey can be used to sign or verify.
-     *
      * @param seed the string encoded seed, see {@link NKey#getSeed() getSeed()}
      * @return the Nkey
      */
@@ -527,14 +509,14 @@ public class NKey {
     /**
      * The seed or private key per the Ed25519 spec, encoded with encodeSeed.
      */
-    private char[] privateKeyAsSeed;
+    private final char[] privateKeyAsSeed;
 
     /**
      * The public key, maybe null. Used for public only NKeys.
      */
-    private char[] publicKey;
+    private final char[] publicKey;
 
-    private Type type;
+    private final Type type;
 
     private NKey(Type t, char[] publicKey, char[] privateKey) {
         this.type = t;
@@ -543,23 +525,19 @@ public class NKey {
     }
 
     /**
-     * Clear the seed and public key char arrays by filling them
-     * with random bytes then zero-ing them out.
-     *
+     * Clear the seed and public key char arrays by zero-ing them out.
      * The nkey is unusable after this operation.
      */
     public void clear() {
         if (privateKeyAsSeed != null) {
             for (int i=0; i< privateKeyAsSeed.length ; i++) {
-                privateKeyAsSeed[i] = (char)(PRAND.nextInt(26) + 'a');
+                privateKeyAsSeed[i] = '\0';
             }
-            Arrays.fill(privateKeyAsSeed, '\0');
         }
         if (publicKey != null) {
             for (int i=0; i< publicKey.length ; i++) {
-                publicKey[i] = (char)(PRAND.nextInt(26) + 'a');
+                publicKey[i] = '\0';
             }
-            Arrays.fill(publicKey, '\0');
         }
     }
 

--- a/src/main/java/io/nats/client/NKey.java
+++ b/src/main/java/io/nats/client/NKey.java
@@ -339,8 +339,7 @@ public class NKey {
         return createPair(type, seed);
     }
 
-    private static NKey createPair(Type type, byte[] seed)
-        throws IOException {
+    private static NKey createPair(Type type, byte[] seed) throws IOException {
         Ed25519PrivateKeyParameters privateKey = new Ed25519PrivateKeyParameters(seed);
         Ed25519PublicKeyParameters publicKey = privateKey.generatePublicKey();
 
@@ -697,7 +696,6 @@ public class NKey {
         return result;
     }
 }
-
 
 abstract class KeyWrapper implements Key {
     @Override

--- a/src/test/java/io/nats/client/NKeyTests.java
+++ b/src/test/java/io/nats/client/NKeyTests.java
@@ -437,8 +437,8 @@ public class NKeyTests {
         char[] seed = theKey.getSeed();
         assertEquals(NKey.fromSeed(seed), NKey.fromSeed(seed));
         assertEquals(NKey.fromSeed(seed).hashCode(), NKey.fromSeed(seed).hashCode());
-        assertTrue(Arrays.equals(NKey.fromSeed(seed).getPublicKey(), NKey.fromSeed(seed).getPublicKey()));
-        assertTrue(Arrays.equals(NKey.fromSeed(seed).getPrivateKey(), NKey.fromSeed(seed).getPrivateKey()));
+        assertArrayEquals(NKey.fromSeed(seed).getPublicKey(), NKey.fromSeed(seed).getPublicKey());
+        assertArrayEquals(NKey.fromSeed(seed).getPrivateKey(), NKey.fromSeed(seed).getPrivateKey());
 
         assertTrue(seed[0] == 'S' && seed[1] == 'A');
 


### PR DESCRIPTION
net.i2p.crypto has a CVE https://nvd.nist.gov/vuln/detail/CVE-2020-36843 and is not being maintained. BouncyCastle is an industry standard well maintained library.