### PR TITLE
Reconnect Delay Behavior and options cleanup

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -272,6 +272,62 @@ public class Options {
          * Strict Subject Validation
          */
         Strict;
+
+        /**
+         * Resolve a {@link SubjectValidationType} from a string (case-insensitive name match).
+         * Returns {@link #Lenient} if the value is null or does not match any constant.
+         *
+         * @param value the string value
+         * @return the matching behavior, or {@link #Lenient} as the default
+         */
+        public static SubjectValidationType get(String value) {
+            if (value != null) {
+                for (SubjectValidationType svt : SubjectValidationType.values()) {
+                    if (svt.name().equalsIgnoreCase(value)) {
+                        return svt;
+                    }
+                }
+            }
+            return Lenient;
+        }
+    }
+
+    /**
+     * Whether subject strings should be validated against naming rules,
+     * and the level of subject validation.
+     */
+    public enum ReconnectDelayBehavior {
+        /**
+         * Invoke reconnect delay behavior as has been done up until now,
+         * only after a full round of reconnect attempts has occurred and failed.
+         * {@link ReconnectDelayHandler#getWaitTime(long)} will only be called with
+         * {@code totalTries} greater than or equal to 1.
+         */
+        Legacy,
+        /**
+         * Invoke reconnect delay behavior before each full round of reconnect attempts.
+         * {@link ReconnectDelayHandler#getWaitTime(long)} will be called with
+         * {@code totalTries} greater than or equal to 0.
+         */
+        Every;
+
+        /**
+         * Resolve a {@link ReconnectDelayBehavior} from a string (case-insensitive name match).
+         * Returns {@link #Legacy} if the value is null or does not match any constant.
+         *
+         * @param value the string value
+         * @return the matching behavior, or {@link #Legacy} as the default
+         */
+        public static ReconnectDelayBehavior get(String value) {
+            if (value != null) {
+                for (ReconnectDelayBehavior rdb : ReconnectDelayBehavior.values()) {
+                    if (rdb.name().equalsIgnoreCase(value)) {
+                        return rdb;
+                    }
+                }
+            }
+            return Legacy;
+        }
     }
 
     /**
@@ -440,6 +496,16 @@ public class Options {
      */
     public static final String PROP_RECONNECT_JITTER_TLS = PFX + "reconnect.jitter.tls";
     /**
+     * Property used to set class name for the ReconnectDelayHandler implementation
+     * {@link Builder#reconnectDelayHandler(ReconnectDelayHandler) reconnectDelayHandler}.
+     */
+    public static final String PROP_RECONNECT_DELAY_HANDLER_CLASS = "reconnect.delay.handler.class";
+    /**
+     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#reconnectDelayBehavior(ReconnectDelayBehavior)
+     * reconnectDelayBehavior}. Value is the name of a {@link ReconnectDelayBehavior} constant (e.g. {@code Legacy}, {@code Every}).
+     */
+    public static final String PROP_RECONNECT_DELAY_BEHAVIOR = PFX + "reconnect.delay.behavior";
+    /**
      * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#pedantic() pedantic}.
      */
     public static final String PROP_PEDANTIC = PFX + "pedantic";
