### PR TITLE
KV TTL (stream max_age) versus stream duplicate_window

### DIFF
--- a/src/main/java/io/nats/client/api/FeatureConfiguration.java
+++ b/src/main/java/io/nats/client/api/FeatureConfiguration.java
@@ -137,8 +137,9 @@ public abstract class FeatureConfiguration implements JsonSerializable {
     }
 
     protected static abstract class Builder<B, FC> {
-        String name;
-        StreamConfiguration.Builder scBuilder;
+        protected String name;
+        protected Duration ttl = Duration.ZERO;
+        protected StreamConfiguration.Builder scBuilder;
         protected abstract B getThis();
 
         /**
@@ -177,7 +178,8 @@ public abstract class FeatureConfiguration implements JsonSerializable {
          * @return Builder
          */
         protected B ttl(Duration ttl) {
-            scBuilder.maxAge(ttl);
+            this.ttl = ttl == null ? Duration.ZERO : ttl;
+            scBuilder.maxAge(this.ttl);
             return getThis();
         }
 

--- a/src/main/java/io/nats/client/api/KeyValueConfiguration.java
+++ b/src/main/java/io/nats/client/api/KeyValueConfiguration.java
@@ -431,7 +431,7 @@ public class KeyValueConfiguration extends FeatureConfiguration {
             if (ttlMs > 0 && ttlMs < SERVER_DEFAULT_DUPLICATE_WINDOW_MS) {
                 dupeMs = ttlMs;
             }
-            scBuilder.duplicateWindow(dupeMs).build();
+            scBuilder.duplicateWindow(dupeMs);
 
             return new KeyValueConfiguration(scBuilder.build());
         }

--- a/src/main/java/io/nats/client/support/NatsJetStreamConstants.java
+++ b/src/main/java/io/nats/client/support/NatsJetStreamConstants.java
@@ -12,6 +12,8 @@ public interface NatsJetStreamConstants {
      */
     int MAX_HISTORY_PER_KEY = 64;
 
+    long SERVER_DEFAULT_DUPLICATE_WINDOW_MS = 120_000; // 1000ms/sec * 60sec/min * 2 min
+
     String PREFIX_DOLLAR_JS_DOT = "$JS.";
     String PREFIX_API = "API";
     String DEFAULT_API_PREFIX = "$JS.API.";


### PR DESCRIPTION
Ensure that duplicate window is 
* never more than 2 minutes
* never greater than the max_age