### PR TITLE
Fix timeout computing to address possible nano time overflow

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -2247,14 +2247,13 @@ class NatsConnection implements Connection {
 
         consumers.forEach(NatsConsumer::markUnsubedForDrain);
 
-        // Wait for the timeout or the pending count to go to 0
+        // Wait for the timeout or the all consumers are drained
         executor.submit(() -> {
             try {
-                long stop = (timeout == null || timeout.equals(Duration.ZERO))
-                    ? Long.MAX_VALUE
-                    : NatsSystemClock.nanoTime() + timeout.toNanos();
-                while (NatsSystemClock.nanoTime() < stop && !Thread.interrupted())
-                {
+                long timeoutNanos = (timeout == null || timeout.toNanos() <= 0)
+                    ? Long.MAX_VALUE : timeout.toNanos();
+                long startTime = System.nanoTime();
+                while (NatsSystemClock.nanoTime() - startTime < timeoutNanos && !Thread.interrupted()) {
                     consumers.removeIf(NatsConsumer::isDrained);
                     if (consumers.isEmpty()) {
                         break;

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -2247,7 +2247,7 @@ class NatsConnection implements Connection {
 
         consumers.forEach(NatsConsumer::markUnsubedForDrain);
 
-        // Wait for the timeout or the all consumers are drained
+        // Wait for the timeout or all consumers are drained
         executor.submit(() -> {
             try {
                 long timeoutNanos = (timeout == null || timeout.toNanos() <= 0)


### PR DESCRIPTION
To avoid overflow issue while comparing elapsed time against a timeout,

given
```
long timeoutNanos = <some timeout value>
long startTime = System.nanoTime;
long stopTime = System.nanoTime + timeoutNanos;
```

use

```
if (System.nanoTime() - startTime >= timeoutNanos)
```
instead of
```
if (System.nanoTime() >= stopTime)
```

and use
```
while (System.nanoTime() - startTime < timeoutNanos)
```
instead of

```
while (System.nanoTime() < stopTime)
```