@@ -487,13 +553,28 @@ public class Options {
      */
     public static final String PROP_HOSTNAME_RESOLVE_MODE = PFX + "hostnameResolveMode";
     /**
-     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#noSubjectValidation() noSubjectValidation}.
+     * Property used to configure a builder from a Properties object. {@value}, when {@code true} sets the
+     * {@link SubjectValidationType} to {@link SubjectValidationType#None}. See {@link Builder#noSubjectValidation() noSubjectValidation}.
+     * @deprecated use {@link #PROP_SUBJECT_VALIDATION_TYPE} with value {@code None} instead
      */
+    @Deprecated
     public static final String PROP_NO_SUBJECT_VALIDATION = PFX + "noSubjectValidation";
     /**
-     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#noSubjectValidation() noSubjectValidation}.
+     * Property used to configure a builder from a Properties object. {@value}, when {@code true} sets the
+     * {@link SubjectValidationType} to {@link SubjectValidationType#Strict}. See {@link Builder#strictSubjectValidation() strictSubjectValidation}.
+     * @deprecated use {@link #PROP_SUBJECT_VALIDATION_TYPE} with value {@code Strict} instead
      */
+    @Deprecated
     public static final String PROP_STRICT_SUBJECT_VALIDATION = PFX + "strictSubjectValidation";
+    /**
+     * Property used to configure a builder from a Properties object. {@value}, sets the
+     * {@link SubjectValidationType} used to validate subjects. Value is the case-insensitive name
+     * of a {@link SubjectValidationType} constant (e.g. {@code None}, {@code Lenient}, {@code Strict}).
+     * Unrecognized or missing values fall back to {@link SubjectValidationType#Lenient}.
+     * Processed after {@link #PROP_NO_SUBJECT_VALIDATION} and {@link #PROP_STRICT_SUBJECT_VALIDATION},
+     * so when set this property takes precedence over those legacy boolean properties.
+     */
+    public static final String PROP_SUBJECT_VALIDATION_TYPE = PFX + "subjectValidationType";
     /**
      * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#reportNoResponders() reportNoResponders}.
      */
@@ -821,6 +902,7 @@ public class Options {
 
     private final AuthHandler authHandler;
     private final ReconnectDelayHandler reconnectDelayHandler;
+    private final ReconnectDelayBehavior reconnectDelayBehavior;
 
     private final ErrorListener errorListener;
     private final TimeTraceLogger timeTraceLogger;
@@ -987,6 +1069,7 @@ public class Options {
 
         private AuthHandler authHandler;
         private ReconnectDelayHandler reconnectDelayHandler;
+        private ReconnectDelayBehavior reconnectDelayBehavior = ReconnectDelayBehavior.Legacy;
 
         private ErrorListener errorListener = null;
         private TimeTraceLogger timeTraceLogger = null;
@@ -1085,6 +1168,8 @@ public class Options {
             booleanProperty(props, PROP_NORANDOMIZE, b -> this.noRandomize = b);
             booleanPropertyIfTrue(props, PROP_NO_SUBJECT_VALIDATION, b -> subjectValidationType = SubjectValidationType.None);
             booleanPropertyIfTrue(props, PROP_STRICT_SUBJECT_VALIDATION, b -> subjectValidationType = SubjectValidationType.Strict);
+            stringProperty(props, PROP_SUBJECT_VALIDATION_TYPE, s -> this.subjectValidationType = SubjectValidationType.get(s));
+
             booleanProperty(props, PROP_REPORT_NO_RESPONDERS, b -> this.reportNoResponders = b);
 
             stringProperty(props, PROP_CONNECTION_NAME, s -> this.connectionName = s);
@@ -1101,6 +1186,9 @@ public class Options {
             durationProperty(props, PROP_RECONNECT_JITTER, d -> this.reconnectJitter = d);
             durationProperty(props, PROP_RECONNECT_JITTER_TLS, d -> this.reconnectJitterTls = d);
             longProperty(props, PROP_RECONNECT_BUF_SIZE, l -> this.reconnectBufferSize = l);
+
+            classnameProperty(props, PROP_RECONNECT_DELAY_HANDLER_CLASS, o -> this.reconnectDelayHandler = (ReconnectDelayHandler) o);
+            stringProperty(props, PROP_RECONNECT_DELAY_BEHAVIOR, s -> this.reconnectDelayBehavior = ReconnectDelayBehavior.get(s));
             durationProperty(props, PROP_CONNECTION_TIMEOUT, d -> this.connectionTimeout = d);
             intProperty(props, PROP_SOCKET_READ_TIMEOUT_MS, i -> this.socketReadTimeoutMillis = i);
             durationProperty(props, PROP_SOCKET_WRITE_TIMEOUT, d -> this.socketWriteTimeout = d);
@@ -1259,7 +1347,9 @@ public class Options {
          * Fastest validation, but use with caution
          * If you know your subjects are always valid.
          * @return the Builder for chaining
+         * @deprecated use {@link #subjectValidationType(SubjectValidationType)} with {@link SubjectValidationType#None} instead
          */
+        @Deprecated
         public Builder noSubjectValidation() {
             this.subjectValidationType = SubjectValidationType.None;
             return this;
@@ -1271,7 +1361,9 @@ public class Options {
          * Slower validation, but may be useful when exposing the ability
          * of an application user to set a subject.
          * @return the Builder for chaining
+         * @deprecated use {@link #subjectValidationType(SubjectValidationType)} with {@link SubjectValidationType#Strict} instead
          */
+        @Deprecated
         public Builder strictSubjectValidation() {
             this.subjectValidationType = SubjectValidationType.Strict;
             return this;
@@ -1868,6 +1960,19 @@ public class Options {
         }
 
         /**
+         * Set the {@link ReconnectDelayBehavior ReconnectDelayBehavior} that controls when the
+         * {@link ReconnectDelayHandler} is invoked during reconnect attempts. Defaults to
+         * {@link ReconnectDelayBehavior#Legacy}. A null value resets to {@link ReconnectDelayBehavior#Legacy}.
+         *
+         * @param reconnectDelayBehavior the behavior
+         * @return the Builder for chaining
+         */
+        public Builder reconnectDelayBehavior(ReconnectDelayBehavior reconnectDelayBehavior) {
+            this.reconnectDelayBehavior = reconnectDelayBehavior == null ? ReconnectDelayBehavior.Legacy : reconnectDelayBehavior;
+            return this;
+        }
+
+        /**
          * Set the {@link ErrorListener ErrorListener} to receive asynchronous error events related to this
          * connection.
          *
@@ -2347,6 +2452,7 @@ public class Options {
 
             this.authHandler = o.authHandler;
             this.reconnectDelayHandler = o.reconnectDelayHandler;
+            this.reconnectDelayBehavior = o.reconnectDelayBehavior;
 
             this.errorListener = o.errorListener;
             this.timeTraceLogger = o.timeTraceLogger;
@@ -2424,6 +2530,7 @@ public class Options {
 
         this.authHandler = b.authHandler;
         this.reconnectDelayHandler = b.reconnectDelayHandler;
+        this.reconnectDelayBehavior = b.reconnectDelayBehavior;
 
         this.errorListener = b.errorListener;
         this.timeTraceLogger = b.timeTraceLogger;
@@ -2732,6 +2839,14 @@ public class Options {
      */
     public ReconnectDelayHandler getReconnectDelayHandler() {
         return this.reconnectDelayHandler;
+    }
+
+    /**
+     * the reconnect delay behavior, see {@link Builder#reconnectDelayBehavior(ReconnectDelayBehavior) reconnectDelayBehavior()} in the builder doc
+     * @return the behavior, never null (defaults to {@link ReconnectDelayBehavior#Legacy})
+     */
+    public ReconnectDelayBehavior reconnectDelayBehavior() {
+        return this.reconnectDelayBehavior;
     }
 
     /**

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -293,30 +293,30 @@ public class Options {
     }
 
     /**
-     * Whether subject strings should be validated against naming rules,
-     * and the level of subject validation.
+     * Controls when the {@link ReconnectDelayHandler} is invoked during reconnect attempts.
      */
     public enum ReconnectDelayBehavior {
         /**
-         * Invoke reconnect delay behavior as has been done up until now,
-         * only after a full round of reconnect attempts has occurred and failed.
+         * Invoke the reconnect delay only before subsequent rounds, never before the first round.
+         * The first round of reconnect attempts runs immediately; the delay applies between rounds
+         * after a full round has been attempted and failed. This is the historical default.
          * {@link ReconnectDelayHandler#getWaitTime(long)} will only be called with
          * {@code totalTries} greater than or equal to 1.
          */
-        Legacy,
+        BeforeSubsequentRounds,
         /**
          * Invoke reconnect delay behavior before each full round of reconnect attempts.
          * {@link ReconnectDelayHandler#getWaitTime(long)} will be called with
          * {@code totalTries} greater than or equal to 0.
          */
-        Every;
+        BeforeAllRounds;
 
         /**
          * Resolve a {@link ReconnectDelayBehavior} from a string (case-insensitive name match).
-         * Returns {@link #Legacy} if the value is null or does not match any constant.
+         * Returns {@link #BeforeSubsequentRounds} if the value is null or does not match any constant.
          *
          * @param value the string value
-         * @return the matching behavior, or {@link #Legacy} as the default
+         * @return the matching behavior, or {@link #BeforeSubsequentRounds} as the default
          */
         public static ReconnectDelayBehavior get(String value) {
             if (value != null) {
@@ -326,7 +326,7 @@ public class Options {
                     }
                 }
             }
-            return Legacy;
+            return BeforeSubsequentRounds;
         }
     }
 
@@ -499,10 +499,10 @@ public class Options {
      * Property used to set class name for the ReconnectDelayHandler implementation
      * {@link Builder#reconnectDelayHandler(ReconnectDelayHandler) reconnectDelayHandler}.
      */
-    public static final String PROP_RECONNECT_DELAY_HANDLER_CLASS = "reconnect.delay.handler.class";
+    public static final String PROP_RECONNECT_DELAY_HANDLER_CLASS = PFX + "reconnect.delay.handler.class";
     /**
      * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#reconnectDelayBehavior(ReconnectDelayBehavior)
-     * reconnectDelayBehavior}. Value is the name of a {@link ReconnectDelayBehavior} constant (e.g. {@code Legacy}, {@code Every}).
+     * reconnectDelayBehavior}. Value is the name of a {@link ReconnectDelayBehavior} constant (e.g. {@code BeforeSubsequentRounds}, {@code BeforeAllRounds}).
      */
     public static final String PROP_RECONNECT_DELAY_BEHAVIOR = PFX + "reconnect.delay.behavior";
     /**
@@ -1069,7 +1069,7 @@ public class Options {
 
         private AuthHandler authHandler;
         private ReconnectDelayHandler reconnectDelayHandler;
-        private ReconnectDelayBehavior reconnectDelayBehavior = ReconnectDelayBehavior.Legacy;
+        private ReconnectDelayBehavior reconnectDelayBehavior = ReconnectDelayBehavior.BeforeSubsequentRounds;
 
         private ErrorListener errorListener = null;
         private TimeTraceLogger timeTraceLogger = null;
@@ -1962,13 +1962,13 @@ public class Options {
         /**
          * Set the {@link ReconnectDelayBehavior ReconnectDelayBehavior} that controls when the
          * {@link ReconnectDelayHandler} is invoked during reconnect attempts. Defaults to
-         * {@link ReconnectDelayBehavior#Legacy}. A null value resets to {@link ReconnectDelayBehavior#Legacy}.
+         * {@link ReconnectDelayBehavior#BeforeSubsequentRounds}. A null value resets to {@link ReconnectDelayBehavior#BeforeSubsequentRounds}.
          *
          * @param reconnectDelayBehavior the behavior
          * @return the Builder for chaining
          */
         public Builder reconnectDelayBehavior(ReconnectDelayBehavior reconnectDelayBehavior) {
-            this.reconnectDelayBehavior = reconnectDelayBehavior == null ? ReconnectDelayBehavior.Legacy : reconnectDelayBehavior;
+            this.reconnectDelayBehavior = reconnectDelayBehavior == null ? ReconnectDelayBehavior.BeforeSubsequentRounds : reconnectDelayBehavior;
             return this;
         }
 
@@ -2843,7 +2843,7 @@ public class Options {
 
     /**
      * the reconnect delay behavior, see {@link Builder#reconnectDelayBehavior(ReconnectDelayBehavior) reconnectDelayBehavior()} in the builder doc
-     * @return the behavior, never null (defaults to {@link ReconnectDelayBehavior#Legacy})
+     * @return the behavior, never null (defaults to {@link ReconnectDelayBehavior#BeforeSubsequentRounds})
      */
     public ReconnectDelayBehavior reconnectDelayBehavior() {
         return this.reconnectDelayBehavior;

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -446,6 +446,9 @@ class NatsConnection implements Connection {
         while ((cur = serverPool.nextServer()) != null) {
             if (first == null) {
                 first = cur;
+                if (options.reconnectDelayBehavior() == Options.ReconnectDelayBehavior.Every) {
+                    invokeReconnectDelayHandler(0);
+                }
             }
             else if (first.equals(cur)) {
                 // went around the pool an entire time

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -446,7 +446,7 @@ class NatsConnection implements Connection {
         while ((cur = serverPool.nextServer()) != null) {
             if (first == null) {
                 first = cur;
-                if (options.reconnectDelayBehavior() == Options.ReconnectDelayBehavior.Every) {
+                if (options.reconnectDelayBehavior() == Options.ReconnectDelayBehavior.BeforeAllRounds) {
                     invokeReconnectDelayHandler(0);
                 }
             }

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -724,6 +724,48 @@ public class OptionsTests {
         o = new Options.Builder(props).build();
         assertEquals(SubjectValidationType.Strict, o.subjectValidationType());
 
+        // PROP_SUBJECT_VALIDATION_TYPE — case-insensitive enum name match for each value
+        props.clear();
+        props.setProperty(Options.PROP_SUBJECT_VALIDATION_TYPE, "None");
+        o = new Options.Builder(props).build();
+        assertEquals(SubjectValidationType.None, o.subjectValidationType());
+
+        props.clear();
+        props.setProperty(Options.PROP_SUBJECT_VALIDATION_TYPE, "lenient");
+        o = new Options.Builder(props).build();
+        assertEquals(SubjectValidationType.Lenient, o.subjectValidationType());
+
+        props.clear();
+        props.setProperty(Options.PROP_SUBJECT_VALIDATION_TYPE, "STRICT");
+        o = new Options.Builder(props).build();
+        assertEquals(SubjectValidationType.Strict, o.subjectValidationType());
+
+        // Unrecognized value falls back to Lenient
+        props.clear();
+        props.setProperty(Options.PROP_SUBJECT_VALIDATION_TYPE, "garbage");
+        o = new Options.Builder(props).build();
+        assertEquals(SubjectValidationType.Lenient, o.subjectValidationType());
+
+        // PROP_SUBJECT_VALIDATION_TYPE is processed last, so it wins over the legacy booleans
+        props.clear();
+        props.setProperty(Options.PROP_NO_SUBJECT_VALIDATION, "true");
+        props.setProperty(Options.PROP_SUBJECT_VALIDATION_TYPE, "Strict");
+        o = new Options.Builder(props).build();
+        assertEquals(SubjectValidationType.Strict, o.subjectValidationType());
+
+        props.clear();
+        props.setProperty(Options.PROP_STRICT_SUBJECT_VALIDATION, "true");
+        props.setProperty(Options.PROP_SUBJECT_VALIDATION_TYPE, "None");
+        o = new Options.Builder(props).build();
+        assertEquals(SubjectValidationType.None, o.subjectValidationType());
+
+        // SubjectValidationType.get direct coverage
+        assertEquals(SubjectValidationType.None, SubjectValidationType.get("none"));
+        assertEquals(SubjectValidationType.Lenient, SubjectValidationType.get("Lenient"));
+        assertEquals(SubjectValidationType.Strict, SubjectValidationType.get("STRICT"));
+        assertEquals(SubjectValidationType.Lenient, SubjectValidationType.get(null));
+        assertEquals(SubjectValidationType.Lenient, SubjectValidationType.get("garbage"));
+
         o = new Options.Builder().build();
         assertEquals(SubjectValidationType.Lenient, o.subjectValidationType());
 
@@ -732,6 +774,77 @@ public class OptionsTests {
 
         o = new Options.Builder().strictSubjectValidation().build();
         assertEquals(SubjectValidationType.Strict, o.subjectValidationType());
+
+        // Builder.subjectValidationType — all three values plus null reset
+        o = new Options.Builder().subjectValidationType(SubjectValidationType.None).build();
+        assertEquals(SubjectValidationType.None, o.subjectValidationType());
+
+        o = new Options.Builder().subjectValidationType(SubjectValidationType.Lenient).build();
+        assertEquals(SubjectValidationType.Lenient, o.subjectValidationType());
+
+        o = new Options.Builder().subjectValidationType(SubjectValidationType.Strict).build();
+        assertEquals(SubjectValidationType.Strict, o.subjectValidationType());
+
+        // null resets to Lenient
+        o = new Options.Builder().subjectValidationType(SubjectValidationType.Strict)
+            .subjectValidationType(null).build();
+        assertEquals(SubjectValidationType.Lenient, o.subjectValidationType());
+    }
+
+    @Test
+    public void testReconnectDelayBehavior() {
+        // default
+        Options o = new Options.Builder().build();
+        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+
+        // builder set explicitly
+        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.Legacy).build();
+        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+
+        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.Every).build();
+        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+
+        // null resets to Legacy
+        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.Every)
+            .reconnectDelayBehavior(null).build();
+        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+
+        // via properties — case-insensitive enum name match
+        Properties props = new Properties();
+        o = new Options.Builder(props).build();
+        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+
+        props.clear();
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "Legacy");
+        o = new Options.Builder(props).build();
+        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+
+        props.clear();
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "Every");
+        o = new Options.Builder(props).build();
+        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+
+        props.clear();
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "every");
+        o = new Options.Builder(props).build();
+        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+
+        props.clear();
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "EVERY");
+        o = new Options.Builder(props).build();
+        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+
+        // unrecognized value falls back to Legacy
+        props.clear();
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "garbage");
+        o = new Options.Builder(props).build();
+        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+
+        // ReconnectDelayBehavior.get direct coverage
+        assertEquals(ReconnectDelayBehavior.Legacy, ReconnectDelayBehavior.get("legacy"));
+        assertEquals(ReconnectDelayBehavior.Every, ReconnectDelayBehavior.get("EVERY"));
+        assertEquals(ReconnectDelayBehavior.Legacy, ReconnectDelayBehavior.get(null));
+        assertEquals(ReconnectDelayBehavior.Legacy, ReconnectDelayBehavior.get("garbage"));
     }
 
     @Test

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -795,56 +795,56 @@ public class OptionsTests {
     public void testReconnectDelayBehavior() {
         // default
         Options o = new Options.Builder().build();
-        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, o.reconnectDelayBehavior());
 
         // builder set explicitly
-        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.Legacy).build();
-        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.BeforeSubsequentRounds).build();
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, o.reconnectDelayBehavior());
 
-        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.Every).build();
-        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.BeforeAllRounds).build();
+        assertEquals(ReconnectDelayBehavior.BeforeAllRounds, o.reconnectDelayBehavior());
 
-        // null resets to Legacy
-        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.Every)
+        // null resets to BeforeSubsequentRounds (default)
+        o = new Options.Builder().reconnectDelayBehavior(ReconnectDelayBehavior.BeforeAllRounds)
             .reconnectDelayBehavior(null).build();
-        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, o.reconnectDelayBehavior());
 
         // via properties — case-insensitive enum name match
         Properties props = new Properties();
         o = new Options.Builder(props).build();
-        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, o.reconnectDelayBehavior());
 
         props.clear();
-        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "Legacy");
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "BeforeSubsequentRounds");
         o = new Options.Builder(props).build();
-        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, o.reconnectDelayBehavior());
 
         props.clear();
-        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "Every");
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "BeforeAllRounds");
         o = new Options.Builder(props).build();
-        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeAllRounds, o.reconnectDelayBehavior());
 
         props.clear();
