### PR TITLE
[BUG] AccountTier read reserved values as int instead of long

### DIFF
--- a/src/main/java/io/nats/client/JetStreamManagement.java
+++ b/src/main/java/io/nats/client/JetStreamManagement.java
@@ -296,7 +296,7 @@ public interface JetStreamManagement {
     /**
      * Get MessageInfo for the first message created at or after the start time.
      * <p>
-     * This API 1) is currently EXPERIMENTAL and is subject to change. 2) Works on Server 2.11 or later
+     * This API works on Server 2.11 or later
      * @param streamName the name of the stream.
      * @param startTime the start time to get the first message for.
      * @return The MessageInfo
@@ -309,7 +309,7 @@ public interface JetStreamManagement {
     /**
      * Get MessageInfo for the first message created at or after the start time matching the subject.
      * <p>
-     * This API 1) is currently EXPERIMENTAL and is subject to change. 2) Works on Server 2.11 or later
+     * This API works on Server 2.11 or later
      * @param streamName the name of the stream.
      * @param startTime the start time to get the first message for.
      * @param subject the subject to get the first message for.

--- a/src/main/java/io/nats/client/api/AccountTier.java
+++ b/src/main/java/io/nats/client/api/AccountTier.java
@@ -17,8 +17,7 @@ import io.nats.client.support.JsonValue;
 import org.jspecify.annotations.NonNull;
 
 import static io.nats.client.support.ApiConstants.*;
-import static io.nats.client.support.JsonValueUtils.readInteger;
-import static io.nats.client.support.JsonValueUtils.readObject;
+import static io.nats.client.support.JsonValueUtils.*;
 
 /**
  * Represents the JetStream Account Tier
@@ -36,8 +35,8 @@ public class AccountTier {
     AccountTier(JsonValue vAccountTier) {
         memory = readInteger(vAccountTier, MEMORY, 0);
         storage = readInteger(vAccountTier, STORAGE, 0);
-        reservedMemory = readInteger(vAccountTier, RESERVED_MEMORY, 0);
-        reservedStorage = readInteger(vAccountTier, RESERVED_STORAGE, 0);
+        reservedMemory = readLong(vAccountTier, RESERVED_MEMORY, 0);
+        reservedStorage = readLong(vAccountTier, RESERVED_STORAGE, 0);
         streams = readInteger(vAccountTier, STREAMS, 0);
         consumers = readInteger(vAccountTier, CONSUMERS, 0);
         limits = new AccountLimits(readObject(vAccountTier, LIMITS));

--- a/src/main/java/io/nats/client/impl/NatsKeyValue.java
+++ b/src/main/java/io/nats/client/impl/NatsKeyValue.java
@@ -177,7 +177,7 @@ public class NatsKeyValue extends NatsFeatureBase implements KeyValue {
                 if (kve != null && kve.getOperation() != KeyValueOperation.PUT) {
                     long revision = kve.getRevision();
                     if (revision > 0) {
-                        return _update(key, value, kve.getRevision(), messageTtl);
+                        return _update(key, value, revision, messageTtl);
                     }
                 }
             }

--- a/src/test/java/io/nats/client/impl/KeyValueTests.java
+++ b/src/test/java/io/nats/client/impl/KeyValueTests.java
@@ -1812,6 +1812,7 @@ public class KeyValueTests extends JetStreamTestBase {
                 .limitMarker(1000)
                 .build();
             KeyValueStatus status = kvm.create(config);
+            assertNotNull(status.getLimitMarkerTtl());
             assertEquals(1000, status.getLimitMarkerTtl().toMillis());
 
             String key = key();
@@ -1832,6 +1833,7 @@ public class KeyValueTests extends JetStreamTestBase {
                 .limitMarker(Duration.ofSeconds(2)) // coverage of duration api vs ms api
                 .build();
             status = kvm.create(config);
+            assertNotNull(status.getLimitMarkerTtl());
             assertEquals(2000, status.getLimitMarkerTtl().toMillis());
 
             assertThrows(IllegalArgumentException.class, () -> KeyValueConfiguration.builder()
@@ -1863,8 +1865,6 @@ public class KeyValueTests extends JetStreamTestBase {
                 .limitMarker(Duration.ofSeconds(5))
                 .build();
             kvm.create(config);
-
-            Dispatcher d = nc.createDispatcher();
 
             KeyValue kv = nc.keyValue(bucket);
 
@@ -1924,6 +1924,7 @@ public class KeyValueTests extends JetStreamTestBase {
                 }
             };
 
+            Dispatcher d = nc.createDispatcher();
             JetStreamSubscription sub = nc.jetStream().subscribe(null, d, rawHandler, true,
                 PushSubscribeOptions.builder()
                     .stream("KV_" + bucket)


### PR DESCRIPTION
Also...
* removed experimental tag for getFirstMessage
* Reused existing variable on KV create
* cleaned up a key value test