### PR TITLE
Server Pool Improvement

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Build and Test
-        run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
+#        run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
+        run: chmod +x gradlew && ./gradlew clean test jacocoTestReport
       - name: Verify Javadoc
         run: ./gradlew javadoc
       - name: Publish Snapshot

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Build and Test
-        run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
+#        run: chmod +x gradlew && ./gradlew clean test jacocoTestReport coveralls
+        run: chmod +x gradlew && ./gradlew clean test jacocoTestReport
       - name: Verify Javadoc
         run: ./gradlew javadoc
       - name: Clean up

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.nats/jnats/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.nats/jnats)
 [![javadoc](https://javadoc.io/badge2/io.nats/jnats/javadoc.svg)](https://javadoc.io/doc/io.nats/jnats)
-[![Coverage Status](https://coveralls.io/repos/github/nats-io/nats.java/badge.svg?branch=main)](https://coveralls.io/github/nats-io/nats.java?branch=main)
 [![Build Main Badge](https://github.com/nats-io/nats.java/actions/workflows/build-main.yml/badge.svg?event=push)](https://github.com/nats-io/nats.java/actions/workflows/build-main.yml)
 [![Release Badge](https://github.com/nats-io/nats.java/actions/workflows/build-release.yml/badge.svg?event=release)](https://github.com/nats-io/nats.java/actions/workflows/build-release.yml)
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.12.0'
+//    id 'com.github.kt3k.coveralls' version '2.12.0'
     id 'biz.aQute.bnd.builder' version '5.1.2'
     id "org.gradle.test-retry" version "1.1.9"
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,12 @@ java {
 
 repositories {
     mavenCentral()
-    maven { url "https://oss.sonatype.org/content/repositories/releases/" }
+    maven {
+        url "https://repo1.maven.org/maven2/"
+    }
+    maven {
+        url "https://central.sonatype.com/repository/maven-snapshots/"
+    }
 }
 
 dependencies {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -733,6 +733,9 @@ class NatsConnection implements Connection {
         }
 
         processException(io);
+        if (currentServer != null) {
+            serverPool.connectFailed(currentServer);
+        }
 
         // Spawn a thread so we don't have timing issues with
         // waiting on read/write threads

--- a/src/main/java/io/nats/client/impl/NatsServerPool.java
+++ b/src/main/java/io/nats/client/impl/NatsServerPool.java
@@ -268,13 +268,15 @@ public class NatsServerPool implements ServerPool {
         // 2. If we find the server in the list...
         //    2.1. increment failed attempts
         //    2.2. if failed attempts reaches max, remove it from the list
+        //         otherwise just move it to the end of the list
         listLock.lock();
         try {
             for (int x = entryList.size() - 1; x >= 0 ; x--) {
                 ServerPoolEntry entry = entryList.get(x);
                 if (entry.nuri.equals(nuri)) {
-                    if (++entry.failedAttempts >= maxConnectAttempts) {
-                        entryList.remove(x);
+                    entryList.remove(x);
+                    if (++entry.failedAttempts < maxConnectAttempts) {
+                        entryList.add(entry);
                     }
                     return;
                 }


### PR DESCRIPTION
It was reported that the just disconnected server was the first server to attempt to be connected to after a disconnect. Even though the server had been put at the end of the pool when it was connected, discovery of servers randomized the list, making it possible to have been put in the first spot. 

This is fixed when there is a disconnection. When a disconnection occurs the server pool is now told that the current server connection has "failed". Telling the pool that the server connection failed used to only happen during the connect or reconnect process and discovery after connection would shuffle the list.

Now on disconnection, we tell the pool that the server failed. On this "failed" function call, the pool used to just mark the server as a fail. But now it also moves it to the end of the list, just in case it had been shuffled to the top.