### PR TITLE
Fixed the Typo in the Example Code

### DIFF
--- a/src/main/java/io/nats/client/JetStream.java
+++ b/src/main/java/io/nats/client/JetStream.java
@@ -566,7 +566,7 @@ public interface JetStream {
      *
      * <pre>
      *  nc = Nats.connect();
-     *  Jetstream js = nc.jetStream();
+     *  JetStream js = nc.jetStream();
 	 *  StreamContext streamContext = js.getStreamContext("my-stream");
 	 *  ConsumerContext consumerContext = streamContext.getConsumerContext("my-consumer");
 	 *  // Or


### PR DESCRIPTION
fix: correct class name typo from Jetstream to JetStream in NATS client JetStream.java