### PR TITLE
Not PR: architectural concept: compact JsonValue

### DIFF
--- a/src/examples/java/io/nats/examples/service/ServiceExample.java
+++ b/src/examples/java/io/nats/examples/service/ServiceExample.java
@@ -16,6 +16,7 @@ package io.nats.examples.service;
 import io.nats.client.*;
 import io.nats.client.support.JsonSerializable;
 import io.nats.client.support.JsonValue;
+import io.nats.client.support.JsonValueObject;
 import io.nats.client.support.JsonValueUtils;
 import io.nats.service.*;
 import org.jspecify.annotations.NonNull;
@@ -245,7 +246,7 @@ public class ServiceExample {
             Map<String, JsonValue> map = new HashMap<>();
             map.put("sdata", new JsonValue(sData));
             map.put("idata", new JsonValue(iData));
-            return new JsonValue(map);
+            return new JsonValueObject(map);
         }
 
         @Override

--- a/src/main/java/io/nats/client/api/AccountStatistics.java
+++ b/src/main/java/io/nats/client/api/AccountStatistics.java
@@ -42,9 +42,9 @@ public class AccountStatistics extends ApiResponse<AccountStatistics> {
         api = new ApiStats(readObject(jv, API));
         JsonValue vTiers = readObject(jv, TIERS);
         tiers = new HashMap<>();
-        if (vTiers.map != null) {
-            for (String key : vTiers.map.keySet()) {
-                tiers.put(key, new AccountTier(vTiers.map.get(key)));
+        if (vTiers.map() != null) {
+            for (String key : vTiers.map().keySet()) {
+                tiers.put(key, new AccountTier(vTiers.map().get(key)));
             }
         }
     }

--- a/src/main/java/io/nats/client/api/ApiResponse.java
+++ b/src/main/java/io/nats/client/api/ApiResponse.java
@@ -94,7 +94,7 @@ public abstract class ApiResponse<T> {
             }
             else {
                 type = temp;
-                jv.map.remove(TYPE); // just so it's not in the toString, it's very long and the object name will be there
+                jv.map().remove(TYPE); // just so it's not in the toString, it's very long and the object name will be there
             }
         }
     }

