### PR TITLE
Improve ConnectionListener

### DIFF
--- a/src/main/java/io/nats/client/ConnectionListener.java
+++ b/src/main/java/io/nats/client/ConnectionListener.java
@@ -70,12 +70,26 @@ public interface ConnectionListener {
     }
 
     /**
+     * @deprecated use new api that gives additional details
      * Connection related events that occur asynchronously in the client code are
      * sent to a ConnectionListener via a single method. The ConnectionListener can
      * use the event type to decide what to do about the problem.
-     * 
+     *
      * @param conn the connection associated with the error
      * @param type the type of event that has occurred
      */
+    @Deprecated
     void connectionEvent(Connection conn, Events type);
+
+    /**
+     * Connection related events that occur asynchronously in the client code are
+     * sent to a ConnectionListener via a single method. The ConnectionListener can
+     * use the event type to decide what to do about the problem.
+     * @param conn the connection associated with the error
+     * @param type the type of event that has occurred
+     * @param details extra details about the event
+     */
+    default void connectionEvent(Connection conn, Events type, String details) {
+        connectionEvent(conn, type);
+    }
 }

--- a/src/main/java/io/nats/client/ConnectionListener.java
+++ b/src/main/java/io/nats/client/ConnectionListener.java
@@ -87,9 +87,9 @@ public interface ConnectionListener {
      * use the event type to decide what to do about the problem.
      * @param conn the connection associated with the error
      * @param type the type of event that has occurred
-     * @param details extra details about the event
+     * @param uriDetails extra details about the uri related to this connection event
      */
-    default void connectionEvent(Connection conn, Events type, String details) {
+    default void connectionEvent(Connection conn, Events type, String uriDetails) {
         connectionEvent(conn, type);
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1922,13 +1922,13 @@ class NatsConnection implements Connection {
         }
     }
 
-    void processConnectionEvent(Events type, String details) {
+    void processConnectionEvent(Events type, String uriDetails) {
         if (!this.callbackRunner.isShutdown()) {
             try {
                 for (ConnectionListener listener : connectionListeners) {
                     this.callbackRunner.execute(() -> {
                         try {
-                            listener.connectionEvent(this, type, details);
+                            listener.connectionEvent(this, type, uriDetails);
                         } catch (Exception ex) {
                             this.statistics.incrementExceptionCount();
                         }

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -508,8 +508,7 @@ class NatsConnection implements Connection {
     // will wait for any previous attempt to complete, using the reader.stop and
     // writer.stop
     void tryToConnect(NatsUri cur, NatsUri resolved, long now) {
-        lastServer = currentServer;
-        currentServer = null;
+        clearCurrentServer();
 
         try {
             Duration connectTimeout = options.getConnectionTimeout();
@@ -672,6 +671,13 @@ class NatsConnection implements Connection {
                 statusLock.unlock();
             }
         }
+    }
+
+    private void clearCurrentServer() {
+        if (currentServer != null) {
+            lastServer = currentServer;
+        }
+        currentServer = null;
     }
 
     void checkVersionRequirements() throws IOException {
@@ -932,8 +938,7 @@ class NatsConnection implements Connection {
 
     // Should only be called from closeSocket or close
     void closeSocketImpl(boolean forceClose) {
-        lastServer = currentServer;
-        currentServer = null;
+        clearCurrentServer();
 
         // Signal both to stop.
         final Future<Boolean> readStop = this.reader.stop();
@@ -1965,7 +1970,7 @@ class NatsConnection implements Connection {
 
     String uriDetail(NatsUri uri, NatsUri hostOrlast) {
         if (uri != null) {
-            if (hostOrlast == null) {
+            if (hostOrlast == null || uri.equals(hostOrlast)) {
                 return uri.toString();
             }
             return uri + " [" + hostOrlast + "]";

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -870,7 +870,7 @@ class NatsConnection implements Connection {
 
         statusLock.lock();
         try {
-            updateStatus(Status.CLOSED);  // will signal, we also signal when we stop disconnecting
+            updateStatus(Status.CLOSED); // will signal, we also signal when we stop disconnecting
 
             /*
              * if (exceptionDuringConnectChange != null) {
@@ -1326,7 +1326,8 @@ class NatsConnection implements Connection {
                             @Nullable Duration timeout,
                             @NonNull CancelAction cancelAction,
                             boolean validateSubjectAndReplyTo,
-                            boolean flushImmediatelyAfterPublish) throws InterruptedException {
+                            boolean flushImmediatelyAfterPublish) throws InterruptedException
+    {
         CompletableFuture<Message> incoming = requestFutureInternal(subject, headers, data, timeout, cancelAction, validateSubjectAndReplyTo, flushImmediatelyAfterPublish);
         try {
             if (timeout == null) {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -305,7 +305,7 @@ class NatsConnection implements Connection {
 
         closeSocketLock.lock();
         try {
-            updateStatus(Status.DISCONNECTED, currentServer == null ? lastServer : currentServer, null);
+            updateStatus(Status.DISCONNECTED);
 
             // Close and reset the current data port and future
             if (dataPortFuture != null) {


### PR DESCRIPTION
A new method with a default implementation is added to ConnectionListener. The caller of connection listeners now calls the new method allowing implementors to have extra details about the uri related to this connection event. This information was not always available from the Connection object server info, for instance on reconnect, the connection will be stale, and the details contain information about the uri trying to be connected to and the host uri if the try to connect uri is an ip address resolved from the host uri.

```
default void connectionEvent(Connection conn, Events type, String uriDetails) {
    connectionEvent(conn, type);
}
```