### PR TITLE
Set the test timeout default to 3 minutes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ test {
         }
     }
     maxParallelForks = Runtime.runtime.availableProcessors()
+    systemProperty 'junit.jupiter.execution.timeout.default', '3m'
 }
 
 javadoc {


### PR DESCRIPTION
Prevent long-running test failures to help figure test not finishing.