### PR TITLE
Fix core unsubscribe by subject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ plugins {
 def jarVersion = "2.21.5"
 
 def buildEvent = System.getenv("BUILD_EVENT")
-def isLocal = buildEvent == null
 def isRelease = buildEvent == "release"
 def brn = System.getenv("BRANCH_REF_NAME")
 def snap = brn == null || brn.equals("") ? "-SNAPSHOT" : "." + brn + "-SNAPSHOT"
@@ -84,19 +83,10 @@ test {
         events "started", "passed", "skipped", "failed"
         showStandardStreams = true
     }
-    if (isLocal) {
-        retry {
-            failOnPassedAfterRetry = false
-            maxFailures = 2
-            maxRetries = 2
-        }
-    }
-    else {
-        retry {
-            failOnPassedAfterRetry = false
-            maxFailures = 5
-            maxRetries = 5
-        }
+    retry {
+        failOnPassedAfterRetry = false
+        maxFailures = 2
+        maxRetries = 2
     }
     maxParallelForks = Runtime.runtime.availableProcessors()
     systemProperty 'junit.jupiter.execution.timeout.default', '3m'

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -36,17 +36,18 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
 
     protected String id;
 
-    // We will use the subject as the key for subscriptions that use the
-    // default handler.
-    protected final Map<String, NatsSubscription> subscriptionsUsingDefaultHandler;
+    // This tracks subscriptions made with the default handlers
+    // There can only be one default handler subscription for any given subject
+    protected final Map<String, NatsSubscription> subWithDefaultHandlerBySubject;
 
-    // We will use the SID as the key. Since  these subscriptions provide
-    // their own handlers, we allow duplicates. There is a subtle but very
-    // important difference here.
-    protected final Map<String, NatsSubscription> subscriptionsWithHandlers;
+    // This tracks subscriptions made with non-default handlers
+    protected final Map<String, NatsSubscription> subWithNonDefaultHandlerBySid;
 
-    // We use the SID as the key here.
-    protected final Map<String, MessageHandler> subscriptionHandlers;
+    // There can be multiple non default handlers for any given subject, this track them
+    protected final Map<String, Map<String, NatsSubscription>> subsBySidNonDefaultHandlersBySubject;
+
+    // This tracks the non-default handler by sid
+    protected final Map<String, MessageHandler> nonDefaultHandlerBySid;
 
     protected final Duration waitForMessage;
 
@@ -54,9 +55,10 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         super(conn);
         this.defaultHandler = handler;
         this.incoming = new MessageQueue(true, conn.getOptions().getRequestCleanupInterval());
-        this.subscriptionsUsingDefaultHandler = new ConcurrentHashMap<>();
-        this.subscriptionsWithHandlers = new ConcurrentHashMap<>();
-        this.subscriptionHandlers = new ConcurrentHashMap<>();
+        this.subWithDefaultHandlerBySubject = new ConcurrentHashMap<>();
+        this.subWithNonDefaultHandlerBySid = new ConcurrentHashMap<>();
+        this.subsBySidNonDefaultHandlersBySubject = new ConcurrentHashMap<>();
+        this.nonDefaultHandlerBySid = new ConcurrentHashMap<>();
         this.running = new AtomicBoolean(false);
         this.started = new AtomicBoolean(false);
         this.waitForMessage = Duration.ofMinutes(5); // This can be long since we aren't doing anything
@@ -67,6 +69,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         internalStart(id, true);
     }
 
+    @SuppressWarnings("SameParameterValue")
     protected void internalStart(String id, boolean threaded) {
         if (!started.get()) {
             this.id = id;
@@ -89,7 +92,7 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
                 if (msg != null) {
                     NatsSubscription sub = msg.getNatsSubscription();
                     if (sub != null && sub.isActive()) {
-                        MessageHandler handler = subscriptionHandlers.get(sub.getSID());
+                        MessageHandler handler = nonDefaultHandlerBySid.get(sub.getSID());
                         if (handler == null) {
                             handler = defaultHandler;
                         }
@@ -147,17 +150,14 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         }
 
         if (unsubscribeAll) {
-            this.subscriptionsUsingDefaultHandler.forEach((subj, sub) -> {
-                this.connection.unsubscribe(sub, -1);
-            });
-            this.subscriptionsWithHandlers.forEach((sid, sub) -> {
-                this.connection.unsubscribe(sub, -1);
-            });
+            subWithDefaultHandlerBySubject.forEach((subject, sub) -> connection.unsubscribe(sub, -1));
+            subWithNonDefaultHandlerBySid.forEach((sid, sub) -> connection.unsubscribe(sub, -1));
         }
 
-        this.subscriptionsUsingDefaultHandler.clear();
-        this.subscriptionsWithHandlers.clear();
-        this.subscriptionHandlers.clear();
+        subWithDefaultHandlerBySubject.clear();
+        subWithNonDefaultHandlerBySid.clear();
+        subsBySidNonDefaultHandlersBySubject.clear();
+        nonDefaultHandlerBySid.clear();
     }
 
     public boolean isActive() {
@@ -172,32 +172,46 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         return incoming;
     }
 
-    Map<String, MessageHandler> getSubscriptionHandlers() {
-        return subscriptionHandlers;
+    MessageHandler getNonDefaultHandlerBySid(String sid) {
+        return nonDefaultHandlerBySid.get(sid);
+    }
+
+    boolean hasNoSubs() {
+        return subWithDefaultHandlerBySubject.isEmpty() && subWithNonDefaultHandlerBySid.isEmpty();
     }
 
     void resendSubscriptions() {
-        this.subscriptionsUsingDefaultHandler.forEach((id, sub)->{
-            this.connection.sendSubscriptionMessage(sub.getSID(), sub.getSubject(), sub.getQueueName(), true);
-        });
-        this.subscriptionsWithHandlers.forEach((sid, sub)->{
-            this.connection.sendSubscriptionMessage(sub.getSID(), sub.getSubject(), sub.getQueueName(), true);
-        });
+        this.subWithDefaultHandlerBySubject.forEach((subject, sub) ->
+            connection.sendSubscriptionMessage(sub.getSID(), subject, sub.getQueueName(), true));
+        this.subWithNonDefaultHandlerBySid.forEach((sid, sub) ->
+            connection.sendSubscriptionMessage(sid, sub.getSubject(), sub.getQueueName(), true));
     }
 
-    // Called by the connection when a subscription is removed.
-    // We will first attempt to remove from subscriptionsWithHandlers
-    // using the sub's SID, and if we don't find it there, we'll check
-    // the subscriptionsUsingDefaultHandler Map and verify the SID
-    // matches before removing. By verifying the SID in all cases we can
-    // be certain we're removing the correct Subscription.
+    // Remove this sub from all of our tracking maps.
+    // Instead of logic to figure where the sub is in the first place,
+    //   we try all tracking maps, with guard rails.
+    // It's possible multiple threads/workflow could be hitting this,
+    //   but all the maps are ConcurrentHashMap, we're safe.
+    // For the case when we do find the sub's subject mapped to the default handler,
+    //   we double-check that what is mapped is the same sub, again mostly a code guard.
     void remove(NatsSubscription sub) {
-        if (this.subscriptionsWithHandlers.remove(sub.getSID()) != null) {
-            this.subscriptionHandlers.remove(sub.getSID());
-        } else {
-            NatsSubscription s = this.subscriptionsUsingDefaultHandler.get(sub.getSubject());
-            if (s.getSID().equals(sub.getSID())) {
-                this.subscriptionsUsingDefaultHandler.remove(sub.getSubject());
+        // remove from all maps
+        // lots of code guards here instead of checking where the sub might be
+        String sid = sub.getSID();
+        NatsSubscription defaultSub = subWithDefaultHandlerBySubject.get(sub.getSubject());
+        if (defaultSub != null && defaultSub.getSID().equals(sid)) {
+            subWithDefaultHandlerBySubject.remove(sub.getSubject());
+        }
+        subWithNonDefaultHandlerBySid.remove(sid);
+        nonDefaultHandlerBySid.remove(sid);
+        Map<String, NatsSubscription> subsBySid = subsBySidNonDefaultHandlersBySubject.get(sub.getSubject());
+        if (subsBySid != null) {
+            // it could be null, I know it's weird
+            subsBySid.remove(sid);
+            if (subsBySid.isEmpty()) {
+                // if there are no more for the subject, we can remove the entry
+                // from the map to avoid empty entries/memory leak
+                subsBySidNonDefaultHandlersBySubject.remove(sub.getSubject());
             }
         }
     }
@@ -242,11 +256,11 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         // If the handler is null, then we use the default handler, which will not allow
         // duplicate subscriptions to exist.
         if (handler == null) {
-            NatsSubscription sub = this.subscriptionsUsingDefaultHandler.get(subject);
+            NatsSubscription sub = this.subWithDefaultHandlerBySubject.get(subject);
 
             if (sub == null) {
                 sub = connection.createSubscription(subject, queueName, this, null);
-                NatsSubscription wonTheRace = this.subscriptionsUsingDefaultHandler.putIfAbsent(subject, sub);
+                NatsSubscription wonTheRace = this.subWithDefaultHandlerBySubject.putIfAbsent(subject, sub);
                 if (wonTheRace != null) {
                     this.connection.unsubscribe(sub, -1); // Could happen on very bad timing
                 }
@@ -265,16 +279,22 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
 
     private NatsSubscription _subscribeImplHandlerProvided(String subject, String queueName, MessageHandler handler, NatsSubscriptionFactory nsf) {
         NatsSubscription sub = connection.createSubscription(subject, queueName, this, nsf);
-        this.subscriptionsWithHandlers.put(sub.getSID(), sub);
-        this.subscriptionHandlers.put(sub.getSID(), handler);
+        trackSubWithUserHandler(sub.getSID(), sub, handler);
         return sub;
     }
 
     String reSubscribe(NatsSubscription sub, String subject, String queueName, MessageHandler handler) {
         String sid = connection.reSubscribe(sub, subject, queueName);
-        this.subscriptionsWithHandlers.put(sid, sub);
-        this.subscriptionHandlers.put(sid, handler);
+        trackSubWithUserHandler(sid, sub, handler);
         return sid;
+    }
+
+    private void trackSubWithUserHandler(String sid, NatsSubscription sub, MessageHandler handler) {
+        subWithNonDefaultHandlerBySid.put(sid, sub);
+        Map<String, NatsSubscription> subsBySid =
+            subsBySidNonDefaultHandlersBySubject.computeIfAbsent(sub.getSubject(), k -> new ConcurrentHashMap<>());
+        subsBySid.put(sid, sub);
+        nonDefaultHandlerBySid.put(sid, handler);
     }
 
     private void checkBeforeSubImpl() {
@@ -308,11 +328,14 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
             throw new IllegalArgumentException("Subject is required in unsubscribe");
         }
 
-        NatsSubscription sub = this.subscriptionsUsingDefaultHandler.get(subject);
-
-        if (sub != null) {
-            this.connection.unsubscribe(sub, after); // Connection will tell us when to remove from the map
+        // Connection unsubscribe ends up calling invalidate on the sub which calls dispatcher.remove
+        // meaning all we do is call this unsubscribe method and the workflow takes care of the rest
+        NatsSubscription defaultHandlerSub = subWithDefaultHandlerBySubject.get(subject);
+        if (defaultHandlerSub != null) {
+            connection.unsubscribe(defaultHandlerSub, after);
         }
+
+        subWithNonDefaultHandlerBySid.forEach((sid, sub) -> connection.unsubscribe(sub, after));
 
         return this;
     }
@@ -337,22 +360,18 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
         
         NatsSubscription ns = ((NatsSubscription) subscription);
         // Grab the NatsSubscription to verify we weren't given a different manager's subscription.
-        NatsSubscription sub = this.subscriptionsWithHandlers.get(ns.getSID());
+        NatsSubscription sub = subWithNonDefaultHandlerBySid.get(ns.getSID());
 
         if (sub != null) {
-            this.connection.unsubscribe(sub, after); // Connection will tell us when to remove from the map
+            connection.unsubscribe(sub, after); // Connection will tell us when to remove from the map
         }
 
         return this;
     }
 
     void sendUnsubForDrain() {
-        this.subscriptionsUsingDefaultHandler.forEach((id, sub)->{
-            this.connection.sendUnsub(sub, -1);
-        });
-        this.subscriptionsWithHandlers.forEach((sid, sub)->{
-            this.connection.sendUnsub(sub, -1);
-        });
+        subWithDefaultHandlerBySubject.forEach((id, sub) -> connection.sendUnsub(sub, -1));
+        subWithNonDefaultHandlerBySid.forEach((sid, sub) -> connection.sendUnsub(sub, -1));
     }
 
     void cleanUpAfterDrain() {

--- a/src/main/java/io/nats/client/impl/NatsDispatcher.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcher.java
@@ -217,6 +217,9 @@ class NatsDispatcher extends NatsConsumer implements Dispatcher, Runnable {
     }
 
     public Dispatcher subscribe(String subject) {
+        if (defaultHandler == null) {
+            throw new IllegalStateException("Dispatcher was made without a default handler.");
+        }
         validateSubject(subject, true);
         this.subscribeImplCore(subject, null, null);
         return this;

--- a/src/main/java/io/nats/client/impl/NatsDispatcherWithExecutor.java
+++ b/src/main/java/io/nats/client/impl/NatsDispatcherWithExecutor.java
@@ -29,7 +29,7 @@ class NatsDispatcherWithExecutor extends NatsDispatcher {
                 if (msg != null) {
                     NatsSubscription sub = msg.getNatsSubscription();
                     if (sub != null && sub.isActive()) {
-                        MessageHandler handler = subscriptionHandlers.get(sub.getSID());
+                        MessageHandler handler = nonDefaultHandlerBySid.get(sub.getSID());
                         if (handler == null) {
                             handler = defaultHandler;
                         }

--- a/src/main/java/io/nats/client/impl/NatsSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsSubscription.java
@@ -57,7 +57,7 @@ class NatsSubscription extends NatsConsumer implements Subscription {
             sid = connection.reSubscribe(this, newDeliverSubject, queueName);
         }
         else {
-            MessageHandler handler = dispatcher.getSubscriptionHandlers().get(sid);
+            MessageHandler handler = dispatcher.getNonDefaultHandlerBySid(sid);
             dispatcher.remove(this);
             sid = dispatcher.reSubscribe(this, newDeliverSubject, queueName, handler);
         }

--- a/src/main/java/io/nats/client/impl/NatsWatchSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsWatchSubscription.java
@@ -93,7 +93,7 @@ public class NatsWatchSubscription<T> implements AutoCloseable {
         if (dispatcher != null) {
             dispatcher.unsubscribe(sub);
             //noinspection SizeReplaceableByIsEmpty
-            if (dispatcher.getSubscriptionHandlers().size() == 0) {
+            if (dispatcher.hasNoSubs()) {
                 dispatcher.connection.closeDispatcher(dispatcher);
                 dispatcher = null;
             }

--- a/src/test/java/io/nats/client/SubscriberTests.java
+++ b/src/test/java/io/nats/client/SubscriberTests.java
@@ -477,7 +477,7 @@ public class SubscriberTests {
         try (NatsTestServer ts = new NatsTestServer(false);
             Connection nc = Nats.connect(ts.getURI())) {
             standardConnectionWait(nc);
-            Dispatcher d = nc.createDispatcher();
+            Dispatcher d = nc.createDispatcher(m -> {});
             for (String bad : BAD_SUBJECTS_OR_QUEUES) {
                 assertThrows(IllegalArgumentException.class, () -> nc.subscribe(bad));
                 assertThrows(IllegalArgumentException.class, () -> d.subscribe(bad));

--- a/src/test/java/io/nats/client/SubscriberTests.java
+++ b/src/test/java/io/nats/client/SubscriberTests.java
@@ -16,7 +16,10 @@ package io.nats.client;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -486,5 +489,41 @@ public class SubscriberTests {
                 assertThrows(IllegalArgumentException.class, () -> d.subscribe("s", bad, m -> {}));
             }
         }
+    }
+
+    @Test
+    public void testDispatcherMultipleBySubject() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer(false);
+             Connection nc = Nats.connect(ts.getURI())) {
+            standardConnectionWait(nc);
+            String subject = subject();
+
+            List<Integer> dflt = Collections.synchronizedList(new ArrayList<>());
+            List<Integer> nd1 = Collections.synchronizedList(new ArrayList<>());
+            List<Integer> nd2 = Collections.synchronizedList(new ArrayList<>());
+            Dispatcher d = nc.createDispatcher(m -> dflt.add(getDataId(m)));
+            d.subscribe(subject);
+            d.subscribe(subject, m -> nd1.add(getDataId(m)));
+            d.subscribe(subject, m -> nd2.add(getDataId(m)));
+
+            nc.publish(subject, "1".getBytes());
+            Thread.sleep(1000);
+            d.unsubscribe(subject);
+            nc.publish(subject, "2".getBytes());
+            Thread.sleep(1000);
+
+            assertTrue(dflt.contains(1));
+            assertTrue(nd1.contains(1));
+            assertTrue(nd2.contains(1));
+
+            assertFalse(dflt.contains(2));
+            assertFalse(nd1.contains(2));
+            assertFalse(nd2.contains(2));
+
+        }
+    }
+
+    private static int getDataId(Message m) {
+        return Integer.parseInt(new String(m.getData()));
     }
 }

--- a/src/test/java/io/nats/client/SubscriberTests.java
+++ b/src/test/java/io/nats/client/SubscriberTests.java
@@ -492,7 +492,7 @@ public class SubscriberTests {
     }
 
     @Test
-    public void testDispatcherMultipleBySubject() throws Exception {
+    public void testDispatcherMultipleSubscriptionsBySubject() throws Exception {
         try (NatsTestServer ts = new NatsTestServer(false);
              Connection nc = Nats.connect(ts.getURI())) {
             standardConnectionWait(nc);
@@ -525,5 +525,17 @@ public class SubscriberTests {
 
     private static int getDataId(Message m) {
         return Integer.parseInt(new String(m.getData()));
+    }
+
+    @Test
+    public void testDispatcherDefaultSubscribeWhenNoDefaultHandler() throws Exception {
+        try (NatsTestServer ts = new NatsTestServer(false);
+             Connection nc = Nats.connect(ts.getURI())) {
+            standardConnectionWait(nc);
+            String subject = subject();
+
+            Dispatcher d = nc.createDispatcher();
+            assertThrows(IllegalStateException.class, () -> d.subscribe(subject));
+        }
     }
 }

--- a/src/test/java/io/nats/client/impl/AuthViolationDuringReconnectTest.java
+++ b/src/test/java/io/nats/client/impl/AuthViolationDuringReconnectTest.java
@@ -60,7 +60,7 @@ public class AuthViolationDuringReconnectTest {
 
             ctx.nc = new MockPausingNatsConnection(options);
             ctx.nc.connect(true);
-            ctx.d = ctx.nc.createDispatcher();
+            ctx.d = ctx.nc.createDispatcher(m -> {});
 
             ctx.latch = new CountDownLatch(1);
             for (int i = 0; i < 1_000; i++) {


### PR DESCRIPTION
Fixes #1232

### Context
The dispatcher api allows subscribe 
1. with a subject and no message handler, `subscribe("foo");`, in which case it will use the message handler provided when the dispatcher was created.
2. with a subject plus and a message handler, `subscribe("foo", nonDefaultHandler);`.


### Problem
If you `unsubscribe("foo")`, the dispatcher currently only unsubscribes the subscription with the default handler, meaning if you had subscribed with a non default handler, that subscriptions did not get unsubscribed. (That was the behavior reported in #1232)

### Desired Behavior
The dispatcher should unsubscribe for all handlers, default or otherwise, for a subject.

### Considerations
You can only have one subscription for a subject with the default handler (otherwise you just get multiple copies of the same message to that handler) but you can have as many subscriptions for a subject if you provide a non default handler.

So if you do this: 
```
subscribe("foo"); 
subscribe("foo"); 
subscribe("foo", handler1); 
subscribe("foo", handler2);
```
you end up with 3 subscriptions.

### Solution
 
Unsubscribe all subscriptions for the subject regardless of the handler.