### PR TITLE
Fix heartbeat timer handling broken when replacing timer with scheduler.

### DIFF
--- a/src/examples/java/io/nats/examples/jetstream/simple/OrderedMessageConsumerExample.java
+++ b/src/examples/java/io/nats/examples/jetstream/simple/OrderedMessageConsumerExample.java
@@ -1,4 +1,4 @@
-// Copyright 2023 The NATS Authors
+// Copyright 2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:

--- a/src/examples/java/io/nats/examples/jetstream/simple/OrderedMessageConsumerExample.java
+++ b/src/examples/java/io/nats/examples/jetstream/simple/OrderedMessageConsumerExample.java
@@ -1,0 +1,155 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.examples.jetstream.simple;
+
+import io.nats.client.*;
+import io.nats.client.api.OrderedConsumerConfiguration;
+import io.nats.client.api.StorageType;
+import io.nats.client.impl.ErrorListenerConsoleImpl;
+import io.nats.examples.jetstream.ResilientPublisher;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.nats.examples.jetstream.NatsJsUtils.createOrReplaceStream;
+
+/**
+ * This example will demonstrate simplified ordered consumer with a handler
+ * To run, start a server and then start the example.
+ * To test resiliency, kill the server, wait a couple seconds, then restart it.
+ */
+public class OrderedMessageConsumerExample {
+    private static final String STREAM = "ordered-stream";
+    private static final String SUBJECT = "ordered-subject";
+    private static final String CONSUMER_PREFIX = "prefix";
+    private static final String MESSAGE_PREFIX = "ordered";
+    private static final int STOP_COUNT = 1_000_000;
+    private static final int REPORT_EVERY = 500;
+
+    private static final String SERVER = "nats://localhost:4222";
+
+    public static void main(String[] args) {
+        Options options = Options.builder()
+            .server(SERVER)
+            .errorListener(new ErrorListenerConsoleImpl())
+            .build();
+        try (Connection nc = Nats.connect(options)) {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            createOrReplaceStream(jsm, STREAM, StorageType.File, SUBJECT); // file is important, memory won't survive a restart
+
+            System.out.println("Starting publish...");
+            ResilientPublisher publisher = new ResilientPublisher(nc, jsm, STREAM, SUBJECT).basicDataPrefix(MESSAGE_PREFIX).jitter(10);
+            Thread pubThread = new Thread(publisher);
+            pubThread.start();
+
+            // get stream context, create consumer and get the consumer context
+            StreamContext streamContext;
+            OrderedConsumerContext orderedConsumerContext;
+            try {
+                OrderedConsumerConfiguration ocConfig = new OrderedConsumerConfiguration()
+                    .consumerNamePrefix(CONSUMER_PREFIX)
+                    .filterSubjects(SUBJECT);
+                streamContext = nc.getStreamContext(STREAM);
+                orderedConsumerContext = streamContext.createOrderedConsumer(ocConfig);
+            }
+            catch (JetStreamApiException | IOException e) {
+                // JetStreamApiException:
+                //      the stream or consumer did not exist
+                // IOException:
+                //      likely a connection problem
+                return;
+            }
+
+            CountDownLatch latch = new CountDownLatch(1);
+            AtomicInteger atomicCount = new AtomicInteger();
+            AtomicLong nextExpectedSequence = new AtomicLong(0);
+            long start = System.nanoTime();
+            MessageHandler handler = msg -> {
+                if (msg.metaData().streamSequence() != nextExpectedSequence.incrementAndGet()) {
+                    System.out.println("MESSAGE RECEIVED OUT OF ORDER!");
+                    System.exit(-1);
+                }
+                msg.ack();
+                int count = atomicCount.incrementAndGet();
+                if (count % REPORT_EVERY == 0) {
+                    report("Handler", start, count);
+                }
+                if (count == STOP_COUNT) {
+                    latch.countDown();
+                }
+            };
+
+            // create the consumer then use it
+            // the expires option affects 2 things
+            // 1. A pull request expiry
+            // 2. The heartbeat checking
+            // The default expiry is 30 seconds which means the idle heartbeat is 15 seconds.
+            // It takes 3 times the heartbeat to trip the alarm, so the subscription does
+            // not restart for 45 seconds since the disconnect.
+            // If your messages come in slowly this is fine, but if your messages are coming in fast
+            // set the expiresIn much lower. Minimum expires is 1 second (1000ms)
+            ConsumeOptions consumeOptions = ConsumeOptions.builder()
+                .expiresIn(ConsumeOptions.MIN_EXPIRES_MILLS)
+                .build();
+            try (MessageConsumer consumer = orderedConsumerContext.consume(consumeOptions, handler)) {
+                latch.await();
+
+                // The consumer has at least 1 pull request active. When stop is called,
+                // no more pull requests will be made, but messages already requested
+                // will still come across the wire to the client.
+                System.out.println("Stop the consumer...");
+                consumer.stop();
+
+                // wait until the consumer is finished
+                while (!consumer.isFinished()) {
+                    //noinspection BusyWait
+                    Thread.sleep(10);
+                }
+            }
+            catch (JetStreamApiException | IOException e) {
+                // JetStreamApiException:
+                //      1. the stream or consumer did not exist
+                //      2. api calls under the covers theoretically this could fail, but practically it won't.
+                // IOException:
+                //      likely a connection problem
+                System.err.println("Exception should be handled properly, just exiting here.");
+                System.exit(-1);
+            }
+            catch (Exception e) {
+                // this is from the FetchConsumer being AutoCloseable, but should never be called
+                // as work inside the close is already guarded by try/catch
+                System.err.println("Exception should be handled properly, just exiting here.");
+                System.exit(-1);
+            }
+
+            report("Final", start, atomicCount.get());
+
+            publisher.stop(); // otherwise it will complain when the connection goes away
+            pubThread.join();
+        }
+        catch (IOException | InterruptedException ioe) {
+            // IOException:
+            //      problem making the connection
+            // InterruptedException:
+            //      thread interruption in the body of the example
+        }
+    }
+
+    private static void report(String label, long start, int count) {
+        long ms = (System.nanoTime() - start) / 1_000_000;
+        System.out.println(label + ": Received " + count + " messages in " + ms + "ms.");
+    }
+}

