### PR TITLE
Replace ed25519 with BouncyCastle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.i2p.crypto:eddsa:0.3.0'
+    implementation 'org.bouncycastle:bcprov-lts8on:2.73.7'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'
     testImplementation 'io.nats:jnats-server-runner:2.0.0'

--- a/dependencies.md
+++ b/dependencies.md
@@ -11,10 +11,9 @@ This file lists the dependencies used in this repository.
 
 #### Runtime Dependencies
 
-| Dependency                           | License                                 |
-|--------------------------------------|-----------------------------------------|
-| net.i2p.crypto:eddsa:0.3.0           | CC 1.0 Universal                        |
-
+| Dependency                            | License     |
+|---------------------------------------|-------------|
+| org.bouncycastle:bcprov-lts8on:2.73.7 | MIT License |
 #### Test Dependencies
 
 | Dependency                                      | License                                 |

--- a/src/test/java/io/nats/client/NKeyTests.java
+++ b/src/test/java/io/nats/client/NKeyTests.java
@@ -437,8 +437,8 @@ public class NKeyTests {
         char[] seed = theKey.getSeed();
         assertEquals(NKey.fromSeed(seed), NKey.fromSeed(seed));
         assertEquals(NKey.fromSeed(seed).hashCode(), NKey.fromSeed(seed).hashCode());
-        assertTrue(Arrays.equals(NKey.fromSeed(seed).getPublicKey(), NKey.fromSeed(seed).getPublicKey()));
-        assertTrue(Arrays.equals(NKey.fromSeed(seed).getPrivateKey(), NKey.fromSeed(seed).getPrivateKey()));
+        assertArrayEquals(NKey.fromSeed(seed).getPublicKey(), NKey.fromSeed(seed).getPublicKey());
+        assertArrayEquals(NKey.fromSeed(seed).getPrivateKey(), NKey.fromSeed(seed).getPrivateKey());
 
         assertTrue(seed[0] == 'S' && seed[1] == 'A');
 


### PR DESCRIPTION
net.i2p.crypto has a CVE https://nvd.nist.gov/vuln/detail/CVE-2020-36843 and is not being maintained. BouncyCastle is an industry standard well maintained library.