### PR TITLE
Ability to supply a name for an ordered consumer.

### DIFF
--- a/src/main/java/io/nats/client/KeyValueManagement.java
+++ b/src/main/java/io/nats/client/KeyValueManagement.java
@@ -28,7 +28,7 @@ public interface KeyValueManagement {
      * @param config the key value configuration
      * @return bucket info
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *         server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      * @throws IllegalArgumentException the server is not JetStream enabled
      */
@@ -39,7 +39,7 @@ public interface KeyValueManagement {
      * @param config the key value configuration
      * @return bucket info
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *         server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      * @throws IllegalArgumentException the server is not JetStream enabled
      */
@@ -49,7 +49,7 @@ public interface KeyValueManagement {
      * Get the list of bucket names.
      * @return list of bucket names
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *          server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      */
     List<String> getBucketNames() throws IOException, JetStreamApiException;
@@ -59,7 +59,7 @@ public interface KeyValueManagement {
      * @deprecated Use {@link #getStatus(String)} instead.
      * @param bucketName the bucket name to use
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *         server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      * @return the bucket status object
      */
@@ -70,7 +70,7 @@ public interface KeyValueManagement {
      * Gets the status for an existing bucket.
      * @param bucketName the bucket name to use
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *         server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      * @return the bucket status object
      */
@@ -80,7 +80,7 @@ public interface KeyValueManagement {
      * Get the statuses for all buckets
      * @return list of statuses
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *         server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      */
     List<KeyValueStatus> getStatuses() throws IOException, JetStreamApiException;
@@ -89,7 +89,7 @@ public interface KeyValueManagement {
      * Deletes an existing bucket. Will throw a JetStreamApiException if the delete fails.
      * @param bucketName the stream name to use.
      * @throws IOException covers various communication issues with the NATS
-     *         server such as timeout or interruption
+     *         server, such as timeout or interruption
      * @throws JetStreamApiException the request had an error related to the data
      */
     void delete(String bucketName) throws IOException, JetStreamApiException;

--- a/src/main/java/io/nats/client/api/OrderedConsumerConfiguration.java
+++ b/src/main/java/io/nats/client/api/OrderedConsumerConfiguration.java
@@ -36,11 +36,12 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     private ZonedDateTime startTime;
     private ReplayPolicy replayPolicy;
     private Boolean headersOnly;
+    private String consumerNamePrefix;
 
     /**
      * OrderedConsumerConfiguration creation works like a builder.
      * The builder supports chaining and will create a default set of options if
-     * no methods are calls, including setting the filter subject to "&gt;"
+     * no methods are calls, including setting the filter subject to &gt;
      */
     public OrderedConsumerConfiguration() {
         startSequence = ConsumerConfiguration.LONG_UNSET;
@@ -67,7 +68,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
 
     /**
      * Returns a JSON representation of this ordered consumer configuration.
-     * @return json ordered consumer configuration json string
+     * @return JSON ordered consumer configuration JSON string
      */
     public String toJson() {
         StringBuilder sb = beginJson();
@@ -89,7 +90,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the filter subject of the OrderedConsumerConfiguration.
      * @param filterSubject the filter subject
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration filterSubject(String filterSubject) {
         return filterSubjects(Collections.singletonList(filterSubject));
@@ -98,7 +99,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the filter subjects of the OrderedConsumerConfiguration.
      * @param filterSubject the filter subject
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration filterSubjects(String... filterSubject) {
         return filterSubjects(Arrays.asList(filterSubject));
@@ -107,14 +108,14 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the filter subject of the OrderedConsumerConfiguration.
      * @param filterSubjects one or more filter subjects
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration filterSubjects(List<String> filterSubjects) {
         this.filterSubjects.clear();
         for (String fs : filterSubjects) {
-            String fsean = emptyAsNull(fs);
-            if (fsean != null) {
-                this.filterSubjects.add(fsean);
+            String fsEan = emptyAsNull(fs);
+            if (fsEan != null) {
+                this.filterSubjects.add(fsEan);
             }
         }
         if (this.filterSubjects.isEmpty()) {
@@ -126,7 +127,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the delivery policy of the OrderedConsumerConfiguration.
      * @param deliverPolicy the delivery policy.
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration deliverPolicy(DeliverPolicy deliverPolicy) {
         this.deliverPolicy = deliverPolicy;
@@ -136,7 +137,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the start sequence of the OrderedConsumerConfiguration.
      * @param startSequence the start sequence
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration startSequence(long startSequence) {
         this.startSequence = startSequence < 1 ? ConsumerConfiguration.LONG_UNSET : startSequence;
@@ -146,7 +147,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the start time of the OrderedConsumerConfiguration.
      * @param startTime the start time
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration startTime(ZonedDateTime startTime) {
         this.startTime = startTime;
@@ -156,7 +157,7 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
     /**
      * Sets the replay policy of the OrderedConsumerConfiguration.
      * @param replayPolicy the replay policy.
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration replayPolicy(ReplayPolicy replayPolicy) {
         this.replayPolicy = replayPolicy;
@@ -167,10 +168,20 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
      * set the headers only flag saying to deliver only the headers of
      * messages in the stream and not the bodies
      * @param headersOnly the flag
-     * @return Builder
+     * @return The Builder
      */
     public OrderedConsumerConfiguration headersOnly(Boolean headersOnly) {
         this.headersOnly = headersOnly != null && headersOnly ? true : null;
+        return this;
+    }
+
+    /**
+     * Sets the consumer name prefix for consumers created by this configuration.
+     * @param consumerNamePrefix the prefix or null to clear.
+     * @return The Builder
+     */
+    public OrderedConsumerConfiguration consumerNamePrefix(String consumerNamePrefix) {
+        this.consumerNamePrefix = emptyAsNull(consumerNamePrefix);
         return this;
     }
 
@@ -204,5 +215,9 @@ public class OrderedConsumerConfiguration implements JsonSerializable {
 
     public Boolean getHeadersOnly() {
         return headersOnly;
+    }
+
+    public String getConsumerNamePrefix() {
+        return consumerNamePrefix;
     }
 }

--- a/src/main/java/io/nats/client/api/Watcher.java
+++ b/src/main/java/io/nats/client/api/Watcher.java
@@ -19,8 +19,7 @@ package io.nats.client.api;
 public interface Watcher<T> {
 
     /**
-     * Called when an object has been updated
-     *
+     * Called when an object has been updated.
      * @param t The watched object
      */
     void watch(T t);
@@ -30,4 +29,13 @@ public interface Watcher<T> {
      * or if there is data, the first time the watch exhausts all existing data.
      */
     void endOfData();
+
+    /**
+     * The watcher can supply a consumer name to be used when creating the internal watch consumer,
+     * improving the ability to monitor the consumer.
+     * @return the name, or null if not needed, which is the default interface implementation.
+     */
+    default String consumerName() {
+        return null;
+    }
 }

--- a/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
@@ -29,10 +29,11 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
     private long startNanos;
 
     NatsFetchConsumer(SimplifiedSubscriptionMaker subscriptionMaker,
+                      String consumerName,
                       ConsumerInfo cachedConsumerInfo,
                       FetchConsumeOptions fetchConsumeOptions) throws IOException, JetStreamApiException
     {
-        super(cachedConsumerInfo);
+        super(consumerName, cachedConsumerInfo);
 
         boolean isNoWait = fetchConsumeOptions.isNoWait();
         long expiresInMillis = fetchConsumeOptions.getExpiresInMillis();

--- a/src/main/java/io/nats/client/impl/NatsIterableConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsIterableConsumer.java
@@ -21,8 +21,8 @@ import java.time.Duration;
 
 class NatsIterableConsumer extends NatsMessageConsumer implements IterableConsumer {
 
-    NatsIterableConsumer(SimplifiedSubscriptionMaker subscriptionMaker, ConsumerInfo cachedConsumerInfo, ConsumeOptions opts) throws IOException, JetStreamApiException {
-        super(subscriptionMaker, cachedConsumerInfo, opts, null, null);
+    NatsIterableConsumer(SimplifiedSubscriptionMaker subscriptionMaker, String consumerName, ConsumerInfo cachedConsumerInfo, ConsumeOptions opts) throws IOException, JetStreamApiException {
+        super(subscriptionMaker, consumerName, cachedConsumerInfo, opts, null, null);
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/NatsKeyValueWatchSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValueWatchSubscription.java
@@ -70,6 +70,6 @@ public class NatsKeyValueWatchSubscription extends NatsWatchSubscription<KeyValu
             readSubjects.add(kv.readSubject(keyPattern.trim()));
         }
 
-        finishInit(kv, readSubjects, deliverPolicy, headersOnly, fromRevision, handler);
+        finishInit(kv, readSubjects, deliverPolicy, headersOnly, fromRevision, handler, watcher.consumerName());
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsMessageConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsMessageConsumer.java
@@ -27,12 +27,13 @@ class NatsMessageConsumer extends NatsMessageConsumerBase implements PullManager
     protected final MessageHandler userMessageHandler;
 
     NatsMessageConsumer(SimplifiedSubscriptionMaker subscriptionMaker,
+                        String consumerName,
                         ConsumerInfo cachedConsumerInfo,
                         ConsumeOptions consumeOpts,
                         Dispatcher userDispatcher,
                         final MessageHandler userMessageHandler) throws IOException, JetStreamApiException
     {
-        super(cachedConsumerInfo);
+        super(consumerName, cachedConsumerInfo);
 
         this.subscriptionMaker = subscriptionMaker;
         this.consumeOpts = consumeOpts;

--- a/src/main/java/io/nats/client/impl/NatsMessageConsumerBase.java
+++ b/src/main/java/io/nats/client/impl/NatsMessageConsumerBase.java
@@ -26,8 +26,10 @@ class NatsMessageConsumerBase implements MessageConsumer {
     protected final AtomicBoolean stopped;
     protected final AtomicBoolean finished;
     protected ConsumerInfo cachedConsumerInfo;
+    protected String consumerName;
 
-    NatsMessageConsumerBase(ConsumerInfo cachedConsumerInfo) {
+    NatsMessageConsumerBase(String consumerName, ConsumerInfo cachedConsumerInfo) {
+        this.consumerName = consumerName;
         this.cachedConsumerInfo = cachedConsumerInfo;
         this.stopped = new AtomicBoolean(false);
         this.finished = new AtomicBoolean(false);
@@ -57,7 +59,7 @@ class NatsMessageConsumerBase implements MessageConsumer {
      */
     @Override
     public String getConsumerName() {
-        return sub.getConsumerName();
+        return consumerName;
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/NatsObjectStoreWatchSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsObjectStoreWatchSubscription.java
@@ -59,6 +59,6 @@ public class NatsObjectStoreWatchSubscription extends NatsWatchSubscription<Obje
                 }
             };
 
-        finishInit(os, Collections.singletonList(os.rawAllMetaSubject()), deliverPolicy, headersOnly, ULONG_UNSET, handler);
+        finishInit(os, Collections.singletonList(os.rawAllMetaSubject()), deliverPolicy, headersOnly, ULONG_UNSET, handler, watcher.consumerName());
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsWatchSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsWatchSubscription.java
@@ -33,7 +33,13 @@ public class NatsWatchSubscription<T> implements AutoCloseable {
         this.js = js;
     }
 
-    protected void finishInit(NatsFeatureBase fb, List<String> subscribeSubjects, DeliverPolicy deliverPolicy, boolean headersOnly, long fromRevision, WatchMessageHandler<T> handler)
+    protected void finishInit(NatsFeatureBase fb,
+                              List<String> subscribeSubjects,
+                              DeliverPolicy deliverPolicy,
+                              boolean headersOnly,
+                              long fromRevision,
+                              WatchMessageHandler<T> handler,
+                              String consumerName)
         throws IOException, JetStreamApiException
     {
         if (fromRevision > ULONG_UNSET) {
@@ -50,6 +56,7 @@ public class NatsWatchSubscription<T> implements AutoCloseable {
             .stream(fb.getStreamName())
             .ordered(true)
             .configuration(ConsumerConfiguration.builder()
+                .name(consumerName)
                 .ackPolicy(AckPolicy.None)
                 .deliverPolicy(deliverPolicy)
                 .startSequence(fromRevision)
@@ -85,6 +92,7 @@ public class NatsWatchSubscription<T> implements AutoCloseable {
     public void unsubscribe() {
         if (dispatcher != null) {
             dispatcher.unsubscribe(sub);
+            //noinspection SizeReplaceableByIsEmpty
             if (dispatcher.getSubscriptionHandlers().size() == 0) {
                 dispatcher.connection.closeDispatcher(dispatcher);
                 dispatcher = null;

--- a/src/main/java/io/nats/client/impl/OrderedMessageManager.java
+++ b/src/main/java/io/nats/client/impl/OrderedMessageManager.java
@@ -84,6 +84,9 @@ class OrderedMessageManager extends PushMessageManager {
             // 1. delete the consumer by name so we can recreate it with a different delivery policy
             //    b/c we cannot edit a push consumer's delivery policy
             JetStreamManagement jsm = conn.jetStreamManagement(js.jso);
+
+            // We ask for the "actual" consumer name because it will
+            // be a generated name if the user had not supplied one
             String actualConsumerName = sub.getConsumerName();
             try {
                 jsm.deleteConsumer(stream, actualConsumerName);
@@ -96,8 +99,7 @@ class OrderedMessageManager extends PushMessageManager {
             sub.reSubscribe(newDeliverSubject);
             targetSid.set(sub.getSID());
 
-            // 3. make a new consumer using the same "deliver" subject
-            //    but with a new starting point
+            // 3. make a new consumer using the same "deliver" subject but with a new starting point
             ConsumerConfiguration userCC = js.consumerConfigurationForOrdered(originalCc, lastStreamSeq, newDeliverSubject, actualConsumerName, null);
             ConsumerInfo ci = js._createConsumer(stream, userCC, ConsumerCreateRequest.Action.Create); // this can fail when a server is down.
             sub.setConsumerName(ci.getName());

--- a/src/test/java/io/nats/client/impl/KeyValueTests.java
+++ b/src/test/java/io/nats/client/impl/KeyValueTests.java
@@ -896,6 +896,11 @@ public class KeyValueTests extends JetStreamTestBase {
         }
 
         @Override
+        public String consumerName() {
+            return name;
+        }
+
+        @Override
         public String toString() {
             return "TestKeyValueWatcher{" +
                 "name='" + name + '\'' +
@@ -1071,6 +1076,9 @@ public class KeyValueTests extends JetStreamTestBase {
         if (!watcher.beforeWatcher) {
             sub = supplier.get(kv);
         }
+
+        // this will throw an exception if the consumer does not exist, so no need to assert anything.
+        nc.jetStreamManagement().getConsumerInfo("KV_" + bucket, watcher.consumerName());
 
         sleep(1500); // give time for the watches to get messages
 

--- a/src/test/java/io/nats/client/impl/SimplificationTests.java
+++ b/src/test/java/io/nats/client/impl/SimplificationTests.java
@@ -757,7 +757,9 @@ public class SimplificationTests extends JetStreamTestBase {
 
             // New pomm factory in place before each subscription is made
             ((NatsJetStream)js)._pullOrderedMessageManagerFactory = PullOrderedNextTestDropSimulator::new;
-            _testOrderedNext(sctx, 1, new OrderedConsumerConfiguration().filterSubject(tsc.subject()));
+            _testOrderedNext(sctx, 1, new OrderedConsumerConfiguration()
+                .consumerNamePrefix("pfx-")
+                .filterSubject(tsc.subject()));
 
             ((NatsJetStream)js)._pullOrderedMessageManagerFactory = PullOrderedNextTestDropSimulator::new;
             _testOrderedNext(sctx, 2, new OrderedConsumerConfiguration().filterSubject(tsc.subject())
@@ -783,6 +785,13 @@ public class SimplificationTests extends JetStreamTestBase {
         // Loop through the messages to make sure I get stream sequence 1 to 6
         while (expectedStreamSeq <= 6) {
             Message m = occtx.next(1000);
+            String cn = occtx.getConsumerName();
+            if (cn == null) {
+                assertNull(occ.getConsumerNamePrefix());
+            }
+            else {
+                assertTrue(cn.startsWith(occ.getConsumerNamePrefix()));
+            }
             if (m != null) {
                 assertEquals(expectedStreamSeq, m.metaData().streamSequence());
                 assertEquals(1, m.metaData().consumerSequence());


### PR DESCRIPTION
* Original Ordered Push Consumers can supply a name.
* Key Value and Object Store watchers can supply a name
* Simplified ordered consumers can supply a prefix in OrderedConsumerConfiguration