-        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "every");
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "beforeallrounds");
         o = new Options.Builder(props).build();
-        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeAllRounds, o.reconnectDelayBehavior());
 
         props.clear();
-        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "EVERY");
+        props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "BEFOREALLROUNDS");
         o = new Options.Builder(props).build();
-        assertEquals(ReconnectDelayBehavior.Every, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeAllRounds, o.reconnectDelayBehavior());
 
-        // unrecognized value falls back to Legacy
+        // unrecognized value falls back to BeforeSubsequentRounds (default)
         props.clear();
         props.setProperty(Options.PROP_RECONNECT_DELAY_BEHAVIOR, "garbage");
         o = new Options.Builder(props).build();
-        assertEquals(ReconnectDelayBehavior.Legacy, o.reconnectDelayBehavior());
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, o.reconnectDelayBehavior());
 
         // ReconnectDelayBehavior.get direct coverage
-        assertEquals(ReconnectDelayBehavior.Legacy, ReconnectDelayBehavior.get("legacy"));
-        assertEquals(ReconnectDelayBehavior.Every, ReconnectDelayBehavior.get("EVERY"));
-        assertEquals(ReconnectDelayBehavior.Legacy, ReconnectDelayBehavior.get(null));
-        assertEquals(ReconnectDelayBehavior.Legacy, ReconnectDelayBehavior.get("garbage"));
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, ReconnectDelayBehavior.get("beforesubsequentrounds"));
+        assertEquals(ReconnectDelayBehavior.BeforeAllRounds, ReconnectDelayBehavior.get("BEFOREALLROUNDS"));
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, ReconnectDelayBehavior.get(null));
+        assertEquals(ReconnectDelayBehavior.BeforeSubsequentRounds, ReconnectDelayBehavior.get("garbage"));
     }
 
     @Test
