### PR TITLE
ObjectMeta metadata

### DIFF
--- a/src/main/java/io/nats/client/api/ObjectInfo.java
+++ b/src/main/java/io/nats/client/api/ObjectInfo.java
@@ -19,6 +19,7 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 import static io.nats.client.support.ApiConstants.*;
 import static io.nats.client.support.JsonUtils.beginJson;
@@ -115,33 +116,66 @@ public class ObjectInfo implements JsonSerializable {
         return deleted;
     }
 
+    /**
+     * The full object meta object
+     * @return the ObjectMeta
+     */
     @NonNull
     public ObjectMeta getObjectMeta() {
         return objectMeta;
     }
 
+    /**
+     * The object name
+     * @return the object name
+     */
     @Nullable
     public String getObjectName() {
         return objectMeta.getObjectName();
     }
 
+    /**
+     * The object meta description
+     * @return the description text or null
+     */
     @Nullable
     public String getDescription() {
         return objectMeta.getDescription();
     }
 
-    @Nullable
+    /**
+     * The object meta Headers. May be empty but will not be null. In all cases it will be unmodifiable
+     * @return the headers object
+     */
+    @NonNull
     public Headers getHeaders() {
         return objectMeta.getHeaders();
     }
 
-    public boolean isLink() {
-        return objectMeta.getObjectMetaOptions().getLink() != null;
+    /**
+     * The object meta metadata. May be empty but will not be null. In all cases it will be unmodifiable
+     * @return the map
+     */
+    @NonNull
+    public Map<String, String> getMetaData() {
+        return objectMeta.getMetadata();
     }
 
+    /**
+     * Whether the object is actually a link
+     * @return true if the object is a link instead of a direct object
+     */
+    public boolean isLink() {
+        return objectMeta.getObjectMetaOptions() != null && objectMeta.getObjectMetaOptions().getLink() != null;
+    }
+
+    /**
+     * If this is a link to an object, get the ObjectLink instance, otherwise this will be null
+     * @return the ObjectLink or null
+     */
     @Nullable
     public ObjectLink getLink() {
-        return objectMeta.getObjectMetaOptions().getLink();
+        return objectMeta.getObjectMetaOptions() == null ? null : objectMeta.getObjectMetaOptions().getLink();
     }
 
     public static Builder builder(String bucket, String objectName) {

--- a/src/main/java/io/nats/client/api/ObjectMetaOptions.java
+++ b/src/main/java/io/nats/client/api/ObjectMetaOptions.java
@@ -26,7 +26,7 @@ import static io.nats.client.support.JsonValueUtils.readInteger;
 import static io.nats.client.support.JsonValueUtils.readValue;
 
 /**
- * The ObjectMeta is Object Meta is high level information about an object.
+ * The ObjectMetaOptions are additional options describing the object
  */
 public class ObjectMetaOptions implements JsonSerializable {
 

--- a/src/test/java/io/nats/client/api/ObjectStoreApiTests.java
+++ b/src/test/java/io/nats/client/api/ObjectStoreApiTests.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static io.nats.client.support.NatsConstants.EMPTY;
 import static io.nats.client.utils.ResourceUtils.dataAsString;
@@ -94,12 +95,20 @@ public class ObjectStoreApiTests extends JetStreamTestBase {
         assertNotNull(oi.getHeaders());
         assertEquals(2, oi.getHeaders().size());
         List<String> list = oi.getHeaders().get(key(1));
+        assertNotNull(list);
         assertEquals(1, list.size());
         assertEquals(data(1), oi.getHeaders().getFirst(key(1)));
         list = oi.getHeaders().get(key(2));
+        assertNotNull(list);
         assertEquals(2, list.size());
         assertTrue(list.contains(data(21)));
         assertTrue(list.contains(data(22)));
+
+        Map<String, String> map = oi.getMetaData();
+        assertNotNull(map);
+        assertEquals(2, map.size());
+        assertEquals("meta-data-1", map.get("meta-key-1"));
+        assertEquals("meta-data-2", map.get("meta-key-2"));
     }
 
     @Test

--- a/src/test/resources/data/ObjectInfo.json
+++ b/src/test/resources/data/ObjectInfo.json
@@ -5,6 +5,10 @@
     "key-1": ["data-1"],
     "key-2": ["data-21", "data-22"]
   },
+  "metadata": {
+    "meta-key-1": "meta-data-1",
+    "meta-key-2": "meta-data-2"
+  },
   "options": {
     "link": {
       "bucket": "link-to-bucket",


### PR DESCRIPTION
The java client has ObjectMeta Headers, which is a map of string (key) to list of strings (value), but does not have the additional, almost identical field of metadata, which is a map of string (key) to string (value). 