### PR TITLE
Enable path component when connecting via WebSocket

### DIFF
--- a/src/main/java/io/nats/client/impl/SocketDataPort.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPort.java
@@ -55,7 +55,8 @@ public class SocketDataPort implements DataPort {
     public void connect(@NonNull String serverURI, @NonNull NatsConnection conn, long timeoutNanos) throws IOException {
         try {
             connect(conn, new NatsUri(serverURI), timeoutNanos);
-        } catch (URISyntaxException e) {
+        }
+        catch (URISyntaxException e) {
             throw new IOException(e);
         }
     }
@@ -105,12 +106,10 @@ public class SocketDataPort implements DataPort {
             }
             in = socket.getInputStream();
             out = socket.getOutputStream();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             if (socket != null) {
-                try {
-                    socket.close();
-                } catch (Exception ignore) {
-                }
+                try { socket.close(); } catch (Exception ignore) {}
             }
             socket = null;
             if (e instanceof IOException) {
@@ -145,7 +144,8 @@ public class SocketDataPort implements DataPort {
         } catch (Exception ex) {
             connection.handleCommunicationIssue(ex);
             return;
-        } finally {
+        }
+        finally {
             sslSocket.removeHandshakeCompletedListener(hcl);
         }
 
@@ -184,7 +184,8 @@ public class SocketDataPort implements DataPort {
             try {
                 // If we are being asked to force close, there is no need to linger.
                 socket.setSoLinger(true, 0);
-            } catch (SocketException e) {
+            }
+            catch (SocketException e) {
                 // don't want to fail if I couldn't set linger
             }
             close();
@@ -196,7 +197,8 @@ public class SocketDataPort implements DataPort {
     }
 
     protected static boolean isWebsocketScheme(String scheme) {
-        return "ws".equalsIgnoreCase(scheme) || "wss".equalsIgnoreCase(scheme);
+        return "ws".equalsIgnoreCase(scheme) ||
+            "wss".equalsIgnoreCase(scheme);
     }
 
     /**
@@ -204,8 +206,8 @@ public class SocketDataPort implements DataPort {
      * which attempts to connect to multiple IP addresses in parallel to reduce
      * connection setup delays.
      */
-    private Socket connectToFastestIp(Options options, String hostname, int port, int timeoutMillis)
-            throws IOException {
+    private Socket connectToFastestIp(Options options, String hostname, int port,
+                                      int timeoutMillis) throws IOException {
         // Get all IP addresses for the hostname
         List<InetAddress> ips = Arrays.asList(NatsInetAddress.getAllByName(hostname));
 

--- a/src/main/java/io/nats/client/support/WebSocket.java
+++ b/src/main/java/io/nats/client/support/WebSocket.java
@@ -72,14 +72,14 @@ public class WebSocket extends Socket {
         String key = base64BasicEncodeToString(keyBytes);
 
         request.getHeaders()
-               .add("Host", host)
-               .add("Upgrade", "websocket")
-               .add("Connection", "Upgrade")
-               .add("Sec-WebSocket-Key", key)
-               .add("Sec-WebSocket-Protocol", "nats")
-               .add("Sec-WebSocket-Version", "13");
-        // TODO: Support Sec-WebSocket-Extensions: permessage-deflate
-        // TODO: Support Nats-No-Masking: TRUE
+            .add("Host", host)
+            .add("Upgrade", "websocket")
+            .add("Connection", "Upgrade")
+            .add("Sec-WebSocket-Key", key)
+            .add("Sec-WebSocket-Protocol", "nats")
+            .add("Sec-WebSocket-Version", "13");
+            // TODO: Support Sec-WebSocket-Extensions: permessage-deflate
+            // TODO: Support Nats-No-Masking: TRUE
 
         for (Consumer<HttpRequest> interceptor : interceptors) {
             interceptor.accept(request);
@@ -110,18 +110,22 @@ public class WebSocket extends Socket {
                 if (headers.size() >= MAX_HTTP_HEADERS) {
                     throw new IllegalStateException("Exceeded max HTTP headers=" + MAX_HTTP_HEADERS);
                 }
-                headers.put(line.substring(0, colon).trim().toLowerCase(), line.substring(colon + 1).trim());
+                headers.put(
+                    line.substring(0, colon).trim().toLowerCase(),
+                    line.substring(colon + 1).trim());
             } else {
                 throw new IllegalStateException("Expected HTTP header to contain ':', but got " + line);
             }
         }
         // 2. Expect `Upgrade: websocket`
         if (!"websocket".equalsIgnoreCase(headers.get("upgrade"))) {
-            throw new IllegalStateException("Expected HTTP `Upgrade: websocket` header");
+            throw new IllegalStateException(
+                "Expected HTTP `Upgrade: websocket` header");
         }
         // 3. Expect `Connection: Upgrade`
         if (!"upgrade".equalsIgnoreCase(headers.get("connection"))) {
-            throw new IllegalStateException("Expected HTTP `Connection: Upgrade` header");
+            throw new IllegalStateException(
+                "Expected HTTP `Connection: Upgrade` header");
         }
         // 4. Sec-WebSocket-Accept: base64(sha1(key + "258EAF..."))
         MessageDigest sha1;
@@ -136,7 +140,7 @@ public class WebSocket extends Socket {
         String gotAcceptKey = headers.get("sec-websocket-accept");
         if (!acceptKey.equals(gotAcceptKey)) {
             throw new IllegalStateException(
-                    "Expected HTTP `Sec-WebSocket-Accept: " + acceptKey + ", but got " + gotAcceptKey);
+                "Expected HTTP `Sec-WebSocket-Accept: " + acceptKey + ", but got " + gotAcceptKey);
         }
         // 5 & 6 are not valid, since nats-server doesn't
         // implement extensions or protocols.
@@ -153,13 +157,16 @@ public class WebSocket extends Socket {
                 return new String(buffer, 0, offset, StandardCharsets.ISO_8859_1);
             case '\n':
                 // Found \n, remove \r if it is there:
-                return new String(buffer, 0, '\r' == lastCh ? offset - 1 : offset, StandardCharsets.ISO_8859_1);
+                return new String(
+                    buffer,
+                    0,
+                    '\r' == lastCh ? offset - 1 : offset, StandardCharsets.ISO_8859_1);
             }
             // Line length exceeded:
             if (offset >= buffer.length) {
                 return null;
             }
-            buffer[offset++] = (byte) ch;
+            buffer[offset++] = (byte)ch;
             lastCh = ch;
         }
     }
@@ -341,7 +348,8 @@ public class WebSocket extends Socket {
         try {
             // TODO: send websocket close:
             wrappedSocket.close();
-        } finally {
+        }
+        finally {
             closeLock.unlock();
         }
     }


### PR DESCRIPTION
When a WebSocket connection url is specfied via ws://HOST:IP/PATH the PATH will now be included when establishing the connection.

I need help implementing a Test as I have not found a way to define the path in the nats websocket configuration.