### PR TITLE
Clarify documentation for JetStreamSubscription

### DIFF
--- a/src/main/java/io/nats/client/JetStreamSubscription.java
+++ b/src/main/java/io/nats/client/JetStreamSubscription.java
@@ -133,7 +133,7 @@ public interface JetStreamSubscription extends Subscription {
      * ! Pull subscriptions only. Push subscription will throw IllegalStateException
      *
      * @param batchSize the size of the batch
-     * @param maxWait the maximum time to wait for the first message.
+     * @param maxWait the maximum time to wait to collect messages for the batch.
      *
      * @return the list of messages
      * @throws IllegalStateException if not a pull subscription.
@@ -148,7 +148,7 @@ public interface JetStreamSubscription extends Subscription {
      * ! Pull subscriptions only. Push subscription will throw IllegalStateException
      *
      * @param batchSize the size of the batch
-     * @param maxWaitMillis the maximum time to wait for the first message, in milliseconds.
+     * @param maxWaitMillis the maximum time to wait to collect messages for the batch, in milliseconds.
      *
      * @return the list of messages
      * @throws IllegalStateException if not a pull subscription.


### PR DESCRIPTION
## Fix javadoc for fetch() maxWait parameter

### Problem
The current javadoc for the `maxWait` parameter in both `fetch()` method overloads incorrectly states that it's "the maximum time to wait for the first message." This is misleading as it suggests the timeout only applies to receiving the initial message.

### Solution
Updated the parameter descriptions to clarify that `maxWait`/`maxWaitMillis` is "the maximum time to wait to collect messages for the batch," which accurately reflects that the timeout governs the entire batch collection operation.

### Changes
- Updated `@param maxWait` description in javadoc for `fetch(int batchSize, Duration maxWait)` method
- Updated `@param maxWaitMillis` description in javadoc for `fetch(int batchSize, long maxWaitMillis)` method

This change improves API documentation clarity for developers using JetStream pull subscriptions.