### PR TITLE
Changed header value validation to accept any ascii except CR & LF

### DIFF
--- a/src/main/java/io/nats/client/impl/Headers.java
+++ b/src/main/java/io/nats/client/impl/Headers.java
@@ -533,11 +533,10 @@ public class Headers {
 	 * @throws IllegalArgumentException if the value contains an invalid character
 	 */
 	private void checkValue(String val) {
-		// Generally more permissive than HTTP.  Allow only printable
-		// characters and include tab (0x9) to cover what's allowed
-		// in quoted strings and comments.
+		// Like rfc822 section 3.1.2 (quoted in ADR 4)
+		// The field-body may be composed of any ASCII characters, except CR or LF.
 		val.chars().forEach(c -> {
-			if ((c < 32 && c != 9) || c > 126) {
+			if (c < 0 || c > 255 || c == 10 || c == 13) {
 				throw new IllegalArgumentException(VALUE_INVALID_CHARACTERS + c);
 			}
 		});

--- a/src/test/java/io/nats/client/impl/HeadersTests.java
+++ b/src/test/java/io/nats/client/impl/HeadersTests.java
@@ -333,20 +333,18 @@ public class HeadersTests {
         // ctrl characters, except for tab not allowed
         for (char c = 0; c < 9; c++) {
             final String val = "val" + c;
-            assertThrows(IllegalArgumentException.class, () -> headers.put(KEY1, val));
+            assertDoesNotThrow(() -> headers.put(KEY1, val));
         }
-        for (char c = 10; c < 32; c++) {
+        assertThrows(IllegalArgumentException.class, () -> headers.put(KEY1, "val" + (char)10));
+        for (char c = 11; c < 13; c++) {
             final String val = "val" + c;
-            assertThrows(IllegalArgumentException.class, () -> headers.put(KEY1, val));
+            assertDoesNotThrow(() -> headers.put(KEY1, val));
         }
-        assertThrows(IllegalArgumentException.class, () -> headers.put(KEY1, "val" + (char)127));
-
-        // printable and tab are allowed
-        for (char c = 32; c < 127; c++) {
-            headers.put(KEY1, "" + c);
+        assertThrows(IllegalArgumentException.class, () -> headers.put(KEY1, "val" + (char)13));
+        for (char c = 14; c < 255; c++) {
+            final String val = "val" + c;
+            assertDoesNotThrow(() -> headers.put(KEY1, val));
         }
-
-        headers.put(KEY1, "val" + (char)9);
     }
 
     @Test


### PR DESCRIPTION
This is a PR for https://github.com/nats-io/nats.java/issues/1315

Header validation does not accept Form Feed chars (ascii 12) but they're used by the server in some headers, thus breaking the client. This happens on messages fetched from a stream that is sourcing another stream.

The validation now accepts any ascii char except for LR and LF as described in ADR 4.