### PR TITLE
Reduce calls to stats by combining.

### DIFF
--- a/src/main/java/io/nats/client/StatisticsCollector.java
+++ b/src/main/java/io/nats/client/StatisticsCollector.java
@@ -82,25 +82,51 @@ public interface StatisticsCollector extends Statistics {
     void incrementOrphanRepliesReceived();
 
     /**
-     * Increments the total number of messages that have come in to this connection.
+     * Increments the total number of messages that have come in to this connection
+     * by 1 AND the number of bytes in the same call.
      */
-    void incrementInMsgs();
+    default void incrementIn(long bytes) {
+        incrementInMsgs();
+        incrementInBytes(bytes);
+    }
 
     /**
      * Increments the total number of messages that have gone out of this connection.
+     * by 1 AND the number of bytes in the same call.
      */
+    default void incrementOut(long bytes) {
+        incrementOutMsgs();
+        incrementOutBytes(bytes);
+    }
+
+    /**
+     * @deprecated Was always called with incrementInBytes. Replaced with incrementIn(long bytes)
+     * Increments the total number of messages that have come in to this connection.
+     */
+    @Deprecated
+    void incrementInMsgs();
+
+    /**
+     * @deprecated Was always called with incrementOutBytes. Replaced with incrementOut(long bytes)
+     * Increments the total number of messages that have gone out of this connection.
+     */
+    @Deprecated
     void incrementOutMsgs();
 
     /**
+     * @deprecated Was always called with incrementIn. Replaced with incrementIn(long bytes)
      * Increment the total number of message bytes that have come in to this connection.
      * @param bytes the number of bytes coming in
      */
+    @Deprecated
     void incrementInBytes(long bytes);
 
     /**
+     * @deprecated Was always called with incrementOut. Replaced with incrementOut(long bytes)
      * Increment the total number of message bytes that have gone out of this connection.
      * @param bytes the number of bytes going out
      */
+    @Deprecated
     void incrementOutBytes(long bytes);
 
     /**

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1834,8 +1834,7 @@ class NatsConnection implements Connection {
 
     void deliverMessage(NatsMessage msg) {
         this.needPing.set(false);
-        this.statistics.incrementInMsgs();
-        this.statistics.incrementInBytes(msg.getSizeInBytes());
+        this.statistics.incrementIn(msg.getSizeInBytes());
 
         NatsSubscription sub = subscribers.get(msg.getSID());
 

--- a/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionWriter.java
@@ -176,8 +176,7 @@ class NatsConnectionWriter implements Runnable {
                     sendBuffer[sendPosition++] = LF;
                 }
 
-                stats.incrementOutMsgs();
-                stats.incrementOutBytes(size);
+                stats.incrementOut(size);
 
                 if (msg.flushImmediatelyAfterPublish) {
                     dataPort.flush();

--- a/src/main/java/io/nats/client/impl/NatsStatistics.java
+++ b/src/main/java/io/nats/client/impl/NatsStatistics.java
@@ -127,6 +127,18 @@ public class NatsStatistics implements StatisticsCollector {
     }
 
     @Override
+    public void incrementIn(long bytes) {
+        this.inMsgs.incrementAndGet();
+        this.inBytes.addAndGet(bytes);
+    }
+
+    @Override
+    public void incrementOut(long bytes) {
+        this.outMsgs.incrementAndGet();
+        this.outBytes.addAndGet(bytes);
+    }
+
+    @Override
     public void incrementInMsgs() {
         this.inMsgs.incrementAndGet();
     }

--- a/src/main/java/io/nats/client/impl/NoOpStatistics.java
+++ b/src/main/java/io/nats/client/impl/NoOpStatistics.java
@@ -27,6 +27,8 @@ public class NoOpStatistics implements StatisticsCollector {
     @Override public void incrementRepliesReceived() {}
     @Override public void incrementDuplicateRepliesReceived() {}
     @Override public void incrementOrphanRepliesReceived() {}
+    @Override public void incrementIn(long bytes) {}
+    @Override public void incrementOut(long bytes) {}
     @Override public void incrementInMsgs() {}
     @Override public void incrementOutMsgs() {}
     @Override public void incrementInBytes(long bytes) {}

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -628,15 +628,20 @@ public class OptionsTests {
 
         Options o = new Options.Builder(props).build();
         assertFalse(o.isVerbose(), "default verbose"); // One from a different type
-        assertNotNull(o.getStatisticsCollector(), "property statistics collector");
 
-        o.getStatisticsCollector().incrementOutMsgs();
-        assertEquals(o.getStatisticsCollector().getOutMsgs(), 1, "property statistics collector class");
+        StatisticsCollector stats = o.getStatisticsCollector();
+        assertNotNull(stats);
+
+        stats.incrementOut(42);
+        assertEquals(1, stats.getOutMsgs());
+        assertEquals(42, stats.getOutBytes());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testStatisticsCoverage() {
         validateStatisticsCollector(new NatsStatistics());
+
         StatisticsCollector stats = new NoOpStatistics();
         stats.setAdvancedTracking(true);
         stats.incrementPingCount();
@@ -653,6 +658,8 @@ public class OptionsTests {
         stats.incrementOutMsgs();
         stats.incrementInBytes(42);
         stats.incrementOutBytes(73);
+        stats.incrementIn(42);
+        stats.incrementOut(73);
         stats.incrementFlushCounter();
         stats.incrementOutstandingRequests();
         stats.decrementOutstandingRequests();

--- a/src/test/java/io/nats/client/impl/CoverageStatisticsCollector.java
+++ b/src/test/java/io/nats/client/impl/CoverageStatisticsCollector.java
@@ -21,14 +21,21 @@ import java.util.concurrent.atomic.AtomicLong;
 public class CoverageStatisticsCollector extends NoOpStatistics {
 
     private final AtomicLong outMsgs = new AtomicLong();
+    private final AtomicLong outBytes = new AtomicLong();
 
     @Override
-    public void incrementOutMsgs() {
+    public void incrementOut(long bytes) {
         outMsgs.incrementAndGet();
+        outBytes.addAndGet(bytes);
     }
 
     @Override
     public long getOutMsgs() {
         return outMsgs.get();
+    }
+
+    @Override
+    public long getOutBytes() {
+        return outBytes.get();
     }
 }


### PR DESCRIPTION
Backward compatible. New interface methods have default implementations which call the old, deprecated methods.