### PR TITLE
JetStreamStatusException: fix 'occured' -> 'occurred' in Javadoc

### DIFF
--- a/src/main/java/io/nats/client/JetStreamStatusException.java
+++ b/src/main/java/io/nats/client/JetStreamStatusException.java
@@ -25,7 +25,7 @@ public class JetStreamStatusException extends IllegalStateException {
     public static final String DEFAULT_DESCRIPTION = "Unknown or unprocessed status message";
 
     /**
-     * The subscription that this exception occured on
+     * The subscription that this exception occurred on
      */
     private final JetStreamSubscription sub;
 


### PR DESCRIPTION
Javadoc comment in `src/main/java/io/nats/client/JetStreamStatusException.java` line 28 reads `this exception occured on`. Fixed to `occurred`. Comment-only change.