--- a/src/main/java/io/nats/client/api/ObjectMeta.java
+++ b/src/main/java/io/nats/client/api/ObjectMeta.java
@@ -47,7 +47,7 @@ public class ObjectMeta implements JsonSerializable {
         description = readString(vObjectMeta, DESCRIPTION);
         headers = new Headers();
         JsonValue hJv = readObject(vObjectMeta, HEADERS);
-        for (String key : hJv.map.keySet()) {
+        for (String key : hJv.map().keySet()) {
             headers.put(key, readStringList(hJv, key));
         }
 

--- a/src/main/java/io/nats/client/api/StreamState.java
+++ b/src/main/java/io/nats/client/api/StreamState.java
@@ -57,9 +57,9 @@ public class StreamState {
         subjects = new ArrayList<>();
         subjectMap = new HashMap<>();
         JsonValue vSubjects = readValue(vStreamState, SUBJECTS);
-        if (vSubjects != null && vSubjects.map != null) {
-            for (String subject : vSubjects.map.keySet()) {
-                Long count = getLong(vSubjects.map.get(subject));
+        if (vSubjects != null && vSubjects.map() != null) {
+            for (String subject : vSubjects.map().keySet()) {
+                Long count = getLong(vSubjects.map().get(subject));
                 if (count != null) {
                     subjects.add(new Subject(subject, count));
                     subjectMap.put(subject, count);

--- a/src/main/java/io/nats/client/api/Subject.java
+++ b/src/main/java/io/nats/client/api/Subject.java
@@ -27,9 +27,9 @@ public class Subject implements Comparable<Subject> {
 
     static List<Subject> listOf(JsonValue vSubjects) {
         List<Subject> list = new ArrayList<>();
-        if (vSubjects != null && vSubjects.map != null) {
-            for (String subject : vSubjects.map.keySet()) {
-                Long count = getLong(vSubjects.map.get(subject));
+        if (vSubjects != null && vSubjects.map() != null) {
+            for (String subject : vSubjects.map().keySet()) {
+                Long count = getLong(vSubjects.map().get(subject));
                 if (count != null) {
                     list.add(new Subject(subject, count));
                 }

--- a/src/main/java/io/nats/client/impl/StringListReader.java
+++ b/src/main/java/io/nats/client/impl/StringListReader.java
@@ -22,10 +22,6 @@ abstract class StringListReader extends AbstractListReader {
 
     List<String> strings;
 
-    StringListReader(String objectName) {
-        this(objectName, null);
-    }
-
     StringListReader(String objectName, String filterFieldName) {
         super(objectName, filterFieldName);
         strings = new ArrayList<>();
@@ -34,8 +30,8 @@ abstract class StringListReader extends AbstractListReader {
     @Override
     void processItems(List<JsonValue> items) {
         for (JsonValue v : items) {
-            if (v.string != null) {
-                strings.add(v.string);
+            if (v.string() != null) {
+                strings.add(v.string());
             }
         }
     }

--- a/src/main/java/io/nats/client/support/JsonParser.java
+++ b/src/main/java/io/nats/client/support/JsonParser.java
@@ -433,7 +433,7 @@ public class JsonParser {
         }
         if (c == '{') {
             nextToken();
-            return new JsonValue(nextObject());
+            return new JsonValueObject(nextObject());
         }
         if (c == '[') {
             nextToken();

--- a/src/main/java/io/nats/client/support/JsonValue.java
+++ b/src/main/java/io/nats/client/support/JsonValue.java
@@ -1,4 +1,4 @@
-// Copyright 2023 The NATS Authors
+// Copyright 2023-2025 The NATS Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:
@@ -14,17 +14,28 @@
 package io.nats.client.support;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
-import static io.nats.client.support.JsonUtils.*;
+import static io.nats.client.support.JsonUtils.addField;
+import static io.nats.client.support.JsonUtils.beginArray;
+import static io.nats.client.support.JsonUtils.beginJson;
+import static io.nats.client.support.JsonUtils.endArray;
+import static io.nats.client.support.JsonUtils.endJson;
 
 public class JsonValue implements JsonSerializable {
 
     public enum Type {
-        STRING, BOOL, INTEGER, LONG, DOUBLE, FLOAT, BIG_DECIMAL, BIG_INTEGER, MAP, ARRAY, NULL;
+        STRING, BOOL,  INTEGER, LONG, DOUBLE, FLOAT, BIG_DECIMAL, BIG_INTEGER,  MAP, ARRAY, NULL;
     }
 
     private static final char QUOTE = '"';
@@ -34,141 +45,99 @@ public class JsonValue implements JsonSerializable {
     public static final JsonValue NULL = new JsonValue();
     public static final JsonValue TRUE = new JsonValue(true);
     public static final JsonValue FALSE = new JsonValue(false);
-    public static final JsonValue EMPTY_MAP = new JsonValue(Collections.unmodifiableMap(new HashMap<>()));
-    public static final JsonValue EMPTY_ARRAY = new JsonValue(Collections.unmodifiableList(new ArrayList<>()));
+    public static final JsonValue EMPTY_MAP = new JsonValue(Collections.emptyMap());
+    public static final JsonValue EMPTY_ARRAY = new JsonValue(Collections.emptyList());
 
-    public final String string;
-    public final Boolean bool;
-    public final Integer i;
-    public final Long l;
-    public final Double d;
-    public final Float f;
-    public final BigDecimal bd;
-    public final BigInteger bi;
-    public final Map<String, JsonValue> map;
-    public final List<JsonValue> array;
     public final Type type;
-    public final Object object;
-    public final Number number;
-
+    public final Object value;
     public final List<String> mapOrder;
 
     public JsonValue() {
-        this(null, null, null, null, null, null, null, null, null, null);
+        this((Object) null);
     }
 
     public JsonValue(String string) {
-        this(string, null, null, null, null, null, null, null, null, null);
-    }
-
-    public JsonValue(char c) {
-        this("" + c, null, null, null, null, null, null, null, null, null);
+        this((Object) string);
     }
 
     public JsonValue(Boolean bool) {
-        this(null, bool, null, null, null, null, null, null, null, null);
+        this((Object) bool);
     }
 
     public JsonValue(int i) {
-        this(null, null, i, null, null, null, null, null, null, null);
+        this((Object) i);
     }
 
     public JsonValue(long l) {
-        this(null, null, null, l, null, null, null, null, null, null);
+        this((Object) l);
     }
 
     public JsonValue(double d) {
-        this(null, null, null, null, d, null, null, null, null, null);
+        this((Object) d);
     }
 
     public JsonValue(float f) {
-        this(null, null, null, null, null, f, null, null, null, null);
+        this((Object) f);
     }
 
     public JsonValue(BigDecimal bd) {
-        this(null, null, null, null, null, null, bd, null, null, null);
+        this((Object) bd);
     }
 
     public JsonValue(BigInteger bi) {
-        this(null, null, null, null, null, null, null, bi, null, null);
+        this((Object) bi);
     }
 
     public JsonValue(Map<String, JsonValue> map) {
-        this(null, null, null, null, null, null, null, null, map, null);
+        this((Object) map);
     }
 
-    public JsonValue(List<JsonValue> list) {
-        this(null, null, null, null, null, null, null, null, null, list);
+    public JsonValue(@Nullable List<JsonValue> list) {
+        this((Object) list);
     }
 
     public JsonValue(JsonValue[] values) {
-        this(null, null, null, null, null, null, null, null, null, values == null ? null : Arrays.asList(values));
+        this((Object)(values == null ? null : Arrays.asList(values)));
     }
 
-    private JsonValue(String string, Boolean bool, Integer i, Long l, Double d, Float f, BigDecimal bd, BigInteger bi, Map<String, JsonValue> map, List<JsonValue> array) {
-        this.map = map;
+    private JsonValue(@Nullable Object value) {
+        this.value = value;
         mapOrder = new ArrayList<>();
-        this.array = array;
-        this.string = string;
-        this.bool = bool;
-        this.i = i;
-        this.l = l;
-        this.d = d;
-        this.f = f;
-        this.bd = bd;
-        this.bi = bi;
-        if (i != null) {
+        if (value instanceof Integer) {
             this.type = Type.INTEGER;
-            number = i;
-            object = number;
         }
-        else if (l != null) {
+        else if (value instanceof Long) {
             this.type = Type.LONG;
-            number = l;
-            object = number;
         }
-        else if (d != null) {
+        else if (value instanceof Double) {
             this.type = Type.DOUBLE;
-            number = this.d;
-            object = number;
         }
-        else if (f != null) {
+        else if (value instanceof Float) {
             this.type = Type.FLOAT;
-            number = this.f;
-            object = number;
         }
-        else if (bd != null) {
+        else if (value instanceof BigDecimal) {
             this.type = Type.BIG_DECIMAL;
-            number = this.bd;
-            object = number;
         }
-        else if (bi != null) {
+        else if (value instanceof BigInteger) {
             this.type = Type.BIG_INTEGER;
-            number = this.bi;
-            object = number;
+        }
+        else if (value instanceof Map) {
+            this.type = Type.MAP;
+        }
+        else if (value instanceof String) {
+            this.type = Type.STRING;
+        }
+        else if (value instanceof Boolean) {
+            this.type = Type.BOOL;
+        }
+        else if (value instanceof List) {
+            this.type = Type.ARRAY;
+        }
+        else if (value == null){
+            this.type = Type.NULL;
         }
         else {
-            number = null;
-            if (map != null) {
-                this.type = Type.MAP;
-                object = map;
-            }
-            else if (string != null) {
-                this.type = Type.STRING;
-                object = string;
-            }
-            else if (bool != null) {
-                this.type = Type.BOOL;
-                object = bool;
-            }
-            else if (array != null) {
-                this.type = Type.ARRAY;
-                object = array;
-            }
-            else {
-                this.type = Type.NULL;
-                object = null;
-            }
+            throw new IllegalArgumentException("Unsupported type: " + value.getClass().getName() + " for value: " + value);
         }
     }
 
@@ -177,7 +146,7 @@ public class JsonValue implements JsonSerializable {
     }
 
     public String toString(String key) {
-        return QUOTE + key + QUOTE + ":" + toJson();
+        return QUOTE + key + QUOTE +':'+ toJson();
     }
 
     @Override
@@ -191,21 +160,125 @@ public class JsonValue implements JsonSerializable {
         return this;
     }
 
+    public @Nullable String string () {
+        switch (type) {
+            case STRING: case NULL: return (String) value;
+            //todo case INTEGER: case LONG: case DOUBLE: case BIG_DECIMAL: case BIG_INTEGER: return value.toString();
+            default: return null;
+        }
+    }
+
+    public @Nullable Boolean bool () {
+        switch (type) {
+            case BOOL: case NULL: return (Boolean) value;
+            //todo case INTEGER: case LONG: case DOUBLE: case BIG_DECIMAL: case BIG_INTEGER: return ((Number) value).longValue() != 0;
+            default: return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public @Nullable Map<String, JsonValue> map () {
+        switch (type) {
+            case MAP: case NULL: return (Map<String, JsonValue>) value;
+            default: return null;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public @Nullable List<JsonValue> array () {
+        switch (type) {
+            case ARRAY: case NULL: return (List<JsonValue>) value;
+            default: return null;
+        }
+    }
+
+    public @Nullable Integer i () {
+        return getInteger();
+    }
+
+    public @Nullable Long l () {
+        return getLong();
+    }
+
+    public @Nullable Float f () {
+        if (value instanceof Float) {
+            return (Float)value;
+        }
+        return value instanceof Number ? ((Number) value).floatValue() : null;
+    }
+
+    public @Nullable Double d () {
+        if (value instanceof Double) {
+            return (Double) value;
+        }
+        return value instanceof Number ? ((Number) value).doubleValue() : null;
+    }
+
+    public @Nullable BigDecimal bd () {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal)value;
+        }
+        return value instanceof Number ? new BigDecimal(value.toString()) : null;
+    }
+
+    public @Nullable BigInteger bi () {
+        if (value instanceof BigInteger) {
+            return (BigInteger)value;
+        }
+        if (value instanceof BigDecimal) {
+            return ((BigDecimal)value).toBigInteger();
+        }
+        return value instanceof Number ? new BigInteger(Long.toString(((Number) value).longValue())) : null;
+    }
+
+    public @Nullable Integer getInteger() {
+        if (value instanceof Integer) {
+            return (Integer)value;
+        }
+        // just in case the number was stored as a long, which is unlikely, but I want to handle it
+        if (value instanceof Number) {
+            long x = ((Number) value).longValue();
+            if (x <= Integer.MAX_VALUE && x >= Integer.MIN_VALUE) {
+                return (int) x;
+            }
+        }
+        return null;
+    }
+
+    public @Nullable Long getLong() {
+        if (value instanceof Long) {
+            return (Long)value;
+        }
+        return value instanceof Number ? ((Number) value).longValue() : null;
+    }
+
+    public long getLong(long dflt) {
+        if (value instanceof Long) {
+            return (Long)value;
+        }
+        return value instanceof Number ? ((Number) value).longValue() : dflt;
+    }
+
+    @SuppressWarnings("unchecked")
+    public int size () {
+        switch (type) {
+            case MAP:   return ((Map<String, JsonValue>) value).size();
+            case ARRAY: return ((Collection<JsonValue>) value).size();
+            case NULL:  return 0;
+            default:    return 1;
+        }
+    }
+
     @Override
     @NonNull
     public String toJson() {
         switch (type) {
-            case STRING:      return valueString(string);
-            case BOOL:        return valueString(bool);
-            case MAP:         return valueString(map);
-            case ARRAY:       return valueString(array);
-            case INTEGER:     return i.toString();
-            case LONG:        return l.toString();
-            case DOUBLE:      return d.toString();
-            case FLOAT:       return f.toString();
-            case BIG_DECIMAL: return bd.toString();
-            case BIG_INTEGER: return bi.toString();
-            default:          return NULL_STR;
+            case STRING:      return valueString(string());
+            case BOOL:        return valueString(bool());
+            case MAP:         return valueString(map());
+            case ARRAY:       return valueString(array());
+            case NULL:        return NULL_STR;
+            default:          return value.toString();
         }
     }
 
@@ -225,8 +298,8 @@ public class JsonValue implements JsonSerializable {
             }
         }
         else {
-            for (String key : map.keySet()) {
-                addField(sbo, key, map.get(key));
+            for (Map.Entry<String, JsonValue> entry : map.entrySet()) {
+                addField(sbo, entry.getKey(), entry.getValue());
             }
         }
         return endJson(sbo).toString();
@@ -243,37 +316,18 @@ public class JsonValue implements JsonSerializable {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof JsonValue)) return false;
 
         JsonValue jsonValue = (JsonValue) o;
 
         if (type != jsonValue.type) return false;
-        if (!Objects.equals(map, jsonValue.map)) return false;
-        if (!Objects.equals(array, jsonValue.array)) return false;
-        if (!Objects.equals(string, jsonValue.string)) return false;
-        if (!Objects.equals(bool, jsonValue.bool)) return false;
-        if (!Objects.equals(i, jsonValue.i)) return false;
-        if (!Objects.equals(l, jsonValue.l)) return false;
-        if (!Objects.equals(d, jsonValue.d)) return false;
-        if (!Objects.equals(f, jsonValue.f)) return false;
-        if (!Objects.equals(bd, jsonValue.bd)) return false;
-        return Objects.equals(bi, jsonValue.bi);
+        return Objects.equals(value, jsonValue.value);
     }
 
     @Override
     public int hashCode() {
-        int result = map != null ? map.hashCode() : 0;
-        result = 31 * result + (array != null ? array.hashCode() : 0);
-        result = 31 * result + (string != null ? string.hashCode() : 0);
-        result = 31 * result + (bool != null ? bool.hashCode() : 0);
-        result = 31 * result + (i != null ? i.hashCode() : 0);
-        result = 31 * result + (l != null ? l.hashCode() : 0);
-        result = 31 * result + (d != null ? d.hashCode() : 0);
-        result = 31 * result + (f != null ? f.hashCode() : 0);
-        result = 31 * result + (bd != null ? bd.hashCode() : 0);
-        result = 31 * result + (bi != null ? bi.hashCode() : 0);
-        result = 31 * result + (type != null ? type.hashCode() : 0);
+        int result = Objects.hashCode(value);
+        result = 31 * result + Objects.hashCode(type);
         return result;
     }
 }

--- a/src/main/java/io/nats/client/support/JsonValue.java
+++ b/src/main/java/io/nats/client/support/JsonValue.java
@@ -102,39 +102,49 @@ public class JsonValue implements JsonSerializable {
 
     private JsonValue(@Nullable Object value) {
         this.value = value;
-        mapOrder = new ArrayList<>();
         if (value instanceof Integer) {
             this.type = Type.INTEGER;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Long) {
             this.type = Type.LONG;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Double) {
             this.type = Type.DOUBLE;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Float) {
             this.type = Type.FLOAT;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof BigDecimal) {
             this.type = Type.BIG_DECIMAL;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof BigInteger) {
             this.type = Type.BIG_INTEGER;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Map) {
             this.type = Type.MAP;
+            mapOrder = new ArrayList<>();
         }
         else if (value instanceof String) {
             this.type = Type.STRING;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Boolean) {
             this.type = Type.BOOL;
+            mapOrder = Collections.emptyList();
         }
         else if (value instanceof List) {
             this.type = Type.ARRAY;
+            mapOrder = Collections.emptyList();
         }
         else if (value == null){
             this.type = Type.NULL;
+            mapOrder = Collections.emptyList();
         }
         else {
             throw new IllegalArgumentException("Unsupported type: " + value.getClass().getName() + " for value: " + value);

--- a/src/main/java/io/nats/client/support/JsonValue.java
+++ b/src/main/java/io/nats/client/support/JsonValue.java
@@ -50,7 +50,6 @@ public class JsonValue implements JsonSerializable {
 
     public final Type type;
     public final Object value;
-    public final List<String> mapOrder;
 
     public JsonValue() {
         this((Object) null);
@@ -88,7 +87,7 @@ public class JsonValue implements JsonSerializable {
         this((Object) bi);
     }
 
-    public JsonValue(Map<String, JsonValue> map) {
+    JsonValue(Map<String, JsonValue> map) {
         this((Object) map);
     }
 
@@ -104,47 +103,36 @@ public class JsonValue implements JsonSerializable {
         this.value = value;
         if (value instanceof Integer) {
             this.type = Type.INTEGER;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Long) {
             this.type = Type.LONG;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Double) {
             this.type = Type.DOUBLE;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Float) {
             this.type = Type.FLOAT;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof BigDecimal) {
             this.type = Type.BIG_DECIMAL;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof BigInteger) {
             this.type = Type.BIG_INTEGER;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Map) {
             this.type = Type.MAP;
-            mapOrder = new ArrayList<>();
         }
         else if (value instanceof String) {
             this.type = Type.STRING;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof Boolean) {
             this.type = Type.BOOL;
-            mapOrder = Collections.emptyList();
         }
         else if (value instanceof List) {
             this.type = Type.ARRAY;
-            mapOrder = Collections.emptyList();
         }
         else if (value == null){
             this.type = Type.NULL;
-            mapOrder = Collections.emptyList();
         }
         else {
             throw new IllegalArgumentException("Unsupported type: " + value.getClass().getName() + " for value: " + value);
@@ -285,37 +273,21 @@ public class JsonValue implements JsonSerializable {
         switch (type) {
             case STRING:      return valueString(string());
             case BOOL:        return valueString(bool());
-            case MAP:         return valueString(map());
             case ARRAY:       return valueString(array());
             case NULL:        return NULL_STR;
             default:          return value.toString();
         }
     }
 
-    private String valueString(String s) {
+    private static String valueString(String s) {
         return QUOTE + Encoding.jsonEncode(s) + QUOTE;
     }
 
-    private String valueString(boolean b) {
+    private static String valueString(boolean b) {
         return Boolean.toString(b).toLowerCase();
     }
 
-    private String valueString(Map<String, JsonValue> map) {
-        StringBuilder sbo = beginJson();
-        if (!mapOrder.isEmpty()) {
-            for (String key : mapOrder) {
-                addField(sbo, key, map.get(key));
-            }
-        }
-        else {
-            for (Map.Entry<String, JsonValue> entry : map.entrySet()) {
-                addField(sbo, entry.getKey(), entry.getValue());
-            }
-        }
-        return endJson(sbo).toString();
-    }
-
-    private String valueString(List<JsonValue> list) {
+    private static String valueString(List<JsonValue> list) {
         StringBuilder sba = beginArray();
         for (JsonValue v : list) {
             sba.append(v.toJson());

--- a/src/main/java/io/nats/client/support/JsonValueObject.java
+++ b/src/main/java/io/nats/client/support/JsonValueObject.java
@@ -1,0 +1,54 @@
+package io.nats.client.support;
+
+import org.jspecify.annotations.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.nats.client.support.JsonUtils.addField;
+import static io.nats.client.support.JsonUtils.beginJson;
+import static io.nats.client.support.JsonUtils.endJson;
+
+/**
+ * @see JsonValue
+ * @see JsonValueUtils
+ */
+public class JsonValueObject extends JsonValue {
+    public final List<String> mapOrder = new ArrayList<>();
+
+    public JsonValueObject(@NonNull Map<String, JsonValue> map) {
+        super(map);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, JsonValue> map() {
+        return (Map<String, JsonValue>) value;
+    }
+
+    private static String valueString(Map<String, JsonValue> map, List<String> mapOrder) {
+        StringBuilder sbo = beginJson();
+        if (!mapOrder.isEmpty()) {
+            for (String key : mapOrder) {
+                addField(sbo, key, map.get(key));
+            }
+        }
+        else {
+            for (Map.Entry<String, JsonValue> entry : map.entrySet()) {
+                addField(sbo, entry.getKey(), entry.getValue());
+            }
+        }
+        return endJson(sbo).toString();
+    }
+
+    @Override
+    public @NonNull JsonValueObject toJsonValue() {
+        return this;
+    }
+
+    @Override
+    public @NonNull String toJson() {
+        return valueString(map(), mapOrder);
+    }
+}

--- a/src/main/java/io/nats/client/support/JsonValueUtils.java
+++ b/src/main/java/io/nats/client/support/JsonValueUtils.java
@@ -228,11 +228,10 @@ public abstract class JsonValueUtils {
         return v;
     }
 
-    @SuppressWarnings("rawtypes")
-    public static JsonValue instance(Map map) {
-        JsonValue v = new JsonValue(new HashMap<>());
-        for (Object key : map.keySet()) {
-            v.map().put(key.toString(), toJsonValue(map.get(key)));
+    public static JsonValue instance(Map<String,?> map) {
+        JsonValueObject v = new JsonValueObject(new HashMap<>(map.size()*4/3));
+        for (Map.Entry<String,?> entry : map.entrySet()) {
+            v.map().put(((Object) entry.getKey()).toString(), toJsonValue(entry.getValue()));
         }
         return v;
     }
@@ -299,12 +298,12 @@ public abstract class JsonValueUtils {
         }
 
         public MapBuilder(JsonValue jv) {
-			if (jv instanceof JsonValueObject) {
-				this.jv = (JsonValueObject)jv;
-			} else {
-				// todo log warn? throw exception?
-				this.jv = new JsonValueObject(new HashMap<>());
-			}
+            if (jv instanceof JsonValueObject) {
+                this.jv = (JsonValueObject)jv;
+            } else {
+                // todo log warn? throw exception?
+                this.jv = new JsonValueObject(new HashMap<>());
+            }
         }
 
         public MapBuilder put(String s, Object o) {

--- a/src/main/java/io/nats/client/support/JsonValueUtils.java
+++ b/src/main/java/io/nats/client/support/JsonValueUtils.java
@@ -292,14 +292,19 @@ public abstract class JsonValueUtils {
     }
 
     public static class MapBuilder implements JsonSerializable {
-        public JsonValue jv;
+        public JsonValueObject jv;
 
         public MapBuilder() {
-            jv = new JsonValue(new HashMap<>());
+            jv = new JsonValueObject(new HashMap<>());
         }
 
         public MapBuilder(JsonValue jv) {
-            this.jv = jv;
+			if (jv instanceof JsonValueObject) {
+				this.jv = (JsonValueObject)jv;
+			} else {
+				// todo log warn? throw exception?
+				this.jv = new JsonValueObject(new HashMap<>());
+			}
         }
 
         public MapBuilder put(String s, Object o) {
@@ -316,8 +321,8 @@ public abstract class JsonValueUtils {
         public MapBuilder put(String s, Map<String, String> stringMap) {
             if (stringMap != null) {
                 MapBuilder mb = new MapBuilder();
-                for (String key : stringMap.keySet()) {
-                    mb.put(key, stringMap.get(key));
+                for (Map.Entry<String, String> entry : stringMap.entrySet()) {
+                    mb.put(entry.getKey(), entry.getValue());
                 }
                 jv.map().put(s, mb.jv);
                 jv.mapOrder.add(s);

--- a/src/test/java/io/nats/client/api/StreamConfigurationTests.java
+++ b/src/test/java/io/nats/client/api/StreamConfigurationTests.java
@@ -129,7 +129,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
         // StreamConfiguration can be built without that field being present in the JSON
         for (String streamConfigFieldName: streamConfigFields) {
             JsonValue originalParsedJson = JsonParser.parse(originalJson);
-            originalParsedJson.map.remove(streamConfigFieldName);
+            originalParsedJson.map().remove(streamConfigFieldName);
             StreamConfiguration sc = StreamConfiguration.instance(originalParsedJson.toJson());
             assertNotNull(sc);
         }
@@ -139,7 +139,7 @@ public class StreamConfigurationTests extends JetStreamTestBase {
     public void testInvalidNameInJson() throws Exception{
         String originalJson = ResourceUtils.dataAsString("StreamConfiguration.json");
         JsonValue originalParsedJson = JsonParser.parse(originalJson);
-        originalParsedJson.map.put(NAME, new JsonValue("Inavlid*Name"));
+        originalParsedJson.map().put(NAME, new JsonValue("Inavlid*Name"));
         assertThrows(IllegalArgumentException.class, () -> StreamConfiguration.instance(originalParsedJson.toJson()));
     }
 

--- a/src/test/java/io/nats/client/support/JsonParsingTests.java
+++ b/src/test/java/io/nats/client/support/JsonParsingTests.java
@@ -126,19 +126,19 @@ public final class JsonParsingTests {
         oMap.put("bigIntegerKey2", new JsonValue(new BigInteger("-9223372036854775808")));
 
         // some coverage here
-        JsonValue vMap = new JsonValue(oMap);
+        JsonValue vMap = new JsonValueObject(oMap);
         assertEquals(vMap.toJson(), vMap.toString());
 
         validateMapTypes(oMap, oMap, true);
 
         // don't keep nulls
-        JsonValue parsed = parse(new JsonValue(oMap).toJson());
+        JsonValue parsed = parse(new JsonValueObject(oMap).toJson());
         assertNotNull(parsed.map());
         assertEquals(oMap.size() - 1, parsed.size());
         validateMapTypes(parsed.map(), oMap, false);
 
         // keep nulls
-        parsed = parse(new JsonValue(oMap).toJson(), KEEP_NULLS);
+        parsed = parse(new JsonValueObject(oMap).toJson(), KEEP_NULLS);
         assertNotNull(parsed.map());
         assertEquals(oMap.size(), parsed.map().size());
         validateMapTypes(parsed.map(), oMap, true);
@@ -405,7 +405,7 @@ public final class JsonParsingTests {
         Duration dur = Duration.ofNanos(4273);
         Duration dur2 = Duration.ofNanos(7342);
 
-        JsonValue v = new JsonValue(new HashMap<>());
+        JsonValueObject v = new JsonValueObject(new HashMap<>());
         v.map().put("bool", new JsonValue(Boolean.TRUE));
         v.map().put("string", new JsonValue("hello"));
         v.map().put("int", new JsonValue(Integer.MAX_VALUE));
@@ -522,7 +522,7 @@ public final class JsonParsingTests {
         EqualsVerifier.simple().forClass(JsonValue.class)
             .withPrefabValues(Map.class, map1, map2)
             .withPrefabValues(List.class, list3, list4)
-            .withIgnoredFields("mapOrder")
+            //.withIgnoredFields("mapOrder")
             .suppress(Warning.BIGDECIMAL_EQUALITY)
             .verify();
     }
@@ -714,7 +714,7 @@ public final class JsonParsingTests {
         @Override
         @NonNull
         public String toJson() {
-            JsonValue v = new JsonValue(new HashMap<>());
+            JsonValueObject v = new JsonValueObject(new HashMap<>());
             v.map().put("a", new JsonValue("A"));
             v.map().put("b", new JsonValue("B"));
             v.map().put("c", new JsonValue("C"));
@@ -777,7 +777,7 @@ public final class JsonParsingTests {
 
     @Test
     public void testValueUtilsInstanceMap() {
-        Map<Object, Object> map = new HashMap<>();
+        Map<String, Object> map = new HashMap<>();
         map.put("string", "Hello");
         map.put("char", 'c');
         map.put("int", 1);

--- a/src/test/java/io/nats/client/support/JsonParsingTests.java
+++ b/src/test/java/io/nats/client/support/JsonParsingTests.java
@@ -960,6 +960,7 @@ public final class JsonParsingTests {
         assertEquals("B", stringString.get("b"));
     }
 
+    /// old 88620
     /// new 89863
     @Test @Disabled
     public void testReadSpeed() {
@@ -977,7 +978,8 @@ public final class JsonParsingTests {
         System.out.println("Elapsed: " + elapsed);
     }
 
-    /// new 50mi ~ 1332MB ~ 27-4=23 ~ 12 + 4+4+4 = 24
+    /// new 50mi ~ 1332 MB ~ 27-4=23 ~ 12 + 4+4+4 = 24
+    /// old 50mi ~ 4770 MB ~ 100-4=96 
     @Test @Disabled
     void usedMemory() throws InterruptedException {
         Runtime r = Runtime.getRuntime();

--- a/src/test/java/io/nats/client/support/JsonParsingTests.java
+++ b/src/test/java/io/nats/client/support/JsonParsingTests.java
@@ -13,9 +13,15 @@
 
 package io.nats.client.support;
 
+import io.nats.client.api.AccountStatistics;
+import io.nats.client.api.ConsumerConfiguration;
+import io.nats.client.api.StreamInfo;
+import io.nats.client.impl.NatsMessage;
+import io.nats.client.utils.ResourceUtils;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -952,5 +958,22 @@ public final class JsonParsingTests {
         assertEquals(2, stringString.size());
         assertEquals("A", stringString.get("a"));
         assertEquals("B", stringString.get("b"));
+    }
+
+    /// new 89863
+    @Test @Disabled
+    public void testReadSpeed() {
+        JsonValue jvSI = JsonParser.parseUnchecked(ResourceUtils.dataAsString("StreamInfo.json"));
+        JsonValue jvCC = JsonParser.parseUnchecked(ResourceUtils.dataAsString("ConsumerConfiguration.json"));
+        NatsMessage accStatMsg = getDataMessage(ResourceUtils.dataAsString("AccountStatistics.json"));
+
+        long start = System.currentTimeMillis();
+        for (int x = 0; x < 5_000_000; x++) {
+            new StreamInfo(jvSI);
+            ConsumerConfiguration.builder().jsonValue(jvCC);
+            new AccountStatistics(accStatMsg);
+        }
+        long elapsed = System.currentTimeMillis() - start;
+        System.out.println("Elapsed: " + elapsed);
     }
 }

--- a/src/test/java/io/nats/client/support/JsonParsingTests.java
+++ b/src/test/java/io/nats/client/support/JsonParsingTests.java
@@ -976,4 +976,21 @@ public final class JsonParsingTests {
         long elapsed = System.currentTimeMillis() - start;
         System.out.println("Elapsed: " + elapsed);
     }
+
+    /// new 50mi ~ 1332MB ~ 27-4=23 ~ 12 + 4+4+4 = 24
+    @Test @Disabled
+    void usedMemory() throws InterruptedException {
+        Runtime r = Runtime.getRuntime();
+        r.gc(); r.gc(); r.gc(); r.gc(); r.gc();
+        Thread.sleep(900);
+        long used0 = r.totalMemory() - r.freeMemory();
+        final String s = "Const";
+
+        JsonValue[] a = new JsonValue[50_000_000];
+        for (int i = 0; i < a.length; i++) {
+            a[i] = new JsonValue(s);
+        }
+        long used1 = r.totalMemory() - r.freeMemory();
+        System.out.println("Used: " + (used1 - used0)/1024/1024.0 + " ~ "+ (used1 - used0) / a.length);
+    }
 }

--- a/src/test/java/io/nats/client/support/JsonParsingTests.java
+++ b/src/test/java/io/nats/client/support/JsonParsingTests.java
@@ -79,7 +79,7 @@ public final class JsonParsingTests {
 
         for (int i = 0; i < list.size(); i++) {
             JsonValue v = list.get(i);
-            assertEquals(decodeds.get(i), v.string);
+            assertEquals(decodeds.get(i), v.string());
             assertEquals(v.toJson(), "\"" + encodeds.get(i) + "\"");
         }
     }
@@ -127,15 +127,15 @@ public final class JsonParsingTests {
 
         // don't keep nulls
         JsonValue parsed = parse(new JsonValue(oMap).toJson());
-        assertNotNull(parsed.map);
-        assertEquals(oMap.size() - 1, parsed.map.size());
-        validateMapTypes(parsed.map, oMap, false);
+        assertNotNull(parsed.map());
+        assertEquals(oMap.size() - 1, parsed.size());
+        validateMapTypes(parsed.map(), oMap, false);
 
         // keep nulls
         parsed = parse(new JsonValue(oMap).toJson(), KEEP_NULLS);
-        assertNotNull(parsed.map);
-        assertEquals(oMap.size(), parsed.map.size());
-        validateMapTypes(parsed.map, oMap, true);
+        assertNotNull(parsed.map());
+        assertEquals(oMap.size(), parsed.map().size());
+        validateMapTypes(parsed.map(), oMap, true);
     }
 
     private static void validateMapTypes(Map<String, JsonValue> map, Map<String, JsonValue> oMap, boolean original) {
@@ -150,16 +150,16 @@ public final class JsonParsingTests {
         assertEquals(JsonValue.Type.LONG, map.get("longKey1").type);
         assertEquals(JsonValue.Type.LONG, map.get("longKey2").type);
 
-        assertNotNull(map.get("trueKey1").bool);
-        assertNotNull(map.get("trueKey2").bool);
-        assertNotNull(map.get("falseKey1").bool);
-        assertNotNull(map.get("falseKey2").bool);
-        assertNotNull(map.get("stringKey").string);
-        assertNotNull(map.get("escapeStringKey").string);
-        assertNotNull(map.get("intKey1").i);
-        assertNotNull(map.get("intKey2").i);
-        assertNotNull(map.get("longKey1").l);
-        assertNotNull(map.get("longKey2").l);
+        assertNotNull(map.get("trueKey1").bool());
+        assertNotNull(map.get("trueKey2").bool());
+        assertNotNull(map.get("falseKey1").bool());
+        assertNotNull(map.get("falseKey2").bool());
+        assertNotNull(map.get("stringKey").string());
+        assertNotNull(map.get("escapeStringKey").string());
+        assertNotNull(map.get("intKey1").i());
+        assertNotNull(map.get("intKey2").i());
+        assertNotNull(map.get("longKey1").l());
+        assertNotNull(map.get("longKey2").l());
 
         assertEquals(oMap.get("trueKey1"), map.get("trueKey1"));
         assertEquals(oMap.get("trueKey2"), map.get("trueKey2"));
@@ -173,36 +173,36 @@ public final class JsonParsingTests {
         assertEquals(oMap.get("longKey2"), map.get("longKey2"));
 
         if (original) {
-            assertNotNull(oMap.get("intKey1").i);
-            assertNotNull(oMap.get("intKey2").i);
-            assertNotNull(oMap.get("longKey1").l);
-            assertNotNull(oMap.get("longKey2").l);
-            assertNotNull(oMap.get("doubleKey1").d);
-            assertNotNull(oMap.get("doubleKey2").d);
-            assertNotNull(oMap.get("floatKey1").f);
-            assertNotNull(oMap.get("floatKey2").f);
-            assertNotNull(oMap.get("bigDecimalKey1").bd);
-            assertNotNull(oMap.get("bigDecimalKey2").bd);
-            assertNotNull(oMap.get("bigIntegerKey1").bi);
-            assertNotNull(oMap.get("bigIntegerKey2").bi);
+            assertNotNull(oMap.get("intKey1").i());
+            assertNotNull(oMap.get("intKey2").i());
+            assertNotNull(oMap.get("longKey1").l());
+            assertNotNull(oMap.get("longKey2").l());
+            assertNotNull(oMap.get("doubleKey1").d());
+            assertNotNull(oMap.get("doubleKey2").d());
+            assertNotNull(oMap.get("floatKey1").f());
+            assertNotNull(oMap.get("floatKey2").f());
+            assertNotNull(oMap.get("bigDecimalKey1").bd());
+            assertNotNull(oMap.get("bigDecimalKey2").bd());
+            assertNotNull(oMap.get("bigIntegerKey1").bi());
+            assertNotNull(oMap.get("bigIntegerKey2").bi());
 
             assertEquals(JsonValue.Type.NULL, map.get("nullKey").type);
-            assertNull(map.get("nullKey").object);
+            assertNull(map.get("nullKey").value);
             assertEquals(oMap.get("nullKey"), map.get("nullKey"));
         }
         else {
-            assertNotNull(oMap.get("intKey1").number);
-            assertNotNull(oMap.get("intKey2").number);
-            assertNotNull(oMap.get("longKey1").number);
-            assertNotNull(oMap.get("longKey2").number);
-            assertNotNull(oMap.get("doubleKey1").number);
-            assertNotNull(oMap.get("doubleKey2").number);
-            assertNotNull(oMap.get("floatKey1").number);
-            assertNotNull(oMap.get("floatKey2").number);
-            assertNotNull(oMap.get("bigDecimalKey1").number);
-            assertNotNull(oMap.get("bigDecimalKey2").number);
-            assertNotNull(oMap.get("bigIntegerKey1").number);
-            assertNotNull(oMap.get("bigIntegerKey2").number);
+            assertNotNull(oMap.get("intKey1").value);
+            assertNotNull(oMap.get("intKey2").value);
+            assertNotNull(oMap.get("longKey1").value);
+            assertNotNull(oMap.get("longKey2").value);
+            assertNotNull(oMap.get("doubleKey1").value);
+            assertNotNull(oMap.get("doubleKey2").value);
+            assertNotNull(oMap.get("floatKey1").value);
+            assertNotNull(oMap.get("floatKey2").value);
+            assertNotNull(oMap.get("bigDecimalKey1").value);
+            assertNotNull(oMap.get("bigDecimalKey2").value);
+            assertNotNull(oMap.get("bigIntegerKey1").value);
+            assertNotNull(oMap.get("bigIntegerKey2").value);
         }
     }
 
@@ -216,13 +216,13 @@ public final class JsonParsingTests {
         list.add(JsonValue.EMPTY_ARRAY);
 
         JsonValue root = parse(new JsonValue(list).toJson());
-        assertNotNull(root.array);
-        assertEquals(list.size(), root.array.size());
-        List<JsonValue> array = root.array;
+        assertNotNull(root.array());
+        assertEquals(list.size(), root.size());
+        List<JsonValue> array = root.array();
         for (int i = 0; i < array.size(); i++) {
             JsonValue v = array.get(i);
-            JsonValue p = root.array.get(i);
-            assertEquals(v.object, p.object);
+            JsonValue p = root.array().get(i);
+            assertEquals(v.value, p.value);
             assertTrue(list.contains(v));
         }
 
@@ -236,25 +236,24 @@ public final class JsonParsingTests {
         list.add(new JsonValue(new BigInteger(Long.toString(Long.MAX_VALUE))));
 
         root = parse(new JsonValue(list).toJson());
-        assertNotNull(root.array);
-        assertEquals(list.size(), root.array.size());
-        array = root.array;
+        assertNotNull(root.array());
+        assertEquals(list.size(), root.array().size());
+        array = root.array();
         for (int i = 0; i < array.size(); i++) {
             JsonValue v = array.get(i);
-            JsonValue p = root.array.get(i);
-            assertEquals(v.object, p.object);
-            assertEquals(v.number, p.number);
+            JsonValue p = root.array().get(i);
+            assertEquals(v.value, p.value);
         }
 
         Map<String, JsonValue> rootMap = new HashMap<>();
         rootMap.put("list", new JsonValue(list));
         rootMap.put("array", new JsonValue(list.toArray(new JsonValue[0])));
         root = new JsonValue(rootMap);
-        List<JsonValue> mappedList = readValue(root, "list").array;
+        List<JsonValue> mappedList = readValue(root, "list").array();
 
-        List<JsonValue> mappedList2 = parse(new JsonValue(mappedList).toJson()).array;
-        List<JsonValue> mappedArray = readValue(root, "array").array;
-        List<JsonValue> mappedArray2 = parse(new JsonValue(list.toArray(new JsonValue[0])).toJson()).array;
+        List<JsonValue> mappedList2 = parse(new JsonValue(mappedList).toJson()).array();
+        List<JsonValue> mappedArray = readValue(root, "array").array();
+        List<JsonValue> mappedArray2 = parse(new JsonValue(list.toArray(new JsonValue[0])).toJson()).array();
         for (int i = 0; i < list.size(); i++) {
             JsonValue v = list.get(i);
             JsonValue lv = mappedList.get(i);
@@ -296,7 +295,7 @@ public final class JsonParsingTests {
         JsonValue root = new JsonValue(jvMap);
 
         List<String> list = readStringList(root, "list");
-        assertEquals(3, list.size());
+        assertEquals(3, list.size(), list::toString);
         assertTrue(list.contains("string1"));
         assertTrue(list.contains("string2"));
         assertTrue(list.contains(""));
@@ -367,25 +366,24 @@ public final class JsonParsingTests {
 
     @Test
     public void testConstantsAreReadOnly() {
-        assertThrows(UnsupportedOperationException.class, () -> JsonValue.EMPTY_MAP.map.put("foo", null));
-        assertThrows(UnsupportedOperationException.class, () -> JsonValue.EMPTY_ARRAY.array.add(null));
+        assertThrows(UnsupportedOperationException.class, () -> JsonValue.EMPTY_MAP.map().put("foo", null));
+        assertThrows(UnsupportedOperationException.class, () -> JsonValue.EMPTY_ARRAY.array().add(null));
     }
 
     @Test
     public void testNullJsonValue() {
         assertEquals(JsonValue.Type.NULL, JsonValue.NULL.type);
-        assertNull(JsonValue.NULL.object);
-        assertNull(JsonValue.NULL.map);
-        assertNull(JsonValue.NULL.array);
-        assertNull(JsonValue.NULL.string);
-        assertNull(JsonValue.NULL.bool);
-        assertNull(JsonValue.NULL.number);
-        assertNull(JsonValue.NULL.i);
-        assertNull(JsonValue.NULL.l);
-        assertNull(JsonValue.NULL.d);
-        assertNull(JsonValue.NULL.f);
-        assertNull(JsonValue.NULL.bd);
-        assertNull(JsonValue.NULL.bi);
+        assertNull(JsonValue.NULL.value);
+        assertNull(JsonValue.NULL.map());
+        assertNull(JsonValue.NULL.array());
+        assertNull(JsonValue.NULL.string());
+        assertNull(JsonValue.NULL.bool());
+        assertNull(JsonValue.NULL.i());
+        assertNull(JsonValue.NULL.l());
+        assertNull(JsonValue.NULL.d());
+        assertNull(JsonValue.NULL.f());
+        assertNull(JsonValue.NULL.bd());
+        assertNull(JsonValue.NULL.bi());
         assertEquals(JsonValue.NULL, new JsonValue((String)null));
         assertEquals(JsonValue.NULL, new JsonValue((Boolean) null));
         assertEquals(JsonValue.NULL, new JsonValue((Map<String, JsonValue>)null));
@@ -402,14 +400,14 @@ public final class JsonParsingTests {
         Duration dur2 = Duration.ofNanos(7342);
 
         JsonValue v = new JsonValue(new HashMap<>());
-        v.map.put("bool", new JsonValue(Boolean.TRUE));
-        v.map.put("string", new JsonValue("hello"));
-        v.map.put("int", new JsonValue(Integer.MAX_VALUE));
-        v.map.put("long", new JsonValue(Long.MAX_VALUE));
-        v.map.put("date", new JsonValue(DateTimeUtils.toRfc3339(zdt)));
-        v.map.put("dur", new JsonValue(dur.toNanos()));
-        v.map.put("strings", new JsonValue(new JsonValue[]{new JsonValue("s1"), new JsonValue("s2")}));
-        v.map.put("durs", new JsonValue(new JsonValue[]{new JsonValue(dur.toNanos()), new JsonValue(dur2.toNanos())}));
+        v.map().put("bool", new JsonValue(Boolean.TRUE));
+        v.map().put("string", new JsonValue("hello"));
+        v.map().put("int", new JsonValue(Integer.MAX_VALUE));
+        v.map().put("long", new JsonValue(Long.MAX_VALUE));
+        v.map().put("date", new JsonValue(DateTimeUtils.toRfc3339(zdt)));
+        v.map().put("dur", new JsonValue(dur.toNanos()));
+        v.map().put("strings", new JsonValue(new JsonValue[]{new JsonValue("s1"), new JsonValue("s2")}));
+        v.map().put("durs", new JsonValue(new JsonValue[]{new JsonValue(dur.toNanos()), new JsonValue(dur2.toNanos())}));
 
         assertNotNull(readValue(v, "string"));
         assertNull(readValue(v, "na"));
@@ -518,7 +516,7 @@ public final class JsonParsingTests {
         EqualsVerifier.simple().forClass(JsonValue.class)
             .withPrefabValues(Map.class, map1, map2)
             .withPrefabValues(List.class, list3, list4)
-            .withIgnoredFields("object", "number", "mapOrder")
+            .withIgnoredFields("mapOrder")
             .suppress(Warning.BIGDECIMAL_EQUALITY)
             .verify();
     }
@@ -575,24 +573,26 @@ public final class JsonParsingTests {
         assertEquals(JsonValue.NULL, v);
 
         v = parse("{\"foo\":1,}");
-        assertEquals(1, v.map.size());
-        assertTrue(v.map.containsKey("foo"));
-        assertEquals(1, v.map.get("foo").i);
+        assertEquals(1, v.map().size());
+        assertEquals(1, v.size());
+        assertTrue(v.map().containsKey("foo"));
+        assertEquals(1, v.map().get("foo").i());
 
         v = parse("INFO{\"foo\":1,}", 4);
-        assertEquals(1, v.map.size());
-        assertTrue(v.map.containsKey("foo"));
-        assertEquals(1, v.map.get("foo").i);
+        assertEquals(1, v.map().size());
+        assertTrue(v.map().containsKey("foo"));
+        assertEquals(1, v.map().get("foo").i());
 
         v = parse("[\"foo\",]"); // handles dangling commas fine
-        assertEquals(1, v.array.size());
-        assertEquals("foo", v.array.get(0).string);
+        assertEquals(1, v.array().size());
+        assertEquals(1, v.size());
+        assertEquals("foo", v.array().get(0).string());
 
         String s = "foo \b \t \n \f \r \" \\ /";
         String j = "\"" + Encoding.jsonEncode(s) + "\"";
         v = parse(j);
-        assertNotNull(v.string);
-        assertEquals(s, v.string);
+        assertNotNull(v.string());
+        assertEquals(s, v.string());
 
         // every constructor
         String json = "{}";
@@ -700,8 +700,8 @@ public final class JsonParsingTests {
     @Test
     public void testValueUtilsInstanceDuration() {
         JsonValue v = instance(Duration.ofSeconds(1));
-        assertNotNull(v.l);
-        assertEquals(1000000000L, v.l);
+        assertNotNull(v.l());
+        assertEquals(1000000000L, v.l());
     }
 
     static class TestSerializableMap implements JsonSerializable {
@@ -709,9 +709,9 @@ public final class JsonParsingTests {
         @NonNull
         public String toJson() {
             JsonValue v = new JsonValue(new HashMap<>());
-            v.map.put("a", new JsonValue("A"));
-            v.map.put("b", new JsonValue("B"));
-            v.map.put("c", new JsonValue("C"));
+            v.map().put("a", new JsonValue("A"));
+            v.map().put("b", new JsonValue("B"));
+            v.map().put("c", new JsonValue("C"));
             return v.toJson();
         }
     }
@@ -721,9 +721,9 @@ public final class JsonParsingTests {
         @NonNull
         public String toJson() {
             JsonValue v = new JsonValue(new ArrayList<>());
-            v.array.add(new JsonValue("X"));
-            v.array.add(new JsonValue("Y"));
-            v.array.add(new JsonValue("Z"));
+            v.array().add(new JsonValue("X"));
+            v.array().add(new JsonValue("Y"));
+            v.array().add(new JsonValue("Z"));
             return v.toJson();
         }
     }
@@ -748,24 +748,25 @@ public final class JsonParsingTests {
         list.add(new TestSerializableList());
         list.add(null);
         JsonValue v = instance(list);
-        assertNotNull(v.array);
-        assertEquals(16, v.array.size());
-        assertEquals(JsonValue.Type.STRING, v.array.get(0).type);
-        assertEquals(JsonValue.Type.NULL, v.array.get(1).type);
-        assertEquals(JsonValue.Type.STRING, v.array.get(2).type);
-        assertEquals(JsonValue.Type.INTEGER, v.array.get(3).type);
-        assertEquals(JsonValue.Type.LONG, v.array.get(4).type);
-        assertEquals(JsonValue.Type.DOUBLE, v.array.get(5).type);
-        assertEquals(JsonValue.Type.FLOAT, v.array.get(6).type);
-        assertEquals(JsonValue.Type.BIG_DECIMAL, v.array.get(7).type);
-        assertEquals(JsonValue.Type.BIG_INTEGER, v.array.get(8).type);
-        assertEquals(JsonValue.Type.BOOL, v.array.get(9).type);
-        assertEquals(JsonValue.Type.MAP, v.array.get(10).type);
-        assertEquals(JsonValue.Type.ARRAY, v.array.get(11).type);
-        assertEquals(JsonValue.Type.ARRAY, v.array.get(12).type);
-        assertEquals(JsonValue.Type.MAP, v.array.get(13).type);
-        assertEquals(JsonValue.Type.ARRAY, v.array.get(14).type);
-        assertEquals(JsonValue.Type.NULL, v.array.get(15).type);
+        assertNotNull(v.array());
+        assertEquals(16, v.array().size());
+        assertEquals(16, v.size());
+        assertEquals(JsonValue.Type.STRING, v.array().get(0).type);
+        assertEquals(JsonValue.Type.NULL, v.array().get(1).type);
+        assertEquals(JsonValue.Type.STRING, v.array().get(2).type);
+        assertEquals(JsonValue.Type.INTEGER, v.array().get(3).type);
+        assertEquals(JsonValue.Type.LONG, v.array().get(4).type);
+        assertEquals(JsonValue.Type.DOUBLE, v.array().get(5).type);
+        assertEquals(JsonValue.Type.FLOAT, v.array().get(6).type);
+        assertEquals(JsonValue.Type.BIG_DECIMAL, v.array().get(7).type);
+        assertEquals(JsonValue.Type.BIG_INTEGER, v.array().get(8).type);
+        assertEquals(JsonValue.Type.BOOL, v.array().get(9).type);
+        assertEquals(JsonValue.Type.MAP, v.array().get(10).type);
+        assertEquals(JsonValue.Type.ARRAY, v.array().get(11).type);
+        assertEquals(JsonValue.Type.ARRAY, v.array().get(12).type);
+        assertEquals(JsonValue.Type.MAP, v.array().get(13).type);
+        assertEquals(JsonValue.Type.ARRAY, v.array().get(14).type);
+        assertEquals(JsonValue.Type.NULL, v.array().get(15).type);
     }
 
     @Test
@@ -820,37 +821,38 @@ public final class JsonParsingTests {
     }
 
     private static void validateMap(boolean checkNull, boolean parsed, JsonValue v) {
-        assertNotNull(v.map);
-        assertEquals(JsonValue.Type.STRING, v.map.get("string").type);
-        assertEquals(JsonValue.Type.STRING, v.map.get("char").type);
-        assertEquals(JsonValue.Type.INTEGER, v.map.get("int").type);
-        assertEquals(JsonValue.Type.LONG, v.map.get("long").type);
+        assertNotNull(v.map());
+        assertEquals(JsonValue.Type.STRING, v.map().get("string").type);
+        assertEquals(JsonValue.Type.STRING, v.map().get("char").type);
+        assertEquals(JsonValue.Type.INTEGER, v.map().get("int").type);
+        assertEquals(JsonValue.Type.LONG, v.map().get("long").type);
         if (parsed) {
-            assertEquals(JsonValue.Type.BIG_DECIMAL, v.map.get("double").type);
-            assertEquals(JsonValue.Type.BIG_DECIMAL, v.map.get("float").type);
-            assertEquals(JsonValue.Type.LONG, v.map.get("bi").type);
+            assertEquals(JsonValue.Type.BIG_DECIMAL, v.map().get("double").type);
+            assertEquals(JsonValue.Type.BIG_DECIMAL, v.map().get("float").type);
+            assertEquals(JsonValue.Type.LONG, v.map().get("bi").type);
         }
         else {
-            assertEquals(JsonValue.Type.DOUBLE, v.map.get("double").type);
-            assertEquals(JsonValue.Type.FLOAT, v.map.get("float").type);
-            assertEquals(JsonValue.Type.BIG_INTEGER, v.map.get("bi").type);
+            assertEquals(JsonValue.Type.DOUBLE, v.map().get("double").type);
+            assertEquals(JsonValue.Type.FLOAT, v.map().get("float").type);
+            assertEquals(JsonValue.Type.BIG_INTEGER, v.map().get("bi").type);
         }
-        assertEquals(JsonValue.Type.BIG_DECIMAL, v.map.get("bd").type);
-        assertEquals(JsonValue.Type.BOOL, v.map.get("bool").type);
-        assertEquals(JsonValue.Type.MAP, v.map.get("map").type);
-        assertEquals(JsonValue.Type.ARRAY, v.map.get("list").type);
-        assertEquals(JsonValue.Type.ARRAY, v.map.get("set").type);
-        assertEquals(JsonValue.Type.MAP, v.map.get("smap").type);
-        assertEquals(JsonValue.Type.ARRAY, v.map.get("slist").type);
-        assertEquals(JsonValue.Type.MAP, v.map.get("jv").type);
+        assertEquals(JsonValue.Type.BIG_DECIMAL, v.map().get("bd").type);
+        assertEquals(JsonValue.Type.BOOL, v.map().get("bool").type);
+        assertEquals(JsonValue.Type.MAP, v.map().get("map").type);
+        assertEquals(JsonValue.Type.ARRAY, v.map().get("list").type);
+        assertEquals(JsonValue.Type.ARRAY, v.map().get("set").type);
+        assertEquals(JsonValue.Type.MAP, v.map().get("smap").type);
+        assertEquals(JsonValue.Type.ARRAY, v.map().get("slist").type);
+        assertEquals(JsonValue.Type.MAP, v.map().get("jv").type);
         if (checkNull) {
-            assertEquals(18, v.map.size());
-            assertEquals(JsonValue.Type.NULL, v.map.get("null").type);
-            assertEquals(JsonValue.Type.NULL, v.map.get("jvNull").type);
-            assertEquals(JsonValue.Type.NULL, v.map.get("empty_is_null").type);
+            assertEquals(18, v.map().size());
+            assertEquals(JsonValue.Type.NULL, v.map().get("null").type);
+            assertEquals(JsonValue.Type.NULL, v.map().get("jvNull").type);
+            assertEquals(JsonValue.Type.NULL, v.map().get("empty_is_null").type);
         }
         else {
-            assertEquals(15, v.map.size());
+            assertEquals(15, v.map().size());
+            assertEquals(15, v.size());
         }
     }
 
@@ -902,35 +904,36 @@ public final class JsonParsingTests {
     }
 
     private static void validateArray(boolean checkNull, boolean parsed, JsonValue v) {
-        assertNotNull(v.array);
-        assertEquals(JsonValue.Type.STRING, v.array.get(0).type);
-        assertEquals(JsonValue.Type.STRING, v.array.get(1).type);
-        assertEquals(JsonValue.Type.INTEGER, v.array.get(2).type);
-        assertEquals(JsonValue.Type.LONG, v.array.get(3).type);
+        assertNotNull(v.array());
+        assertEquals(JsonValue.Type.STRING, v.array().get(0).type);
+        assertEquals(JsonValue.Type.STRING, v.array().get(1).type);
+        assertEquals(JsonValue.Type.INTEGER, v.array().get(2).type);
+        assertEquals(JsonValue.Type.LONG, v.array().get(3).type);
         if (parsed) {
-            assertEquals(JsonValue.Type.BIG_DECIMAL, v.array.get(4).type);
-            assertEquals(JsonValue.Type.BIG_DECIMAL, v.array.get(5).type);
-            assertEquals(JsonValue.Type.LONG, v.array.get(7).type);
+            assertEquals(JsonValue.Type.BIG_DECIMAL, v.array().get(4).type);
+            assertEquals(JsonValue.Type.BIG_DECIMAL, v.array().get(5).type);
+            assertEquals(JsonValue.Type.LONG, v.array().get(7).type);
         }
         else {
-            assertEquals(JsonValue.Type.DOUBLE, v.array.get(4).type);
-            assertEquals(JsonValue.Type.FLOAT, v.array.get(5).type);
-            assertEquals(JsonValue.Type.BIG_INTEGER, v.array.get(7).type);
+            assertEquals(JsonValue.Type.DOUBLE, v.array().get(4).type);
+            assertEquals(JsonValue.Type.FLOAT, v.array().get(5).type);
+            assertEquals(JsonValue.Type.BIG_INTEGER, v.array().get(7).type);
         }
-        assertEquals(JsonValue.Type.BIG_DECIMAL, v.array.get(6).type);
-        assertEquals(JsonValue.Type.BOOL, v.array.get(8).type);
-        assertEquals(JsonValue.Type.MAP, v.array.get(9).type);
-        assertEquals(JsonValue.Type.ARRAY, v.array.get(10).type);
-        assertEquals(JsonValue.Type.MAP, v.array.get(11).type);
-        assertEquals(JsonValue.Type.ARRAY, v.array.get(12).type);
-        assertEquals(JsonValue.Type.MAP, v.array.get(13).type);
+        assertEquals(JsonValue.Type.BIG_DECIMAL, v.array().get(6).type);
+        assertEquals(JsonValue.Type.BOOL, v.array().get(8).type);
+        assertEquals(JsonValue.Type.MAP, v.array().get(9).type);
+        assertEquals(JsonValue.Type.ARRAY, v.array().get(10).type);
+        assertEquals(JsonValue.Type.MAP, v.array().get(11).type);
+        assertEquals(JsonValue.Type.ARRAY, v.array().get(12).type);
+        assertEquals(JsonValue.Type.MAP, v.array().get(13).type);
         if (checkNull) {
-            assertEquals(16, v.array.size());
-            assertEquals(JsonValue.Type.NULL, v.array.get(14).type);
-            assertEquals(JsonValue.Type.NULL, v.array.get(15).type);
+            assertEquals(16, v.array().size());
+            assertEquals(JsonValue.Type.NULL, v.array().get(14).type);
+            assertEquals(JsonValue.Type.NULL, v.array().get(15).type);
         }
         else {
-            assertEquals(14, v.array.size());
+            assertEquals(14, v.array().size());
+            assertEquals(14, v.size());
         }
     }
 

--- a/src/test/java/io/nats/service/ServiceTests.java
+++ b/src/test/java/io/nats/service/ServiceTests.java
@@ -22,6 +22,7 @@ import io.nats.client.support.DateTimeUtils;
 import io.nats.client.support.JsonSerializable;
 import io.nats.client.support.JsonUtils;
 import io.nats.client.support.JsonValue;
+import io.nats.client.support.JsonValueObject;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
@@ -1488,7 +1489,7 @@ public class ServiceTests extends JetStreamTestBase {
             Map<String, JsonValue> map = new HashMap<>();
             map.put("sdata", new JsonValue(sData));
             map.put("idata", new JsonValue(iData));
-            return new JsonValue(map);
+            return new JsonValueObject(map);
         }
 
         @Override


### PR DESCRIPTION
This is not an actual PR, because it breaks public JsonValue API 🤷‍♀️

The size of the current JsonValue (only object itself) is ~ 96 bytes.

The size of new JsonValue is ~ 24 bytes ⇒ 4 times smaller.
(see `io.nats.client.support.JsonParsingTests#usedMemory`)

The speed of working with the object does not seem to have changed (within the margin of error)
(see `io.nats.client.support.JsonParsingTests#testReadSpeed`)

If there can be significant amounts of objects in memory, then the difference will be noticeable.
E.g: for 50_000_000 objects
old 4.77 G
new 1.332 G

It passes the unit tests.

You might probably find this useful as a proof of concept or a source of inspiration 🤝
