### PR TITLE
KV Limit Marker

### DIFF
--- a/src/main/java/io/nats/client/KeyValue.java
+++ b/src/main/java/io/nats/client/KeyValue.java
@@ -105,6 +105,20 @@ public interface KeyValue {
     long create(String key, byte[] value) throws IOException, JetStreamApiException;
 
     /**
+     * Put as the value for a key iff the key does not exist (there is no history)
+     * or is deleted (history shows the key is deleted)
+     * @param key the key
+     * @param value the bytes of the value
+     * @param messageTtl the individual ttl for the key
+     * @return the revision number for the key
+     * @throws IOException covers various communication issues with the NATS
+     *         server such as timeout or interruption
+     * @throws JetStreamApiException the request had an error related to the data
+     * @throws IllegalArgumentException the server is not JetStream enabled
+     */
+    long create(String key, byte[] value, MessageTtl messageTtl) throws IOException, JetStreamApiException;
+
+    /**
      * Put as the value for a key iff the key exists and its last revision matches the expected
      * @param key the key
      * @param value the bytes of the value

--- a/src/main/java/io/nats/client/MessageTtl.java
+++ b/src/main/java/io/nats/client/MessageTtl.java
@@ -1,0 +1,64 @@
+// Copyright 2015-2018 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client;
+
+public class MessageTtl {
+    private final String messageTtl;
+
+    private MessageTtl(String messageTtl) {
+        this.messageTtl = messageTtl;
+    }
+
+    public String getMessageTtl() {
+        return messageTtl;
+    }
+
+    @Override
+    public String toString() {
+        return "MessageTtl{'" + messageTtl + "'}";
+    }
+
+    /**
+     * Sets the TTL for this specific message to be published
+     * @param msgTtlSeconds the ttl in seconds
+     * @return The Builder
+     */
+    public static MessageTtl seconds(int msgTtlSeconds) {
+        if (msgTtlSeconds < 0) {
+            throw new IllegalArgumentException("msgTtlSeconds must be at least 1 second.");
+        }
+        return new MessageTtl(msgTtlSeconds + "s");
+    }
+
+    /**
+     * Sets the TTL for this specific message to be published. Use at your own risk.
+     * The current specification can be found here @see <a href="https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-43.md#per-message-ttl">JetStream Per-Message TTL</a>
+     * @param messageTtlCustom the ttl in seconds
+     * @return The Builder
+     */
+    public static MessageTtl custom(String messageTtlCustom) {
+        if (messageTtlCustom == null) {
+            throw new IllegalArgumentException("messageTtlCustom required.");
+        }
+        return new MessageTtl(messageTtlCustom);
+    }
+
+    /**
+     * Sets the TTL for this specific message to be published and never be expired
+     * @return The Builder
+     */
+    public static MessageTtl never() {
+        return new MessageTtl("never");
+    }
+}

