### PR TITLE
Stream Name cannot be null

### DIFF
--- a/src/main/java/io/nats/client/api/StreamConfiguration.java
+++ b/src/main/java/io/nats/client/api/StreamConfiguration.java
@@ -1129,6 +1129,10 @@ public class StreamConfiguration implements JsonSerializable {
          * @return a stream configuration.
          */
         public StreamConfiguration build() {
+            if (nullOrEmpty(name)) {
+                throw new IllegalArgumentException("Configuration must have a valid stream name");
+            }
+
             return new StreamConfiguration(this);
         }
     }

--- a/src/main/java/io/nats/client/api/StreamInfo.java
+++ b/src/main/java/io/nats/client/api/StreamInfo.java
@@ -47,7 +47,8 @@ public class StreamInfo extends ApiResponse<StreamInfo> {
     public StreamInfo(JsonValue vStreamInfo) {
         super(vStreamInfo);
         createTime = readDate(jv, CREATED);
-        config = StreamConfiguration.instance(readValue(jv, CONFIG));
+        JsonValue jvConfig = readValue(jv, CONFIG); // null when it's an error
+        config = jvConfig == null ? null : StreamConfiguration.instance(jvConfig);
         streamState = new StreamState(readValue(jv, STATE));
         clusterInfo = ClusterInfo.optionalInstance(readValue(jv, CLUSTER));
         mirrorInfo = MirrorInfo.optionalInstance(readValue(jv, MIRROR));

--- a/src/main/java/io/nats/client/impl/NatsJetStreamManagement.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamManagement.java
@@ -14,15 +14,16 @@
 package io.nats.client.impl;
 
 import io.nats.client.*;
-import io.nats.client.api.Error;
 import io.nats.client.api.*;
+import io.nats.client.api.Error;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import static io.nats.client.support.Validator.*;
+import static io.nats.client.support.Validator.validateNotNull;
+import static io.nats.client.support.Validator.validateStreamName;
 
 public class NatsJetStreamManagement extends NatsJetStreamImpl implements JetStreamManagement {
     private NatsJetStream js; // this is lazy init'ed
@@ -59,10 +60,6 @@ public class NatsJetStreamManagement extends NatsJetStreamImpl implements JetStr
     private StreamInfo addOrUpdateStream(StreamConfiguration config, String template) throws IOException, JetStreamApiException {
         validateNotNull(config, "Configuration");
         String streamName = config.getName();
-        if (nullOrEmpty(streamName)) {
-            throw new IllegalArgumentException("Configuration must have a valid stream name");
-        }
-
         String subj = String.format(template, streamName);
         Message resp = makeRequestResponseRequired(subj, config.toJson().getBytes(StandardCharsets.UTF_8), getTimeout());
         return createAndCacheStreamInfoThrowOnError(streamName, resp);

--- a/src/test/java/io/nats/client/api/StreamConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/StreamConfigurationTests.java
@@ -77,7 +77,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
     @Test
     public void testSerializationDeserializationDefaults() throws Exception {
-        StreamConfiguration sc = StreamConfiguration.instance("");
+        StreamConfiguration sc = StreamConfiguration.instance("{\"name\":\"name\"}");
         assertNotNull(sc);
         String serializedJson = sc.toJson();
         assertNotNull(StreamConfiguration.instance(serializedJson));
@@ -91,7 +91,6 @@ public class StreamConfigurationTests extends JetStreamTestBase {
                 add(COMPRESSION);
                 add(STORAGE);
                 add(DISCARD);
-                add(NAME);
                 add(DESCRIPTION);
                 add(MAX_CONSUMERS);
                 add(MAX_MSGS);
@@ -273,11 +272,12 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
         // coverage for null StreamConfiguration, millis maxAge, millis duplicateWindow
         StreamConfiguration scCov = StreamConfiguration.builder(null)
-                .maxAge(1111)
-                .duplicateWindow(2222)
-                .build();
+            .name(name())
+            .maxAge(1111)
+            .duplicateWindow(2222)
+            .build();
 
-        assertNull(scCov.getName());
+        assertNotNull(scCov.getName());
         assertEquals(Duration.ofMillis(1111), scCov.getMaxAge());
         assertEquals(Duration.ofMillis(2222), scCov.getDuplicateWindow());
     }
@@ -381,7 +381,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
     @Test
     public void testSubjects() {
-        StreamConfiguration.Builder builder = StreamConfiguration.builder();
+        StreamConfiguration.Builder builder = StreamConfiguration.builder().name(name());
 
         // subjects(...) replaces
         builder.subjects(subject(0));
@@ -437,7 +437,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
     @Test
     public void testRetentionPolicy() {
-        StreamConfiguration.Builder builder = StreamConfiguration.builder();
+        StreamConfiguration.Builder builder = StreamConfiguration.builder().name(name());
         assertEquals(RetentionPolicy.Limits, builder.build().getRetentionPolicy());
 
         builder.retentionPolicy(RetentionPolicy.Limits);
@@ -455,7 +455,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
     @Test
     public void testCompressionOption() {
-        StreamConfiguration.Builder builder = StreamConfiguration.builder();
+        StreamConfiguration.Builder builder = StreamConfiguration.builder().name(name());
         assertEquals(None, builder.build().getCompressionOption());
 
         builder.compressionOption(None);
@@ -472,7 +472,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
     @Test
     public void testStorageType() {
-        StreamConfiguration.Builder builder = StreamConfiguration.builder();
+        StreamConfiguration.Builder builder = StreamConfiguration.builder().name(name());
         assertEquals(StorageType.File, builder.build().getStorageType());
 
         builder.storageType(StorageType.Memory);
@@ -484,7 +484,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
 
     @Test
     public void testDiscardPolicy() {
-        StreamConfiguration.Builder builder = StreamConfiguration.builder();
+        StreamConfiguration.Builder builder = StreamConfiguration.builder().name(name());
         assertEquals(DiscardPolicy.Old, builder.build().getDiscardPolicy());
 
         builder.discardPolicy(DiscardPolicy.New);

--- a/src/test/java/io/nats/client/api/StreamInfoTests.java
+++ b/src/test/java/io/nats/client/api/StreamInfoTests.java
@@ -164,8 +164,7 @@ public class StreamInfoTests {
         si = new StreamInfo(JsonValue.EMPTY_MAP);
         assertNull(si.getCreateTime());
         assertNotNull(si.getStreamState());
-        assertNotNull(si.getConfiguration());
-        assertNull(si.getConfiguration().getPlacement());
+        assertNull(si.getConfiguration());
         assertNull(si.getClusterInfo());
         assertNull(si.getMirrorInfo());
         assertNull(si.getSourceInfos());

--- a/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
+++ b/src/test/java/io/nats/client/impl/JetStreamManagementTests.java
@@ -250,9 +250,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
         jsServer.run(TestBase::atLeast2_10, nc -> {
             JetStreamManagement jsm = nc.jetStreamManagement();
 
-            StreamConfiguration scNoName = StreamConfiguration.builder().build();
             assertThrows(IllegalArgumentException.class, () -> jsm.addStream(null));
-            assertThrows(IllegalArgumentException.class, () -> jsm.addStream(scNoName));
 
             String stream = stream();
 
@@ -298,9 +296,7 @@ public class JetStreamManagementTests extends JetStreamTestBase {
         jsServer.run(nc -> {
             JetStreamManagement jsm = nc.jetStreamManagement();
 
-            StreamConfiguration scNoName = StreamConfiguration.builder().build();
             assertThrows(IllegalArgumentException.class, () -> jsm.updateStream(null));
-            assertThrows(IllegalArgumentException.class, () -> jsm.updateStream(scNoName));
 
             String stream = stream();
             String[] subjects = new String[]{subject(), subject()};


### PR DESCRIPTION
StreamName was annotated as `@NonNull`
```
@NonNull
public String getName() {
    return name;
}
```

This is actually correct, but under the covers...
* The builder allowed null but this was handled in JetStreamManagement when adding or updating a stream, the name was valdiate. This has been moved to the builder. Same type of exception and same message, so is backward compatible, and should have no practical issues for users, since it's still the same error, just on build(...) instead of addStream or updateStream, which is called with a built StreamConfiguration.
* The StreamInfo creation _always_ read the "config" field from an incoming response to getStreamInfo(). This was a problem because if the request was an error, there is no StreamConfiguration in the response. So this is fixed by checking the field first.