### PR TITLE
Properly return size in bytes

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -268,7 +268,7 @@ class NatsConnectionWriter implements Runnable {
     long outgoingPendingBytes() {
         writerLock.lock();
         try {
-            return outgoing == null ? -1 : outgoing.length();
+            return outgoing == null ? -1 : outgoing.sizeInBytes();
         }
         finally {
             writerLock.unlock();

--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -47,18 +47,12 @@ public class SocketDataPort implements DataPort {
     protected int port;
     protected Socket socket;
     protected boolean isSecure = false;
-    protected int soLinger;
-    protected int receiveBufferSize;
-    protected int sendBufferSize;
 
     protected InputStream in;
     protected OutputStream out;
 
     @Override
     public void afterConstruct(Options options) {
-        soLinger = options.getSocketSoLinger();
-        receiveBufferSize = options.getReceiveBufferSize();
-        sendBufferSize = options.getSendBufferSize();
     }
 
     @Override
@@ -86,20 +80,21 @@ public class SocketDataPort implements DataPort {
                 socket = createSocket(options);
                 socket.connect(new InetSocketAddress(host, port), (int) timeout);
             }
+
             if (options.getSocketReadTimeoutMillis() > 0) {
                 socket.setSoTimeout(options.getSocketReadTimeoutMillis());
             }
 
-            if (soLinger > 0) {
-                socket.setSoLinger(true, soLinger);
+            if (options.getSocketSoLinger() > 0) {
+                socket.setSoLinger(true, options.getSocketSoLinger());
             }
 
-            if (receiveBufferSize > 0) {
-                socket.setReceiveBufferSize(receiveBufferSize);
+            if (options.getReceiveBufferSize() > 0) {
+                socket.setReceiveBufferSize(options.getReceiveBufferSize());
             }
 
-            if (sendBufferSize > 0) {
-                socket.setSendBufferSize(sendBufferSize);
+            if (options.getSendBufferSize() > 0) {
+                socket.setSendBufferSize(options.getSendBufferSize());
             }
 
             if (isWebsocketScheme(nuri.getScheme())) {


### PR DESCRIPTION
Fixing issue reporting message count (length) instead of bytes