--- a/src/main/java/io/nats/client/MessageTtl.java
+++ b/src/main/java/io/nats/client/MessageTtl.java
@@ -38,7 +38,7 @@ public class MessageTtl {
      */
     public static MessageTtl seconds(int msgTtlSeconds) {
         if (msgTtlSeconds < 1) {
-            throw new IllegalArgumentException("msgTtlSeconds must be at least 1 second.");
+            throw new IllegalArgumentException("Must be at least 1 second.");
         }
         return new MessageTtl(msgTtlSeconds + "s");
     }

--- a/src/main/java/io/nats/client/MessageTtl.java
+++ b/src/main/java/io/nats/client/MessageTtl.java
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:

--- a/src/main/java/io/nats/client/MessageTtl.java
+++ b/src/main/java/io/nats/client/MessageTtl.java
@@ -13,6 +13,8 @@
 
 package io.nats.client;
 
+import io.nats.client.support.Validator;
+
 public class MessageTtl {
     private final String messageTtl;
 
@@ -35,7 +37,7 @@ public class MessageTtl {
      * @return The Builder
      */
     public static MessageTtl seconds(int msgTtlSeconds) {
-        if (msgTtlSeconds < 0) {
+        if (msgTtlSeconds < 1) {
             throw new IllegalArgumentException("msgTtlSeconds must be at least 1 second.");
         }
         return new MessageTtl(msgTtlSeconds + "s");
@@ -48,7 +50,7 @@ public class MessageTtl {
      * @return The Builder
      */
     public static MessageTtl custom(String messageTtlCustom) {
-        if (messageTtlCustom == null) {
+        if (Validator.nullOrEmpty(messageTtlCustom)) {
             throw new IllegalArgumentException("messageTtlCustom required.");
         }
         return new MessageTtl(messageTtlCustom);

--- a/src/main/java/io/nats/client/PublishOptions.java
+++ b/src/main/java/io/nats/client/PublishOptions.java
@@ -45,7 +45,7 @@ public class PublishOptions {
     private final long expectedLastSeq;
     private final long expectedLastSubSeq;
     private final String msgId;
-    private final String messageTtl;
+    private final MessageTtl messageTtl;
 
     private PublishOptions(Builder b) {
         this.stream = b.stream;
@@ -56,6 +56,20 @@ public class PublishOptions {
         this.expectedLastSubSeq = b.expectedLastSubSeq;
         this.msgId = b.msgId;
         this.messageTtl = b.messageTtl;
+    }
+
+    @Override
+    public String toString() {
+        return "PublishOptions{" +
+            "stream='" + stream + '\'' +
+            ", streamTimeout=" + streamTimeout +
+            ", expectedStream='" + expectedStream + '\'' +
+            ", expectedLastId='" + expectedLastId + '\'' +
+            ", expectedLastSeq=" + expectedLastSeq +
+            ", expectedLastSubSeq=" + expectedLastSubSeq +
+            ", msgId='" + msgId + '\'' +
+            ", messageTtl=" + messageTtl +
+            '}';
     }
 
     /**
@@ -130,7 +144,7 @@ public class PublishOptions {
      * @return the message ttl string
      */
     public String getMessageTtl() {
-        return messageTtl;
+        return messageTtl == null ? null : messageTtl.getMessageTtl();
     }
 
     /**
@@ -155,7 +169,7 @@ public class PublishOptions {
         long expectedLastSeq = UNSET_LAST_SEQUENCE;
         long expectedLastSubSeq = UNSET_LAST_SEQUENCE;
         String msgId;
-        String messageTtl;
+        MessageTtl messageTtl;
 
         /**
          * Constructs a new publish options Builder with the default values.
@@ -259,7 +273,7 @@ public class PublishOptions {
          * @return The Builder
          */
         public Builder messageTtlSeconds(int msgTtlSeconds) {
-            this.messageTtl = msgTtlSeconds < 1 ? null : msgTtlSeconds + "s";
+            this.messageTtl = msgTtlSeconds < 1 ? null : MessageTtl.seconds(msgTtlSeconds);
             return this;
         }
 
@@ -270,15 +284,7 @@ public class PublishOptions {
          * @return The Builder
          */
         public Builder messageTtlCustom(String messageTtlCustom) {
-            if (messageTtlCustom == null) {
-                this.messageTtl = null;
-            }
-            else {
-                this.messageTtl = messageTtlCustom.trim();
-                if (this.messageTtl.isEmpty()) {
-                    this.messageTtl = null;
-                }
-            }
+            this.messageTtl = messageTtlCustom == null ? null : MessageTtl.custom(messageTtlCustom);
             return this;
         }
 
@@ -287,7 +293,16 @@ public class PublishOptions {
          * @return The Builder
          */
         public Builder messageTtlNever() {
-            this.messageTtl = "never";
+            this.messageTtl = MessageTtl.never();
+            return this;
+        }
+
+        /**
+         * Sets the TTL for this specific message to be published
+         * @return The Builder
+         */
+        public Builder messageTtl(MessageTtl messageTtl) {
+            this.messageTtl = messageTtl;
             return this;
         }
 

--- a/src/main/java/io/nats/client/PublishOptions.java
+++ b/src/main/java/io/nats/client/PublishOptions.java
@@ -284,7 +284,7 @@ public class PublishOptions {
          * @return The Builder
          */
         public Builder messageTtlCustom(String messageTtlCustom) {
-            this.messageTtl = messageTtlCustom == null ? null : MessageTtl.custom(messageTtlCustom);
+            this.messageTtl = nullOrEmpty(messageTtlCustom) ? null : MessageTtl.custom(messageTtlCustom);
             return this;
         }
 

--- a/src/main/java/io/nats/client/PublishOptions.java
+++ b/src/main/java/io/nats/client/PublishOptions.java
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 The NATS Authors
+// Copyright 2015-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -68,7 +68,7 @@ public class PublishOptions {
             ", expectedLastSeq=" + expectedLastSeq +
             ", expectedLastSubSeq=" + expectedLastSubSeq +
             ", msgId='" + msgId + '\'' +
-            ", messageTtl=" + messageTtl +
+            ", messageTtl=" + getMessageTtl() +
             '}';
     }
 

--- a/src/main/java/io/nats/client/api/KeyValueConfiguration.java
+++ b/src/main/java/io/nats/client/api/KeyValueConfiguration.java
@@ -136,6 +136,7 @@ public class KeyValueConfiguration extends FeatureConfiguration {
         extends FeatureConfiguration.Builder<Builder, KeyValueConfiguration>
     {
         Mirror mirror;
+        Duration limitMarkerTtl;
         final List<Source> sources = new ArrayList<>();
 
         @Override
@@ -379,6 +380,31 @@ public class KeyValueConfiguration extends FeatureConfiguration {
         }
 
         /**
+         * The limit marker TTL duration. Server accepts 1 second or more.
+         * @param limitMarkerTtl the TTL duration
+         * @return The Builder
+         */
+        public Builder limitMarker(Duration limitMarkerTtl) {
+            this.limitMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, limitMarkerTtl, Duration.ZERO);
+            return this;
+        }
+
+        /**
+         * The limit marker TTL duration. Server accepts 1 second or more.
+         * @param limitMarkerTtlMillis the TTL duration
+         * @return The Builder
+         */
+        public Builder limitMarker(long limitMarkerTtlMillis) {
+            if (limitMarkerTtlMillis <= 0) {
+                this.limitMarkerTtl = Duration.ZERO;
+            }
+            else {
+                this.limitMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, limitMarkerTtlMillis);
+            }
+            return this;
+        }
+
+        /**
          * Builds the KeyValueConfiguration
          * @return the KeyValueConfiguration.
          */
@@ -419,6 +445,10 @@ public class KeyValueConfiguration extends FeatureConfiguration {
             }
             else {
                 scBuilder.subjects(toStreamSubject(name));
+            }
+
+            if (limitMarkerTtl != null) {
+                scBuilder.subjectDeleteMarkerTtl(limitMarkerTtl).allowMessageTtl();
             }
 
             // When stream's MaxAge is not set, server uses 2 minutes as the default

--- a/src/main/java/io/nats/client/api/KeyValueConfiguration.java
+++ b/src/main/java/io/nats/client/api/KeyValueConfiguration.java
@@ -399,7 +399,7 @@ public class KeyValueConfiguration extends FeatureConfiguration {
                 this.limitMarkerTtl = null;
             }
             else {
-                this.limitMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, limitMarkerTtlMillis);
+                this.limitMarkerTtl = validateDurationGtOrEqSeconds(1, limitMarkerTtlMillis);
             }
             return this;
         }

--- a/src/main/java/io/nats/client/api/KeyValueConfiguration.java
+++ b/src/main/java/io/nats/client/api/KeyValueConfiguration.java
@@ -385,7 +385,7 @@ public class KeyValueConfiguration extends FeatureConfiguration {
          * @return The Builder
          */
         public Builder limitMarker(Duration limitMarkerTtl) {
-            this.limitMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, limitMarkerTtl, Duration.ZERO);
+            this.limitMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, limitMarkerTtl, null);
             return this;
         }
 
@@ -396,7 +396,7 @@ public class KeyValueConfiguration extends FeatureConfiguration {
          */
         public Builder limitMarker(long limitMarkerTtlMillis) {
             if (limitMarkerTtlMillis <= 0) {
-                this.limitMarkerTtl = Duration.ZERO;
+                this.limitMarkerTtl = null;
             }
             else {
                 this.limitMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, limitMarkerTtlMillis);

--- a/src/main/java/io/nats/client/api/KeyValueStatus.java
+++ b/src/main/java/io/nats/client/api/KeyValueStatus.java
@@ -169,6 +169,13 @@ public class KeyValueStatus {
     }
 
     /**
+     * Get the Limit Marker TTL duration or null if configured.
+     * @return the duration.
+     */
+    public Duration getLimitMarkerTtl() {
+        return streamInfo.getConfig().getSubjectDeleteMarkerTtl();
+    }
+    /**
      * Gets the name of the type of backing store, currently only "JetStream"
      * @return the name of the store, currently only "JetStream"
      */

--- a/src/main/java/io/nats/client/api/StreamConfiguration.java
+++ b/src/main/java/io/nats/client/api/StreamConfiguration.java
@@ -1081,12 +1081,26 @@ public class StreamConfiguration implements JsonSerializable {
 
         /**
          * The time delete marker TTL duration. Server accepts 1 second or more.
-         * CLIENT DOES NOT VALIDATE
          * @param subjectDeleteMarkerTtl the TTL duration
          * @return The Builder
          */
         public Builder subjectDeleteMarkerTtl(Duration subjectDeleteMarkerTtl) {
-            this.subjectDeleteMarkerTtl = subjectDeleteMarkerTtl;
+            this.subjectDeleteMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtl, Duration.ZERO);
+            return this;
+        }
+
+        /**
+         * The time delete marker TTL duration in milliseconds. Server accepts 1 second or more.
+         * @param subjectDeleteMarkerTtlMillis the TTL duration
+         * @return The Builder
+         */
+        public Builder subjectDeleteMarkerTtl(long subjectDeleteMarkerTtlMillis) {
+            if (subjectDeleteMarkerTtlMillis <= 0) {
+                this.subjectDeleteMarkerTtl = Duration.ZERO;
+            }
+            else {
+                this.subjectDeleteMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtlMillis);
+            }
             return this;
         }
 

--- a/src/main/java/io/nats/client/api/StreamConfiguration.java
+++ b/src/main/java/io/nats/client/api/StreamConfiguration.java
@@ -557,7 +557,7 @@ public class StreamConfiguration implements JsonSerializable {
         private Map<String, String> metadata;
         private long firstSequence = 1;
         private boolean allowMessageTtl = false;
-        private Duration subjectDeleteMarkerTtl = Duration.ZERO;
+        private Duration subjectDeleteMarkerTtl;
 
         /**
          * Default Builder
@@ -1085,7 +1085,7 @@ public class StreamConfiguration implements JsonSerializable {
          * @return The Builder
          */
         public Builder subjectDeleteMarkerTtl(Duration subjectDeleteMarkerTtl) {
-            this.subjectDeleteMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtl, Duration.ZERO);
+            this.subjectDeleteMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtl, null);
             return this;
         }
 
@@ -1095,12 +1095,8 @@ public class StreamConfiguration implements JsonSerializable {
          * @return The Builder
          */
         public Builder subjectDeleteMarkerTtl(long subjectDeleteMarkerTtlMillis) {
-            if (subjectDeleteMarkerTtlMillis <= 0) {
-                this.subjectDeleteMarkerTtl = Duration.ZERO;
-            }
-            else {
-                this.subjectDeleteMarkerTtl = validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtlMillis);
-            }
+            this.subjectDeleteMarkerTtl = subjectDeleteMarkerTtlMillis <= 0 ? null
+                : validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtlMillis);
             return this;
         }
 

--- a/src/main/java/io/nats/client/api/StreamConfiguration.java
+++ b/src/main/java/io/nats/client/api/StreamConfiguration.java
@@ -1096,7 +1096,7 @@ public class StreamConfiguration implements JsonSerializable {
          */
         public Builder subjectDeleteMarkerTtl(long subjectDeleteMarkerTtlMillis) {
             this.subjectDeleteMarkerTtl = subjectDeleteMarkerTtlMillis <= 0 ? null
-                : validateDurationNotRequiredGtOrEqSeconds(1, subjectDeleteMarkerTtlMillis);
+                : validateDurationGtOrEqSeconds(1, subjectDeleteMarkerTtlMillis);
             return this;
         }
 

--- a/src/main/java/io/nats/client/impl/NatsKeyValueManagement.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValueManagement.java
@@ -51,6 +51,9 @@ public class NatsKeyValueManagement implements KeyValueManagement {
         return new KeyValueStatus(jsm.addStream(sc));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public KeyValueStatus update(KeyValueConfiguration config) throws IOException, JetStreamApiException {
         return new KeyValueStatus(jsm.updateStream(config.getBackingConfig()));

--- a/src/main/java/io/nats/client/support/NatsKeyValueUtil.java
+++ b/src/main/java/io/nats/client/support/NatsKeyValueUtil.java
@@ -14,6 +14,8 @@
 package io.nats.client.support;
 
 import io.nats.client.Message;
+import io.nats.client.MessageTtl;
+import io.nats.client.PublishOptions;
 import io.nats.client.api.KeyValueOperation;
 import io.nats.client.impl.Headers;
 
@@ -75,6 +77,20 @@ public abstract class NatsKeyValueUtil {
         return new Headers()
             .put(KV_OPERATION_HEADER_KEY, KeyValueOperation.PURGE.getHeaderValue())
             .put(ROLLUP_HDR, ROLLUP_HDR_SUBJECT);
+    }
+
+    public static PublishOptions getPublishOptions(long expectedRevision, MessageTtl messageTtl) {
+        boolean returnNull = true;
+        PublishOptions.Builder b = PublishOptions.builder();
+        if (expectedRevision > -1) {
+            returnNull = false;
+            b.expectedLastSubjectSequence(expectedRevision);
+        }
+        if (messageTtl != null) {
+            returnNull = false;
+            b.messageTtl(messageTtl);
+        }
+        return returnNull ? null : b.build();
     }
 
     public static class BucketAndKey {

--- a/src/main/java/io/nats/client/support/Validator.java
+++ b/src/main/java/io/nats/client/support/Validator.java
@@ -364,12 +364,12 @@ public abstract class Validator {
     }
 
     public static Duration validateDurationNotRequiredGtOrEqSeconds(long minSeconds, Duration d, Duration ifNull) {
-        return d == null ? ifNull : validateDurationNotRequiredGtOrEqSeconds(minSeconds, d.toMillis());
+        return d == null ? ifNull : validateDurationGtOrEqSeconds(minSeconds, d.toMillis());
     }
 
-    public static Duration validateDurationNotRequiredGtOrEqSeconds(long minSeconds, long millis) {
+    public static Duration validateDurationGtOrEqSeconds(long minSeconds, long millis) {
         if (millis < (minSeconds * 1000)) {
-            throw new IllegalArgumentException("Duration must be greater than or equal to " + minSeconds + " seconds.");
+            throw new IllegalArgumentException("Must be greater than or equal to " + minSeconds + " second(s).");
         }
         return Duration.ofMillis(millis);
     }

--- a/src/main/java/io/nats/client/support/Validator.java
+++ b/src/main/java/io/nats/client/support/Validator.java
@@ -363,6 +363,17 @@ public abstract class Validator {
         return Duration.ofMillis(millis);
     }
 
+    public static Duration validateDurationNotRequiredGtOrEqSeconds(long minSeconds, Duration d, Duration ifNull) {
+        return d == null ? ifNull : validateDurationNotRequiredGtOrEqSeconds(minSeconds, d.toMillis());
+    }
+
+    public static Duration validateDurationNotRequiredGtOrEqSeconds(long minSeconds, long millis) {
+        if (millis < (minSeconds * 1000)) {
+            throw new IllegalArgumentException("Duration must be greater than or equal to " + minSeconds + " seconds.");
+        }
+        return Duration.ofMillis(millis);
+    }
+
     public static String validateNotNull(String s, String fieldName) {
         if (s == null) {
             throw new IllegalArgumentException(fieldName + " cannot be null");

--- a/src/test/java/io/nats/client/PublishOptionsTests.java
+++ b/src/test/java/io/nats/client/PublishOptionsTests.java
@@ -19,8 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PublishOptionsTests extends TestBase {
 
@@ -82,5 +81,40 @@ public class PublishOptionsTests extends TestBase {
         po = new PublishOptions.Builder(p).build();
         assertEquals(PublishOptions.UNSET_STREAM, po.getStream());
         assertEquals(PublishOptions.DEFAULT_TIMEOUT, po.getStreamTimeout());
+    }
+
+    @Test
+    public void testMessageTtl() {
+        PublishOptions po = PublishOptions.builder()
+            .messageTtlSeconds(3)
+            .build();
+        assertEquals("3s", po.getMessageTtl());
+
+        po = PublishOptions.builder()
+            .messageTtlCustom("abcd")
+            .build();
+        assertEquals("abcd", po.getMessageTtl());
+
+        po = PublishOptions.builder()
+            .messageTtlNever()
+            .build();
+        assertEquals("never", po.getMessageTtl());
+
+        po = PublishOptions.builder()
+            .messageTtl(MessageTtl.seconds(3))
+            .build();
+        assertEquals("3s", po.getMessageTtl());
+
+        po = PublishOptions.builder()
+            .messageTtl(MessageTtl.custom("abcd"))
+            .build();
+        assertEquals("abcd", po.getMessageTtl());
+
+        po = PublishOptions.builder()
+            .messageTtl(MessageTtl.never())
+            .build();
+        assertEquals("never", po.getMessageTtl());
+
+        assertTrue(MessageTtl.seconds(3).toString().contains("3s")); // COVERAGE
     }
 }

--- a/src/test/java/io/nats/client/PublishOptionsTests.java
+++ b/src/test/java/io/nats/client/PublishOptionsTests.java
@@ -85,40 +85,44 @@ public class PublishOptionsTests extends TestBase {
 
     @Test
     public void testMessageTtl() {
-        PublishOptions po = PublishOptions.builder()
-            .messageTtlSeconds(3)
-            .build();
+        PublishOptions po = PublishOptions.builder().messageTtlSeconds(3).build();
         assertEquals("3s", po.getMessageTtl());
 
-        po = PublishOptions.builder()
-            .messageTtlCustom("abcd")
-            .build();
+        po = PublishOptions.builder().messageTtlCustom("abcd").build();
         assertEquals("abcd", po.getMessageTtl());
 
-        po = PublishOptions.builder()
-            .messageTtlNever()
-            .build();
+        po = PublishOptions.builder().messageTtlNever().build();
         assertEquals("never", po.getMessageTtl());
 
-        po = PublishOptions.builder()
-            .messageTtl(MessageTtl.seconds(3))
-            .build();
+        po = PublishOptions.builder().messageTtl(MessageTtl.seconds(3)).build();
         assertEquals("3s", po.getMessageTtl());
 
-        po = PublishOptions.builder()
-            .messageTtl(MessageTtl.custom("abcd"))
-            .build();
+        po = PublishOptions.builder().messageTtl(MessageTtl.custom("abcd")).build();
         assertEquals("abcd", po.getMessageTtl());
 
-        po = PublishOptions.builder()
-            .messageTtl(MessageTtl.never())
-            .build();
+        po = PublishOptions.builder().messageTtl(MessageTtl.never()).build();
         assertEquals("never", po.getMessageTtl());
+
+        po = PublishOptions.builder().messageTtlSeconds(0).build();
+        assertNull(po.getMessageTtl());
+
+        po = PublishOptions.builder().messageTtlSeconds(-1).build();
+        assertNull(po.getMessageTtl());
+
+        po = PublishOptions.builder().messageTtlCustom(null).build();
+        assertNull(po.getMessageTtl());
+
+        po = PublishOptions.builder().messageTtlCustom("").build();
+        assertNull(po.getMessageTtl());
+
+        po = PublishOptions.builder().messageTtl(null).build();
+        assertNull(po.getMessageTtl());
 
         assertThrows(IllegalArgumentException.class, () -> MessageTtl.seconds(0));
         assertThrows(IllegalArgumentException.class, () -> MessageTtl.seconds(-1));
         assertThrows(IllegalArgumentException.class, () -> MessageTtl.custom(null));
         assertThrows(IllegalArgumentException.class, () -> MessageTtl.custom(""));
+
         assertTrue(MessageTtl.seconds(3).toString().contains("3s")); // COVERAGE
     }
 }

--- a/src/test/java/io/nats/client/PublishOptionsTests.java
+++ b/src/test/java/io/nats/client/PublishOptionsTests.java
@@ -115,6 +115,10 @@ public class PublishOptionsTests extends TestBase {
             .build();
         assertEquals("never", po.getMessageTtl());
 
+        assertThrows(IllegalArgumentException.class, () -> MessageTtl.seconds(0));
+        assertThrows(IllegalArgumentException.class, () -> MessageTtl.seconds(-1));
+        assertThrows(IllegalArgumentException.class, () -> MessageTtl.custom(null));
+        assertThrows(IllegalArgumentException.class, () -> MessageTtl.custom(""));
         assertTrue(MessageTtl.seconds(3).toString().contains("3s")); // COVERAGE
     }
 }

--- a/src/test/java/io/nats/client/impl/JetStreamPubTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamPubTests.java
@@ -503,6 +503,20 @@ public class JetStreamPubTests extends JetStreamTestBase {
             MessageInfo mi = jsm.getLastMessage(stream, subject);
             assertEquals("MaxAge", mi.getHeaders().getFirst(NATS_MARKER_REASON_HDR));
             assertEquals("50s", mi.getHeaders().getFirst(MSG_TTL_HDR));
+
+            assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.builder()
+                .name(stream)
+                .storageType(StorageType.Memory)
+                .allowMessageTtl()
+                .subjectDeleteMarkerTtl(Duration.ofMillis(999))
+                .subjects(subject).build());
+
+            assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.builder()
+                .name(stream)
+                .storageType(StorageType.Memory)
+                .allowMessageTtl()
+                .subjectDeleteMarkerTtl(999)
+                .subjects(subject).build());
         });
     }
 }

--- a/src/test/java/io/nats/client/impl/KeyValueTests.java
+++ b/src/test/java/io/nats/client/impl/KeyValueTests.java
@@ -1802,7 +1802,7 @@ public class KeyValueTests extends JetStreamTestBase {
             KeyValueEntry kve = kv.get(key);
             assertNotNull(kve);
 
-            Thread.sleep(1200);
+            Thread.sleep(2000); // a good amount of time to make sure a CI server works
 
             kve = kv.get(key);
             assertNull(kve);

--- a/src/test/java/io/nats/client/support/ValidatorTests.java
+++ b/src/test/java/io/nats/client/support/ValidatorTests.java
@@ -240,14 +240,14 @@ public class ValidatorTests {
     }
 
     @Test
-    public void testValidateDurationNotRequiredGtOrEqMinimum() {
+    public void testValidateDurationGtOrEqSeconds() {
         Duration ifNull = Duration.ofMillis(999);
         assertEquals(ifNull, validateDurationNotRequiredGtOrEqSeconds(1, null, ifNull));
         assertEquals(Duration.ofSeconds(1), validateDurationNotRequiredGtOrEqSeconds(1, Duration.ofSeconds(1), ifNull));
         assertThrows(IllegalArgumentException.class, () -> validateDurationNotRequiredGtOrEqSeconds(1, Duration.ofMillis(999), ifNull));
 
-        assertEquals(Duration.ofSeconds(1), validateDurationNotRequiredGtOrEqSeconds(1, 1000));
-        assertThrows(IllegalArgumentException.class, () -> validateDurationNotRequiredGtOrEqSeconds(1, 999));
+        assertEquals(Duration.ofSeconds(1), validateDurationGtOrEqSeconds(1, 1000));
+        assertThrows(IllegalArgumentException.class, () -> validateDurationGtOrEqSeconds(1, 999));
     }
 
     @Test

--- a/src/test/java/io/nats/client/support/ValidatorTests.java
+++ b/src/test/java/io/nats/client/support/ValidatorTests.java
@@ -240,6 +240,17 @@ public class ValidatorTests {
     }
 
     @Test
+    public void testValidateDurationNotRequiredGtOrEqMinimum() {
+        Duration ifNull = Duration.ofMillis(999);
+        assertEquals(ifNull, validateDurationNotRequiredGtOrEqSeconds(1, null, ifNull));
+        assertEquals(Duration.ofSeconds(1), validateDurationNotRequiredGtOrEqSeconds(1, Duration.ofSeconds(1), ifNull));
+        assertThrows(IllegalArgumentException.class, () -> validateDurationNotRequiredGtOrEqSeconds(1, Duration.ofMillis(999), ifNull));
+
+        assertEquals(Duration.ofSeconds(1), validateDurationNotRequiredGtOrEqSeconds(1, 1000));
+        assertThrows(IllegalArgumentException.class, () -> validateDurationNotRequiredGtOrEqSeconds(1, 999));
+    }
+
+    @Test
     public void testIsGtEqZero() {
         assertTrue(Validator.isGtEqZero(0));
         assertTrue(Validator.isGtEqZero(1));


### PR DESCRIPTION
Accept a per message ttl when creating a kv. Implements [ADR-43](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-43.md)

```
public long create(String key, byte[] value, MessageTtl messageTtl) throws IOException, JetStreamApiException
```