--- a/src/main/java/io/nats/client/impl/MessageManager.java
+++ b/src/main/java/io/nats/client/impl/MessageManager.java
@@ -47,7 +47,7 @@ abstract class MessageManager {
     protected final AtomicBoolean hb;
     protected final AtomicLong idleHeartbeatSettingMillis;
     protected final AtomicLong alarmPeriodSettingNanos;
-    protected final AtomicReference<ScheduledTask> heartbeatTask;
+    protected final AtomicReference<ScheduledTask> heartbeatTaskRef;
 
     protected MessageManager(NatsConnection conn, SubscribeOptions so, boolean syncMode) {
         stateChangeLock = new ReentrantLock();
@@ -62,7 +62,7 @@ abstract class MessageManager {
         idleHeartbeatSettingMillis = new AtomicLong();
         alarmPeriodSettingNanos = new AtomicLong();
         lastMsgReceivedNanoTime = new AtomicLong(NatsSystemClock.nanoTime());
-        heartbeatTask = new AtomicReference<>();
+        heartbeatTaskRef = new AtomicReference<>();
     }
 
     protected boolean isSyncMode()              { return syncMode; }
@@ -139,33 +139,26 @@ abstract class MessageManager {
     protected void initOrResetHeartbeatTimer() {
         stateChangeLock.lock();
         try {
-            ScheduledTask hbTask = heartbeatTask.get();
+            ScheduledTask hbTask = heartbeatTaskRef.get();
             if (hbTask != null) {
-                // Same settings, just reuse the existing scheduled task
-                if (hbTask.getPeriodNanos() == alarmPeriodSettingNanos.get()) {
-                    updateLastMessageReceived();
-                    return;
-                }
-
-                // Replace timer since settings have changed
+                // we always want a fresh schedule because it will have the initial delay
                 hbTask.shutdown();
             }
 
-            // so the alarm doesn't trigger too soon
+            // set the ref with a new ScheduledTask
+            // reminder that ScheduledTask schedules itself, which is why we pass the executor
+            heartbeatTaskRef.set(
+                new ScheduledTask(conn.getScheduledExecutor(), alarmPeriodSettingNanos.get(), TimeUnit.NANOSECONDS,
+                    () -> {
+                        long sinceLast = NatsSystemClock.nanoTime() - lastMsgReceivedNanoTime.get();
+                        if (sinceLast > alarmPeriodSettingNanos.get()) {
+                            handleHeartbeatError();
+                        }
+                    })
+            );
+
+            // since we just scheduled, reset this otherwise it may alarm too soon
             updateLastMessageReceived();
-
-            // replacement or new comes here
-            heartbeatTask.set(new ScheduledTask(
-                conn.getScheduledExecutor(),
-                alarmPeriodSettingNanos.get(), TimeUnit.NANOSECONDS,
-                () -> {
-                    long sinceLast = NatsSystemClock.nanoTime() - lastMsgReceivedNanoTime.get();
-                    if (sinceLast > alarmPeriodSettingNanos.get()) {
-                        updateLastMessageReceived(); // allow the system time to re-sub before alarming
-                        handleHeartbeatError();
-                    }
-                }));
-
         }
         finally {
             stateChangeLock.unlock();
@@ -175,10 +168,10 @@ abstract class MessageManager {
     protected void shutdownHeartbeatTimer() {
         stateChangeLock.lock();
         try {
-            ScheduledTask hbTask = heartbeatTask.get();
+            ScheduledTask hbTask = heartbeatTaskRef.get();
             if (hbTask != null) {
                 hbTask.shutdown();
-                heartbeatTask.set(null);
+                heartbeatTaskRef.set(null);
             }
         }
         finally {

--- a/src/main/java/io/nats/client/impl/NatsConsumerContext.java
+++ b/src/main/java/io/nats/client/impl/NatsConsumerContext.java
@@ -129,7 +129,7 @@ public class NatsConsumerContext implements ConsumerContext, SimplifiedSubscript
                 }
             }
             if (lastCon.finished.get() && !lastCon.stopped.get()) {
-                lastCon.lenientClose(); // finished, might as well make sure the sub is closed.
+                lastCon.shutdownSub(); // finished, might as well make sure the sub is closed.
             }
         }
     }

--- a/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
@@ -67,7 +67,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
 
     @Override
     public void heartbeatError() {
-        finishAndClose();
+        finishAndShutdownSub();
     }
 
     @Override
@@ -85,7 +85,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
                 if (m == null) {
                     // if there are no messages in the internal cache AND there are no more pending,
                     // they all have been read and we can go ahead and finish
-                    finishAndClose();
+                    finishAndShutdownSub();
                 }
                 return m;
             }
@@ -103,7 +103,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
                 Message m = sub._nextUnmanagedNoWait(pullSubject);
                 if (m == null) {
                     // no message and no time left, go ahead and finish
-                    finishAndClose();
+                    finishAndShutdownSub();
                 }
                 return m;
             }
@@ -111,7 +111,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
             Message m = sub._nextUnmanaged(timeLeftNanos, pullSubject);
             if (m == null && isNoWaitNoExpires) {
                 // no message and no wait, go ahead and finish
-                finishAndClose();
+                finishAndShutdownSub();
             }
             return m;
         }

--- a/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsFetchConsumer.java
@@ -67,7 +67,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
 
     @Override
     public void heartbeatError() {
-        finishAndShutdownSub();
+        fullClose();
     }
 
     @Override
@@ -85,7 +85,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
                 if (m == null) {
                     // if there are no messages in the internal cache AND there are no more pending,
                     // they all have been read and we can go ahead and finish
-                    finishAndShutdownSub();
+                    fullClose();
                 }
                 return m;
             }
