### PR TITLE
Reuse public createDispatcher

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1301,12 +1301,7 @@ class NatsConnection implements Connection {
             inboxDispatcherLock.lock();
             try {
                 if (inboxDispatcher.get() == null) {
-                    NatsDispatcher d = dispatcherFactory.createDispatcher(this, this::deliverReply);
-
-                    // Ensure the dispatcher is started before publishing messages
-                    String id = this.nuid.next();
-                    this.dispatchers.put(id, d);
-                    d.start(id);
+                    NatsDispatcher d = (NatsDispatcher) createDispatcher(this::deliverReply);
                     d.subscribe(this.mainInbox);
                     inboxDispatcher.set(d);
                 }


### PR DESCRIPTION
Allows custom wrapper to overload requestInternal MessageHandler.

---

Hello,

So this is a naive proposal, but I'd like to know if we could find something around this. I've been working on [OTel for NATS](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/13999) recently and I noticed a behavior on the java agent that I can not reproduce on the library.

If I instrument MessageHandler on the agent to create both `receive` and `process` spans on `onMessage`, I see that for a `request`, I have the following sequence/spans:
1. producer publish (subject:sub, replyTo: _INBOX.x)
2. consumer receive (subject: sub)
3. consumer process (subject: sub)
4. consumer publish (subject: _INBOX.x)
5. producer receive (subject: _INBOX.x)
6. producer process (subject: _INBOX.x)

Which is a very good thing to troubleshoot server latencies between 4-5.

On the other hand, not using the agent, I can not overload the dispatcher created since it's not exposed anywhere. This little change reflects what could be done to have a better observability (I don't like the cast, though).

Thanks