### PR TITLE
Update version of `bouncycastle` to resolve CVE-2025-9341

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.bouncycastle:bcprov-lts8on:2.73.7'
+    implementation 'org.bouncycastle:bcprov-lts8on:2.73.8'
     implementation 'org.jspecify:jspecify:1.0.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.0'


### PR DESCRIPTION
For more information, please see [CVE-2025-9341](https://nvd.nist.gov/vuln/detail/CVE-2025-9341) and Bouncycastle [resolution](https://github.com/bcgit/bc-java/wiki/CVE%E2%80%902025%E2%80%909341).