@@ -1417,6 +1417,21 @@ public class OptionsTests {
 
         assertNotNull(rdhO);
         assertEquals(10, rdhO.getWaitTime(5).getSeconds());
+
+        // PROP_RECONNECT_DELAY_HANDLER_CLASS — instantiate by class name
+        Properties props = new Properties();
+        props.setProperty(Options.PROP_RECONNECT_DELAY_HANDLER_CLASS,
+            "io.nats.client.utils.CoverageReconnectDelayHandler");
+        o = new Options.Builder(props).build();
+        rdhO = o.getReconnectDelayHandler();
+        assertNotNull(rdhO);
+        assertInstanceOf(io.nats.client.utils.CoverageReconnectDelayHandler.class, rdhO);
+        assertEquals(7, rdhO.getWaitTime(7).toMillis());
+
+        // bad classname surfaces as IllegalArgumentException at build time
+        Properties badProps = new Properties();
+        badProps.setProperty(Options.PROP_RECONNECT_DELAY_HANDLER_CLASS, "does.not.Exist");
+        assertThrows(IllegalArgumentException.class, () -> new Options.Builder(badProps).build());
     }
 
     @Test

--- a/src/test/java/io/nats/client/utils/CoverageReconnectDelayHandler.java
+++ b/src/test/java/io/nats/client/utils/CoverageReconnectDelayHandler.java
@@ -1,0 +1,29 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.utils;
+
+import io.nats.client.ReconnectDelayHandler;
+
+import java.time.Duration;
+
+/**
+ * Concrete ReconnectDelayHandler used to test setting it via PROP_RECONNECT_DELAY_HANDLER_CLASS.
+ * Requires a public no-arg constructor for reflective instantiation.
+ */
+public class CoverageReconnectDelayHandler implements ReconnectDelayHandler {
+    @Override
+    public Duration getWaitTime(long totalTries) {
+        return Duration.ofMillis(totalTries);
+    }
+}


### PR DESCRIPTION
* adds the new ReconnectDelayBehavior enum (BeforeSubsequentRounds default, BeforeAllRounds new) wired into NatsConnection's reconnect loop
* add the PROP_RECONNECT_DELAY_HANDLER_CLASS and PROP_RECONNECT_DELAY_BEHAVIOR properties. 
* adds SubjectValidationType.get(String) and the PROP_SUBJECT_VALIDATION_TYPE property
  * deprecates PROP_NO_SUBJECT_VALIDATION / PROP_STRICT_SUBJECT_VALIDATION and the corresponding builder methods. 
* Includes OptionsTests coverage and a CoverageReconnectDelayHandler test utility.