### PR TITLE
Fix Claude workflow configuration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,8 +12,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request_target:
-    types: [opened, reopened]
 
 jobs:
   claude:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,22 +1,32 @@
-name: Claude Code Review
+name: Claude Code
 
+# GITHUB_TOKEN needs contents:read and actions:read — required by
+# claude-code-action for restoring trusted config files from the base branch.
+# All other GitHub API access uses the App token.
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
+  actions: read
 
 on:
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_target:
+    types: [opened, reopened]
 
 jobs:
   claude:
     uses: synadia-io/ai-workflows/.github/workflows/claude.yml@v2
     with:
       gh_app_id: ${{ vars.CLAUDE_GH_APP_ID }}
+      checkout_mode: base
+      review_focus: |
+        Additionally focus on:
+        - Thread safety and proper synchronization (concurrent access, connection lifecycle)
+        - Exception handling patterns (checked vs unchecked, proper resource cleanup with try-with-resources)
+        - JetStream API correctness (subscription semantics, ack/nak behavior, consumer configuration)
+        - API compatibility with existing public interfaces
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
       gh_app_private_key: ${{ secrets.CLAUDE_GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Fix GITHUB_TOKEN permissions: remove excessive `pull-requests: write`, `issues: write`, `id-token: write`; add required `actions: read`
- Add missing `pull_request_target` trigger for automatic PR reviews
- Add `checkout_mode: base` for safer fork reviews
- Add Java-specific `review_focus` areas
- Align with the standard pattern used in ConnectEverything/insights and other nats-io repos

## Changes
- Permissions: `contents: read, pull-requests: write, issues: write, id-token: write` → `contents: read, actions: read`
- Added `pull_request_target: types: [opened, reopened]` trigger
- Added `checkout_mode: base`
- Added `review_focus` with Java-specific review areas
- Renamed workflow from "Claude Code Review" to "Claude Code" for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)