@@ -103,7 +103,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
                 Message m = sub._nextUnmanagedNoWait(pullSubject);
                 if (m == null) {
                     // no message and no time left, go ahead and finish
-                    finishAndShutdownSub();
+                    fullClose();
                 }
                 return m;
             }
@@ -111,7 +111,7 @@ class NatsFetchConsumer extends NatsMessageConsumerBase implements FetchConsumer
             Message m = sub._nextUnmanaged(timeLeftNanos, pullSubject);
             if (m == null && isNoWaitNoExpires) {
                 // no message and no wait, go ahead and finish
-                finishAndShutdownSub();
+                fullClose();
             }
             return m;
         }

--- a/src/main/java/io/nats/client/impl/NatsMessageConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsMessageConsumer.java
@@ -53,7 +53,7 @@ class NatsMessageConsumer extends NatsMessageConsumerBase implements PullManager
     public void heartbeatError() {
         try {
             if (stopped.get()) {
-                finishAndShutdownSub();
+                fullClose();
             }
             else {
                 shutdownSub();
@@ -92,10 +92,10 @@ class NatsMessageConsumer extends NatsMessageConsumerBase implements PullManager
     public void pendingUpdated() {
         if (stopped.get()) {
             if (pmm.noMorePending()) {
-                finishAndShutdownSub();
+                fullClose();
             }
         }
-        else if ((pmm.pendingMessages <= thresholdMessages || (pmm.trackingBytes && pmm.pendingBytes <= thresholdBytes)))
+        else if (pmm.pendingMessages <= thresholdMessages || (pmm.trackingBytes && pmm.pendingBytes <= thresholdBytes))
         {
             repull();
         }

--- a/src/main/java/io/nats/client/impl/NatsMessageConsumer.java
+++ b/src/main/java/io/nats/client/impl/NatsMessageConsumer.java
@@ -52,15 +52,8 @@ class NatsMessageConsumer extends NatsMessageConsumerBase implements PullManager
     @Override
     public void heartbeatError() {
         try {
-            // just close the current sub and make another one.
-            // this could go on endlessly - unless the user had called stop
-            if (stopped.get()) {
-                finishAndClose();
-            }
-            else {
-                lenientClose();
-                doSub();
-            }
+            lenientClose();
+            doSub();
         }
         catch (JetStreamApiException | IOException e) {
             pmm.resetTracking();

--- a/src/main/java/io/nats/client/impl/NatsMessageConsumerBase.java
+++ b/src/main/java/io/nats/client/impl/NatsMessageConsumerBase.java
@@ -105,7 +105,7 @@ class NatsMessageConsumerBase implements MessageConsumer {
         shutdownSub();
     }
 
-    protected void finishAndShutdownSub() {
+    protected void fullClose() {
         stopped.set(true);
         finished.set(true);
         shutdownSub();

--- a/src/main/java/io/nats/client/impl/PullOrderedMessageManager.java
+++ b/src/main/java/io/nats/client/impl/PullOrderedMessageManager.java
@@ -44,6 +44,7 @@ class PullOrderedMessageManager extends PullMessageManager {
 
     @Override
     protected void startup(NatsJetStreamSubscription sub) {
+        expectedExternalConsumerSeq = 1; // consumer always starts with consumer sequence 1
         super.startup(sub);
         targetSid.set(sub.getSID());
     }

--- a/src/main/java/io/nats/client/support/ScheduledTask.java
+++ b/src/main/java/io/nats/client/support/ScheduledTask.java
@@ -121,8 +121,8 @@ public class ScheduledTask implements Runnable {
         else {
             sb.append(" [shutdown");
         }
-        sb.append(isDone() ? "/done" : "/not done");
-        sb.append(executing.get() ? "/executing" : "/not executing");
+        sb.append(isDone() ? "/done" : "/!done");
+        sb.append(executing.get() ? "/executing" : "/!executing");
         sb.append("]");
         return sb.toString();
     }

--- a/src/main/java/io/nats/client/support/ScheduledTask.java
+++ b/src/main/java/io/nats/client/support/ScheduledTask.java
@@ -36,6 +36,8 @@ public class ScheduledTask implements Runnable {
 
     protected final AtomicBoolean notShutdown;
     protected final AtomicBoolean executing;
+    protected final long initialDelayNanos;
+    protected final long periodNanos;
 
     public ScheduledTask(ScheduledExecutorService ses, long initialAndPeriodMillis, Runnable runnable) {
         this(null, ses, initialAndPeriodMillis, initialAndPeriodMillis, TimeUnit.MILLISECONDS, runnable);
@@ -53,17 +55,27 @@ public class ScheduledTask implements Runnable {
         this(id, ses, initialAndPeriod, initialAndPeriod, unit, runnable);
     }
 
-    public ScheduledTask(ScheduledExecutorService ses, long initialDelay, long initialAndPeriod, TimeUnit unit, Runnable runnable) {
-        this(null, ses, initialDelay, initialAndPeriod, unit, runnable);
+    public ScheduledTask(ScheduledExecutorService ses, long initialDelay, long period, TimeUnit unit, Runnable runnable) {
+        this(null, ses, initialDelay, period, unit, runnable);
     }
 
-    public ScheduledTask(String id, ScheduledExecutorService ses, long initialDelay, long initialAndPeriod, TimeUnit unit, Runnable runnable) {
+    public ScheduledTask(String id, ScheduledExecutorService ses, long initialDelay, long period, TimeUnit unit, Runnable runnable) {
         this.id = id == null || id.isEmpty() ? "st-" + ID_GENERATOR.getAndIncrement() : id;
         this.runnable = runnable;
         notShutdown = new AtomicBoolean(true);
         executing = new AtomicBoolean(false);
+        this.initialDelayNanos = unit.toNanos(initialDelay);
+        this.periodNanos = unit.toNanos(period);
         scheduledFutureRef = new AtomicReference<>(
-            ses.scheduleAtFixedRate(this, initialDelay, initialAndPeriod, unit));
+            ses.scheduleAtFixedRate(this, initialDelay, period, unit));
+    }
+
+    public long getInitialDelayNanos() {
+        return initialDelayNanos;
+    }
+
+    public long getPeriodNanos() {
+        return periodNanos;
     }
 
     @Override

--- a/src/test/java/io/nats/client/support/ScheduledTaskTests.java
+++ b/src/test/java/io/nats/client/support/ScheduledTaskTests.java
@@ -20,17 +20,17 @@ public class ScheduledTaskTests {
         AtomicInteger counter400 = new AtomicInteger();
         SttRunnable sttr400 = new SttRunnable(100, counter400);
         ScheduledTask task400 = new ScheduledTask(stpe, 0, 400, TimeUnit.MILLISECONDS, sttr400);
-        assertEquals(TimeUnit.MILLISECONDS.toNanos(400), task400.getPeriodNanos());
+        validateTaskPeriods(task400, 0, 400);
 
         AtomicInteger counter200 = new AtomicInteger();
         SttRunnable sttr200 = new SttRunnable(300, counter200);
         ScheduledTask task200 = new ScheduledTask(stpe, 0, 200, TimeUnit.MILLISECONDS, sttr200);
-        assertEquals(TimeUnit.MILLISECONDS.toNanos(200), task200.getPeriodNanos());
+        validateTaskPeriods(task200, 0, 200);
 
         AtomicInteger counter100 = new AtomicInteger();
         SttRunnable sttr100 = new SttRunnable(400, counter100);
         ScheduledTask task100 = new ScheduledTask(stpe, 0, 100, TimeUnit.MILLISECONDS, sttr100);
-        assertEquals(TimeUnit.MILLISECONDS.toNanos(100), task100.getPeriodNanos());
+        validateTaskPeriods(task100, 0, 100);
 
         validateState(task400, false, false, null);
         validateState(task200, false, false, null);
@@ -54,6 +54,12 @@ public class ScheduledTaskTests {
         assertTrue(counter400.get() >= 3);
         assertTrue(counter200.get() >= 3);
         assertTrue(counter100.get() >= 3);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void validateTaskPeriods(ScheduledTask task, long expectedDelay, long expectedPeriod) {
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(expectedDelay), task.getInitialDelayNanos());
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(expectedPeriod), task.getPeriodNanos());
     }
 
     static void validateState(ScheduledTask task, boolean shutdown, boolean done, Boolean executing) {

--- a/src/test/java/io/nats/client/support/ScheduledTaskTests.java
+++ b/src/test/java/io/nats/client/support/ScheduledTaskTests.java
@@ -20,14 +20,17 @@ public class ScheduledTaskTests {
         AtomicInteger counter400 = new AtomicInteger();
         SttRunnable sttr400 = new SttRunnable(100, counter400);
         ScheduledTask task400 = new ScheduledTask(stpe, 0, 400, TimeUnit.MILLISECONDS, sttr400);
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(400), task400.getPeriodNanos());
 
         AtomicInteger counter200 = new AtomicInteger();
         SttRunnable sttr200 = new SttRunnable(300, counter200);
         ScheduledTask task200 = new ScheduledTask(stpe, 0, 200, TimeUnit.MILLISECONDS, sttr200);
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(200), task200.getPeriodNanos());
 
         AtomicInteger counter100 = new AtomicInteger();
         SttRunnable sttr100 = new SttRunnable(400, counter100);
         ScheduledTask task100 = new ScheduledTask(stpe, 0, 100, TimeUnit.MILLISECONDS, sttr100);
+        assertEquals(TimeUnit.MILLISECONDS.toNanos(100), task100.getPeriodNanos());
 
         validateState(task400, false, false, null);
         validateState(task200, false, false, null);


### PR DESCRIPTION
Much better. 
* It was not the scheduler change that was the error, it was a change in workflow
* Added a unit test to simulate the error found. 
* Added a simplified Ordered Consumer example
* fixed an issue that was pre-existing which may have caused simplified ordered consumers to not reset correctly after disconnnect.