### PR TITLE
Exposed StreamName

### DIFF
--- a/src/main/java/io/nats/client/ErrorListener.java
+++ b/src/main/java/io/nats/client/ErrorListener.java
@@ -13,7 +13,11 @@
 
 package io.nats.client;
 
+import java.io.IOException;
+
+import io.nats.client.api.ConsumerInfo;
 import io.nats.client.api.ServerInfo;
+import io.nats.client.impl.NatsJetStreamSubscription;
 import io.nats.client.support.Status;
 
 /**
@@ -28,7 +32,7 @@ import io.nats.client.support.Status;
  * <dt>Fast Producers</dt>
  * <dd>One of the connections producers is too fast, and is discarding messages</dd>
  * </dl>
- * <p>All of these problems are reported to the application code using the ErrorListener. The 
+ * <p>All of these problems are reported to the application code using the ErrorListener. The
  * listener is configured in the {@link Options Options} at creation time.
  */
 public interface ErrorListener {
@@ -49,7 +53,7 @@ public interface ErrorListener {
      * during Dispatcher callbacks, IOExceptions from the underlying socket, etc..
      * The library will try to handle these, via reconnect or catching them, but they are
      * forwarded here in case the application code needs them for debugging purposes.
-     * 
+     *
      * @param conn The connection associated with the error
      * @param exp The exception that has occurred, and was handled by the library
      */
@@ -59,13 +63,13 @@ public interface ErrorListener {
      * Called by the connection when a &quot;slow&quot; consumer is detected. This call is only made once
      * until the consumer stops being slow. At which point it will be called again if the consumer starts
      * being slow again.
-     * 
-     * <p>See {@link Consumer#setPendingLimits(long, long) Consumer.setPendingLimits} 
+     *
+     * <p>See {@link Consumer#setPendingLimits(long, long) Consumer.setPendingLimits}
      * for information on how to configure when this method is fired.
-     * 
+     *
      * <p> Slow consumers will result in dropped messages each consumer provides a method
      * for retrieving the count of dropped messages, see {@link Consumer#getDroppedCount() Consumer.getDroppedCount}.
-     * 
+     *
      * @param conn The connection associated with the error
      * @param consumer The consumer that is being marked slow
      */
@@ -163,6 +167,7 @@ public interface ErrorListener {
             sb.append(", Subscription: ").append(sub.hashCode());
             if (sub instanceof JetStreamSubscription) {
                 JetStreamSubscription jssub = (JetStreamSubscription)sub;
+                sb.append(", Stream Name: ").append(jssub.getStreamName());
                 sb.append(", Consumer Name: ").append(jssub.getConsumerName());
             }
         }

--- a/src/main/java/io/nats/client/ErrorListener.java
+++ b/src/main/java/io/nats/client/ErrorListener.java
@@ -13,11 +13,7 @@
 
 package io.nats.client;
 
-import java.io.IOException;
-
-import io.nats.client.api.ConsumerInfo;
 import io.nats.client.api.ServerInfo;
-import io.nats.client.impl.NatsJetStreamSubscription;
 import io.nats.client.support.Status;
 
 /**

--- a/src/main/java/io/nats/client/ErrorListener.java
+++ b/src/main/java/io/nats/client/ErrorListener.java
@@ -167,7 +167,6 @@ public interface ErrorListener {
             sb.append(", Subscription: ").append(sub.hashCode());
             if (sub instanceof JetStreamSubscription) {
                 JetStreamSubscription jssub = (JetStreamSubscription)sub;
-                sb.append(", Stream Name: ").append(jssub.getStreamName());
                 sb.append(", Consumer Name: ").append(jssub.getConsumerName());
             }
         }

--- a/src/main/java/io/nats/client/JetStreamSubscription.java
+++ b/src/main/java/io/nats/client/JetStreamSubscription.java
@@ -35,7 +35,7 @@ public interface JetStreamSubscription extends Subscription {
      * Gets the stream name associated with the subscription.
      * @return the stream name
      */
-    String getStreamName();
+    default String getStreamName() { return null; }
 
     /**
      * Initiate pull with the specified batch size.

--- a/src/main/java/io/nats/client/JetStreamSubscription.java
+++ b/src/main/java/io/nats/client/JetStreamSubscription.java
@@ -32,6 +32,12 @@ public interface JetStreamSubscription extends Subscription {
     String getConsumerName();
 
     /**
+     * Gets the stream name associated with the subscription.
+     * @return the stream name
+     */
+    String getStreamName();
+
+    /**
      * Initiate pull with the specified batch size.
      * ! Pull subscriptions only. Push subscription will throw IllegalStateException
      * ! Primitive API for ADVANCED use only, officially not supported. Prefer fetch, iterate or reader.

--- a/src/main/java/io/nats/client/impl/NatsJetStreamSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamSubscription.java
@@ -65,6 +65,11 @@ public class NatsJetStreamSubscription extends NatsSubscription implements JetSt
         return consumerName;
     }
 
+    @Override
+    public String getStreamName() {
+        return getStream();
+    }
+
     String getStream() {
         return stream;
     }

--- a/src/main/java/io/nats/client/impl/NatsJetStreamSubscription.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamSubscription.java
@@ -67,10 +67,6 @@ public class NatsJetStreamSubscription extends NatsSubscription implements JetSt
 
     @Override
     public String getStreamName() {
-        return getStream();
-    }
-
-    String getStream() {
         return stream;
     }
 

--- a/src/test/java/io/nats/client/impl/JetStreamTestBase.java
+++ b/src/test/java/io/nats/client/impl/JetStreamTestBase.java
@@ -84,7 +84,7 @@ public class JetStreamTestBase extends TestBase {
 
     public NatsMessage getTestMessage(String replyTo, String sid) {
         return new IncomingMessageFactory(sid, "subj", replyTo, 0, false).getMessage();
-    } 
+    }
 
     // ----------------------------------------------------------------------------------------------------
     // Management
@@ -349,7 +349,7 @@ public class JetStreamTestBase extends TestBase {
 
     public static void assertSubscription(JetStreamSubscription sub, String stream, String consumer, String deliver, boolean isPullMode) {
         NatsJetStreamSubscription njssub = (NatsJetStreamSubscription)sub;
-        assertEquals(stream, njssub.getStream());
+        assertEquals(stream, njssub.getStreamName());
         if (consumer == null) {
             assertNotNull(njssub.getConsumerName());
         }


### PR DESCRIPTION
Exposed StreamName to NatsJetstreamSubscription and extended ErrorListener to log it.

The change is fairly simple and has not hidden dependencies. The NatsJetstreamSubscription was only implemented once. The streamName was already present (but protected).