### PR TITLE
Micro-optimization getBytes(ISO_8859_1) vs getBytes(US_ASCII)

### DIFF
--- a/src/main/java/io/nats/client/api/KeyValueEntry.java
+++ b/src/main/java/io/nats/client/api/KeyValueEntry.java
@@ -18,11 +18,12 @@ import io.nats.client.support.NatsKeyValueUtil;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 
 import static io.nats.client.support.NatsJetStreamConstants.MSG_SIZE_HDR;
 import static io.nats.client.support.NatsKeyValueUtil.BucketAndKey;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * The KeyValueEntry represents a record in the Key Value history
@@ -75,12 +76,12 @@ public class KeyValueEntry {
 
     @Nullable
     public String getValueAsString() {
-        return value == null ? null : new String(value, StandardCharsets.UTF_8);
+        return value == null ? null : new String(value, UTF_8);
     }
 
     @Nullable
     public Long getValueAsLong() {
-        return value == null ? null : Long.parseLong(new String(value, StandardCharsets.US_ASCII));
+        return value == null ? null : Long.parseLong(new String(value, ISO_8859_1));
     }
 
     public long getDataLen() {

--- a/src/main/java/io/nats/client/impl/AckType.java
+++ b/src/main/java/io/nats/client/impl/AckType.java
@@ -1,6 +1,6 @@
 package io.nats.client.impl;
 
-import java.nio.charset.StandardCharsets;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public enum AckType {
     // Acknowledgement protocol messages
@@ -18,11 +18,11 @@ public enum AckType {
 
     AckType(String text, boolean terminal) {
         this.text = text;
-        this.bytes = text.getBytes(StandardCharsets.US_ASCII);
+        this.bytes = text.getBytes(ISO_8859_1);
         this.terminal = terminal;
     }
 
     public byte[] bodyBytes(long delayNanoseconds) {
-        return delayNanoseconds < 1 ? bytes : (text + " {\"delay\": " + delayNanoseconds + "}").getBytes(StandardCharsets.US_ASCII);
+        return delayNanoseconds < 1 ? bytes : (text + " {\"delay\": " + delayNanoseconds + "}").getBytes(ISO_8859_1);
     }
 }

--- a/src/main/java/io/nats/client/impl/NatsKeyValue.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValue.java
@@ -151,7 +151,7 @@ public class NatsKeyValue extends NatsFeatureBase implements KeyValue {
      */
     @Override
     public long put(String key, Number value) throws IOException, JetStreamApiException {
-        return _write(key, value.toString().getBytes(StandardCharsets.US_ASCII), null, null).getSeqno();
+        return _write(key, value.toString().getBytes(StandardCharsets.ISO_8859_1), null, null).getSeqno();
     }
 
     /**

--- a/src/main/java/io/nats/client/impl/NatsMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsMessage.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeoutException;
 import static io.nats.client.support.NatsConstants.*;
 import static io.nats.client.support.Validator.validateReplyTo;
 import static io.nats.client.support.Validator.validateSubject;
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class NatsMessage implements Message {
@@ -153,11 +153,11 @@ public class NatsMessage implements Message {
 
         // header length if there are headers
         if (headerLen > 0) {
-            bab.append(Integer.toString(headerLen).getBytes(US_ASCII)).append(SP);
+            bab.append(Integer.toString(headerLen).getBytes(ISO_8859_1)).append(SP);
         }
 
         // payload length
-        bab.append(Integer.toString(headerAndDataLen).getBytes(US_ASCII));
+        bab.append(Integer.toString(headerAndDataLen).getBytes(ISO_8859_1));
 
         protocolBab = bab;
         controlLineLength = protocolBab.length() + 2; // One CRLF. This is just how controlLineLength is defined.
@@ -409,7 +409,7 @@ public class NatsMessage implements Message {
     }
 
     private String headersToString() {
-        return hasHeaders() ? new String(headers.getSerialized(), US_ASCII).replace("\r", "+").replace("\n", "+") : "";
+        return hasHeaders() ? new String(headers.getSerialized(), ISO_8859_1).replace("\r", "+").replace("\n", "+") : "";
     }
 
     private String dataToString() {

--- a/src/main/java/io/nats/client/support/BuilderBase.java
+++ b/src/main/java/io/nats/client/support/BuilderBase.java
@@ -15,6 +15,7 @@ package io.nats.client.support;
 
 import java.nio.charset.Charset;
 
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 public abstract class BuilderBase {
@@ -24,7 +25,7 @@ public abstract class BuilderBase {
     public static final int ALLOCATION_BOUNDARY = 32;
     public static final int DEFAULT_ASCII_ALLOCATION = 32;
     public static final int DEFAULT_OTHER_ALLOCATION = 64;
-    public static final byte[] NULL = "null".getBytes(US_ASCII);
+    public static final byte[] NULL = "null".getBytes(ISO_8859_1);
 
     protected BuilderBase(Charset defaultCharset, int allocationSize) {
         this.defaultCharset = defaultCharset;
@@ -105,7 +106,7 @@ public abstract class BuilderBase {
     }
 
     private int _defaultCharsetAllocationSize() {
-        return defaultCharset == US_ASCII ? DEFAULT_ASCII_ALLOCATION : DEFAULT_OTHER_ALLOCATION;
+        return defaultCharset == US_ASCII || defaultCharset == ISO_8859_1 ? DEFAULT_ASCII_ALLOCATION : DEFAULT_OTHER_ALLOCATION;
     }
 
     public static int bufferAllocSize(int atLeast, int blockSize) {

--- a/src/main/java/io/nats/client/support/ByteArrayBuilder.java
+++ b/src/main/java/io/nats/client/support/ByteArrayBuilder.java
@@ -20,7 +20,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public class ByteArrayBuilder extends BuilderBase {
     private ByteBuffer buffer;
@@ -40,21 +40,22 @@ public class ByteArrayBuilder extends BuilderBase {
     /**
      * Construct the ByteArrayBuilder with
      * the initial size and allocation size of {@value #DEFAULT_ASCII_ALLOCATION}
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
+     * since ISO_8859_1 is faster when encoding and decoding than ISO_8859_1
      */
     public ByteArrayBuilder() {
-        this(-1, DEFAULT_ASCII_ALLOCATION, US_ASCII);
+        this(-1, DEFAULT_ASCII_ALLOCATION, ISO_8859_1);
     }
 
     /**
      * Construct the ByteArrayBuilder with the supplied initial size,
      * allocation size of {@value #DEFAULT_ASCII_ALLOCATION}
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
      *
      * @param initialSize the initial size
      */
     public ByteArrayBuilder(int initialSize) {
-        this(initialSize, DEFAULT_ASCII_ALLOCATION, US_ASCII);
+        this(initialSize, DEFAULT_ASCII_ALLOCATION, ISO_8859_1);
     }
 
     /**
@@ -80,8 +81,8 @@ public class ByteArrayBuilder extends BuilderBase {
 
     /**
      * Construct the ByteArrayBuilder copying all the bytes
-     * using the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * using the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
      * Then initializes the buffer with the supplied bytes
      * @param bytes the bytes
      */
@@ -91,13 +92,13 @@ public class ByteArrayBuilder extends BuilderBase {
 
     /**
      * Construct the ByteArrayBuilder copying the specified number of bytes;
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
      * Then initializes the buffer with the supplied bytes
      * @param bytes the bytes
      * @param len the number of bytes to copy
      */
     public ByteArrayBuilder(byte[] bytes, int len) {
-        super(US_ASCII, DEFAULT_ASCII_ALLOCATION);
+        super(ISO_8859_1, DEFAULT_ASCII_ALLOCATION);
         this.buffer = ByteBuffer.allocate(bufferAllocSize(len, allocationSize));
         buffer.put(bytes, 0, bytes.length);
     }
@@ -225,7 +226,7 @@ public class ByteArrayBuilder extends BuilderBase {
      * @return this (fluent)
      */
     public ByteArrayBuilder append(int i) {
-        append(Integer.toString(i).getBytes(US_ASCII)); // a number is always ascii
+        append(Integer.toString(i).getBytes(ISO_8859_1)); // a number is always ascii (ISO_8859_1 is faster)
         return this;
     }
 

--- a/src/main/java/io/nats/client/support/ByteArrayPrimitiveBuilder.java
+++ b/src/main/java/io/nats/client/support/ByteArrayPrimitiveBuilder.java
@@ -18,7 +18,7 @@ import java.io.OutputStream;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public class ByteArrayPrimitiveBuilder extends BuilderBase {
     private byte[] buffer;
@@ -40,20 +40,22 @@ public class ByteArrayPrimitiveBuilder extends BuilderBase {
     /**
      * Construct the ByteArrayPrimitiveBuilder with
      * the initial size and allocation size of {@value #DEFAULT_ASCII_ALLOCATION}
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
+     * since ISO_8859_1 is faster when encoding and decoding than US_ASCII
      */
     public ByteArrayPrimitiveBuilder() {
-        this(-1, DEFAULT_ASCII_ALLOCATION, US_ASCII);
+        this(-1, DEFAULT_ASCII_ALLOCATION, ISO_8859_1);
     }
 
     /**
      * Construct the ByteArrayPrimitiveBuilder with the supplied initial size,
      * allocation size of {@value #DEFAULT_ASCII_ALLOCATION}
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
+     * since ISO_8859_1 is faster when encoding and decoding than US_ASCII
      * @param initialSize the initial size
      */
     public ByteArrayPrimitiveBuilder(int initialSize) {
-        this(initialSize, DEFAULT_ASCII_ALLOCATION, US_ASCII);
+        this(initialSize, DEFAULT_ASCII_ALLOCATION, ISO_8859_1);
     }
 
     /**
@@ -77,7 +79,8 @@ public class ByteArrayPrimitiveBuilder extends BuilderBase {
 
     /**
      * Construct the ByteArrayPrimitiveBuilder copying all the bytes
-     * using the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * using the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
+     * since ISO_8859_1 is faster when encoding and decoding than US_ASCII
      * Then initializes the buffer with the supplied bytes
      * @param bytes the bytes
      */
@@ -87,13 +90,14 @@ public class ByteArrayPrimitiveBuilder extends BuilderBase {
 
     /**
      * Construct the ByteArrayPrimitiveBuilder copying the specified number of bytes;
-     * and the character set {@link java.nio.charset.StandardCharsets#US_ASCII}
+     * and the character set {@link java.nio.charset.StandardCharsets#ISO_8859_1}
+     * since ISO_8859_1 is faster when encoding and decoding than US_ASCII
      * Then initializes the buffer with the supplied bytes
      * @param bytes the bytes
      * @param len the number of bytes to copy
      */
     public ByteArrayPrimitiveBuilder(byte[] bytes, int len) {
-        super(US_ASCII, DEFAULT_ASCII_ALLOCATION);
+        super(ISO_8859_1, DEFAULT_ASCII_ALLOCATION);
         position = len;
         buffer = new byte[bufferAllocSize(len, allocationSize)];
         System.arraycopy(bytes, 0, buffer, 0, len);
@@ -216,7 +220,7 @@ public class ByteArrayPrimitiveBuilder extends BuilderBase {
      * @return this (fluent)
      */
     public ByteArrayPrimitiveBuilder append(int i) {
-        append(Integer.toString(i).getBytes(US_ASCII)); // a number is always ascii
+        append(Integer.toString(i).getBytes(ISO_8859_1)); // a number is always ascii (ISO_8859_1 is faster)
         return this;
     }
 

--- a/src/main/java/io/nats/client/support/JwtUtils.java
+++ b/src/main/java/io/nats/client/support/JwtUtils.java
@@ -247,7 +247,7 @@ public abstract class JwtUtils {
 
         // Compute jti, a base32 encoded sha256 hash
         MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
-        byte[] encoded = sha256.digest(claimJson.getBytes(StandardCharsets.US_ASCII));
+        byte[] encoded = sha256.digest(claimJson.getBytes(StandardCharsets.ISO_8859_1));
 
         claim.jti = new String(base32Encode(encoded));
         claimJson = claim.toJson();

--- a/src/main/java/io/nats/client/support/NatsConstants.java
+++ b/src/main/java/io/nats/client/support/NatsConstants.java
@@ -16,7 +16,7 @@ package io.nats.client.support;
 import java.util.Arrays;
 import java.util.List;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public interface NatsConstants {
     String HEADER_VERSION = "NATS/1.0";
@@ -48,10 +48,10 @@ public interface NatsConstants {
     byte LF = '\n';
 
     byte[] EMPTY_BODY = new byte[0];
-    byte[] HEADER_VERSION_BYTES = HEADER_VERSION.getBytes(US_ASCII);
-    byte[] HEADER_VERSION_BYTES_PLUS_CRLF = (HEADER_VERSION + "\r\n").getBytes(US_ASCII);
-    byte[] COLON_BYTES = ":".getBytes(US_ASCII);
-    byte[] CRLF_BYTES = CRLF.getBytes(US_ASCII);
+    byte[] HEADER_VERSION_BYTES = HEADER_VERSION.getBytes(ISO_8859_1);
+    byte[] HEADER_VERSION_BYTES_PLUS_CRLF = (HEADER_VERSION + "\r\n").getBytes(ISO_8859_1);
+    byte[] COLON_BYTES = ":".getBytes(ISO_8859_1);
+    byte[] CRLF_BYTES = CRLF.getBytes(ISO_8859_1);
     int HEADER_VERSION_BYTES_LEN = HEADER_VERSION_BYTES.length;
 
     String OP_CONNECT = "CONNECT";
@@ -71,8 +71,8 @@ public interface NatsConstants {
     byte[] OP_PING_BYTES = OP_PING.getBytes();
     byte[] OP_PONG_BYTES = OP_PONG.getBytes();
 
-    byte[] PUB_SP_BYTES = (OP_PUB + SPACE).getBytes(US_ASCII);
-    byte[] HPUB_SP_BYTES = (OP_HPUB + SPACE).getBytes(US_ASCII);
+    byte[] PUB_SP_BYTES = (OP_PUB + SPACE).getBytes(ISO_8859_1);
+    byte[] HPUB_SP_BYTES = (OP_HPUB + SPACE).getBytes(ISO_8859_1);
     byte[] CONNECT_SP_BYTES = (OP_CONNECT + SPACE).getBytes();
     byte[] SUB_SP_BYTES = (OP_SUB + SPACE).getBytes();
     byte[] UNSUB_SP_BYTES = (OP_UNSUB + SPACE).getBytes();

--- a/src/main/java/io/nats/client/support/NatsJetStreamConstants.java
+++ b/src/main/java/io/nats/client/support/NatsJetStreamConstants.java
@@ -1,6 +1,6 @@
 package io.nats.client.support;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public interface NatsJetStreamConstants {
     /**
@@ -104,9 +104,9 @@ public interface NatsJetStreamConstants {
     String CONSUMER_STALLED_HDR         = "Nats-Consumer-Stalled";
     String MSG_SIZE_HDR                 = "Nats-Msg-Size";
     String NATS_MARKER_REASON_HDR       = "Nats-Marker-Reason";
-    byte[] CONSUMER_STALLED_HDR_BYTES   = CONSUMER_STALLED_HDR.getBytes(US_ASCII);
-    byte[] MSG_SIZE_HDR_BYTES           = MSG_SIZE_HDR.getBytes(US_ASCII);
-    byte[] NATS_MARKER_REASON_HDR_BYTES = NATS_MARKER_REASON_HDR.getBytes(US_ASCII);
+    byte[] CONSUMER_STALLED_HDR_BYTES   = CONSUMER_STALLED_HDR.getBytes(ISO_8859_1);
+    byte[] MSG_SIZE_HDR_BYTES           = MSG_SIZE_HDR.getBytes(ISO_8859_1);
+    byte[] NATS_MARKER_REASON_HDR_BYTES = NATS_MARKER_REASON_HDR.getBytes(ISO_8859_1);
 
     String ROLLUP_HDR = "Nats-Rollup";
     String ROLLUP_HDR_SUBJECT = "sub";
@@ -121,20 +121,20 @@ public interface NatsJetStreamConstants {
     String[] MESSAGE_INFO_HEADERS = new String[]{NATS_SUBJECT, NATS_SEQUENCE, NATS_TIMESTAMP, NATS_STREAM, NATS_LAST_SEQUENCE, NATS_NUM_PENDING};
 
     // bytes used for faster matching and less string allocation when
-    byte[] NATS_STREAM_BYTES = NATS_STREAM.getBytes(US_ASCII);
-    byte[] NATS_SEQUENCE_BYTES = NATS_SEQUENCE.getBytes(US_ASCII);
-    byte[] NATS_TIMESTAMP_BYTES = NATS_TIMESTAMP.getBytes(US_ASCII);
-    byte[] NATS_SUBJECT_BYTES = NATS_SUBJECT.getBytes(US_ASCII);
-    byte[] NATS_LAST_SEQUENCE_BYTES = NATS_LAST_SEQUENCE.getBytes(US_ASCII);
-    byte[] NATS_NUM_PENDING_BYTES = NATS_NUM_PENDING.getBytes(US_ASCII);
+    byte[] NATS_STREAM_BYTES = NATS_STREAM.getBytes(ISO_8859_1);
+    byte[] NATS_SEQUENCE_BYTES = NATS_SEQUENCE.getBytes(ISO_8859_1);
+    byte[] NATS_TIMESTAMP_BYTES = NATS_TIMESTAMP.getBytes(ISO_8859_1);
+    byte[] NATS_SUBJECT_BYTES = NATS_SUBJECT.getBytes(ISO_8859_1);
+    byte[] NATS_LAST_SEQUENCE_BYTES = NATS_LAST_SEQUENCE.getBytes(ISO_8859_1);
+    byte[] NATS_NUM_PENDING_BYTES = NATS_NUM_PENDING.getBytes(ISO_8859_1);
 
     String NATS_PENDING_MESSAGES       = "Nats-Pending-Messages";
     String NATS_PENDING_BYTES          = "Nats-Pending-Bytes";
-    byte[] NATS_PENDING_MESSAGES_BYTES = NATS_PENDING_MESSAGES.getBytes(US_ASCII);
-    byte[] NATS_PENDING_BYTES_BYTES    = NATS_PENDING_BYTES.getBytes(US_ASCII);
+    byte[] NATS_PENDING_MESSAGES_BYTES = NATS_PENDING_MESSAGES.getBytes(ISO_8859_1);
+    byte[] NATS_PENDING_BYTES_BYTES    = NATS_PENDING_BYTES.getBytes(ISO_8859_1);
 
     String KV_OPERATION_HEADER_KEY       = "KV-Operation";
-    byte[] KV_OPERATION_HEADER_KEY_BYTES = KV_OPERATION_HEADER_KEY.getBytes(US_ASCII);
+    byte[] KV_OPERATION_HEADER_KEY_BYTES = KV_OPERATION_HEADER_KEY.getBytes(ISO_8859_1);
 
     String NATS_SCHEDULE_HDR        = "Nats-Schedule";
     String NATS_SCHEDULE_TARGET_HDR = "Nats-Schedule-Target";

--- a/src/main/java/io/nats/client/support/Status.java
+++ b/src/main/java/io/nats/client/support/Status.java
@@ -16,7 +16,7 @@ package io.nats.client.support;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
 
 public class Status {
 
@@ -24,10 +24,10 @@ public class Status {
     public static final String HEARTBEAT_TEXT     = "Idle Heartbeat";
     public static final String NO_RESPONDERS_TEXT = "No Responders Available For Request";
     public static final String EOB_TEXT           = "EOB";
-    public static final byte[] FLOW_CONTROL_TEXT_BYTES  = FLOW_CONTROL_TEXT.getBytes(US_ASCII);
-    public static final byte[] HEARTBEAT_TEXT_BYTES     = HEARTBEAT_TEXT.getBytes(US_ASCII);
-    public static final byte[] NO_RESPONDERS_TEXT_BYTES = NO_RESPONDERS_TEXT.getBytes(US_ASCII);
-    public static final byte[] EOB_TEXT_BYTES           = EOB_TEXT.getBytes(US_ASCII);
+    public static final byte[] FLOW_CONTROL_TEXT_BYTES  = FLOW_CONTROL_TEXT.getBytes(ISO_8859_1);
+    public static final byte[] HEARTBEAT_TEXT_BYTES     = HEARTBEAT_TEXT.getBytes(ISO_8859_1);
+    public static final byte[] NO_RESPONDERS_TEXT_BYTES = NO_RESPONDERS_TEXT.getBytes(ISO_8859_1);
+    public static final byte[] EOB_TEXT_BYTES           = EOB_TEXT.getBytes(ISO_8859_1);
 
     public static final int FLOW_OR_HEARTBEAT_STATUS_CODE = 100;
     public static final int NO_RESPONDERS_CODE = 503;
@@ -40,16 +40,16 @@ public class Status {
 
 // TODO - PINNED CONSUMER SUPPORT
 //    public static final int PIN_ERROR_CODE = 423;
-//    public static final byte[] PIN_ERROR_CODE_BYTES = ("" + PIN_ERROR_CODE).getBytes(US_ASCII);
+//    public static final byte[] PIN_ERROR_CODE_BYTES = ("" + PIN_ERROR_CODE).getBytes(ISO_8859_1);
 
     public static final String BAD_REQUEST                    = "Bad Request"; // 400
     public static final String NO_MESSAGES                    = "No Messages"; // 404
     public static final String CONSUMER_DELETED               = "Consumer Deleted"; // 409
     public static final String CONSUMER_IS_PUSH_BASED         = "Consumer is push based"; // 409
-    public static final byte[] BAD_REQUEST_BYTES              = BAD_REQUEST.getBytes(US_ASCII);
-    public static final byte[] NO_MESSAGES_BYTES              = NO_MESSAGES.getBytes(US_ASCII);
-    public static final byte[] CONSUMER_DELETED_BYTES         = CONSUMER_DELETED.getBytes(US_ASCII);
-    public static final byte[] CONSUMER_IS_PUSH_BASED_BYTES   = CONSUMER_IS_PUSH_BASED.getBytes(US_ASCII);
+    public static final byte[] BAD_REQUEST_BYTES              = BAD_REQUEST.getBytes(ISO_8859_1);
+    public static final byte[] NO_MESSAGES_BYTES              = NO_MESSAGES.getBytes(ISO_8859_1);
+    public static final byte[] CONSUMER_DELETED_BYTES         = CONSUMER_DELETED.getBytes(ISO_8859_1);
+    public static final byte[] CONSUMER_IS_PUSH_BASED_BYTES   = CONSUMER_IS_PUSH_BASED.getBytes(ISO_8859_1);
 
     public static final String MESSAGE_SIZE_EXCEEDS_MAX_BYTES = "Message Size Exceeds MaxBytes"; // 409
     public static final String EXCEEDED_MAX_PREFIX            = "Exceeded Max";
@@ -57,18 +57,18 @@ public class Status {
     public static final String EXCEEDED_MAX_REQUEST_BATCH     = "Exceeded MaxRequestBatch"; // 409
     public static final String EXCEEDED_MAX_REQUEST_EXPIRES   = "Exceeded MaxRequestExpires"; // 409
     public static final String EXCEEDED_MAX_REQUEST_MAX_BYTES = "Exceeded MaxRequestMaxBytes"; // 409
-    public static final byte[] MESSAGE_SIZE_EXCEEDS_MAX_BYTES_BYTES = MESSAGE_SIZE_EXCEEDS_MAX_BYTES.getBytes(US_ASCII);
-    public static final byte[] EXCEEDED_MAX_WAITING_BYTES           = EXCEEDED_MAX_WAITING.getBytes(US_ASCII);
-    public static final byte[] EXCEEDED_MAX_REQUEST_BATCH_BYTES     = EXCEEDED_MAX_REQUEST_BATCH.getBytes(US_ASCII);
-    public static final byte[] EXCEEDED_MAX_REQUEST_EXPIRES_BYTES   = EXCEEDED_MAX_REQUEST_EXPIRES.getBytes(US_ASCII);
-    public static final byte[] EXCEEDED_MAX_REQUEST_MAX_BYTES_BYTES = EXCEEDED_MAX_REQUEST_MAX_BYTES.getBytes(US_ASCII);
+    public static final byte[] MESSAGE_SIZE_EXCEEDS_MAX_BYTES_BYTES = MESSAGE_SIZE_EXCEEDS_MAX_BYTES.getBytes(ISO_8859_1);
+    public static final byte[] EXCEEDED_MAX_WAITING_BYTES           = EXCEEDED_MAX_WAITING.getBytes(ISO_8859_1);
+    public static final byte[] EXCEEDED_MAX_REQUEST_BATCH_BYTES     = EXCEEDED_MAX_REQUEST_BATCH.getBytes(ISO_8859_1);
+    public static final byte[] EXCEEDED_MAX_REQUEST_EXPIRES_BYTES   = EXCEEDED_MAX_REQUEST_EXPIRES.getBytes(ISO_8859_1);
+    public static final byte[] EXCEEDED_MAX_REQUEST_MAX_BYTES_BYTES = EXCEEDED_MAX_REQUEST_MAX_BYTES.getBytes(ISO_8859_1);
 
     public static final String BATCH_COMPLETED                = "Batch Completed"; // 409 informational
     public static final String SERVER_SHUTDOWN                = "Server Shutdown"; // 409 informational with headers
     public static final String LEADERSHIP_CHANGE              = "Leadership Change"; // 409
-    public static final byte[] BATCH_COMPLETED_BYTES          = BATCH_COMPLETED.getBytes(US_ASCII);
-    public static final byte[] SERVER_SHUTDOWN_BYTES          = SERVER_SHUTDOWN.getBytes(US_ASCII);
-    public static final byte[] LEADERSHIP_CHANGE_BYTES        = LEADERSHIP_CHANGE.getBytes(US_ASCII);
+    public static final byte[] BATCH_COMPLETED_BYTES          = BATCH_COMPLETED.getBytes(ISO_8859_1);
+    public static final byte[] SERVER_SHUTDOWN_BYTES          = SERVER_SHUTDOWN.getBytes(ISO_8859_1);
+    public static final byte[] LEADERSHIP_CHANGE_BYTES        = LEADERSHIP_CHANGE.getBytes(ISO_8859_1);
 
     public static final Status EOB = new Status(EOB_CODE, EOB_TEXT);
     public static final Status TIMEOUT_OR_NO_MESSAGES = new Status(NOT_FOUND_CODE, "Timeout or No Messages");


### PR DESCRIPTION
* Addresses #1386
* ISO_8859_1 is faster when encoding and decoding than US_ASCII
* See https://cl4es.github.io/2021/10/17/Faster-Charset-Encoding.html