### PR TITLE
Advanced Request Behavior Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,12 @@
 gnatsd.log
 *.csv
 examples/**/Z*.java
+**/examples/z/**
+**/examples/testapp_mc/**
 **/Debug*.java
+.claude/**
+env.bat
+**/TestDebugger*
 
 # Compiled source #
 ###################

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ Behavior and Benchmark over 37 million passes...
 
 This release adds an opt-in connection option, `advancedRequestBehavior`, that surfaces *why* a request
 came back without a response instead of the generic timeout. The detail is a classified
-`RequestFailureReason` — one of `TIMEOUT`, `CONNECTION_CLOSING`, `NO_RESPONDERS`, `PROTOCOL_ERROR`, or
-`CANCELLED` — plus the connection status, the last protocol error, how long the request waited, and the
-original exception chained as the cause, so you can tell a real timeout apart from a reconnect, a
-permissions error, or no stream on the subject.
+`RequestFailureReason` — one of `TIMEOUT`, `CONNECTION_CLOSING`, `NO_RESPONDERS`, `SERVER_ERROR`, or
+`CANCELLED` — plus the connection status, the last server error, and the original exception chained as
+the cause, so you can tell a real timeout apart from a reconnect, a permissions error, or no stream on
+the subject.
 
 It applies to both request styles:
 - **JetStream** requests (publish, stream/consumer management) throw a `RequestFailureException` in
@@ -212,9 +212,8 @@ try {
     js.publish("subject", data);
 }
 catch (RequestFailureException e) {
-    // e.getReason(), e.getConnectionStatus(), e.getWaited(), e.getLastError(), e.getCause()
-    log.warn("publish failed: {} (status={}, waited={})",
-        e.getReason(), e.getConnectionStatus(), e.getWaited());
+    // e.getReason(), e.getConnectionStatus(), e.getLastError(), e.getCause()
+    log.warn("publish failed: {} (status={})", e.getReason(), e.getConnectionStatus());
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,57 @@ Behavior and Benchmark over 37 million passes...
 
 ## Recent Version Notes
 
+### Version 2.26.0 Advanced Request Behavior
+
+This release adds an opt-in connection option, `advancedRequestBehavior`, that surfaces *why* a request
+came back without a response instead of the generic timeout. The detail is a classified
+`RequestFailureReason` — one of `TIMEOUT`, `CONNECTION_CLOSING`, `NO_RESPONDERS`, `PROTOCOL_ERROR`, or
+`CANCELLED` — plus the connection status, the last protocol error, how long the request waited, and the
+original exception chained as the cause, so you can tell a real timeout apart from a reconnect, a
+permissions error, or no stream on the subject.
+
+It applies to both request styles:
+- **JetStream** requests (publish, stream/consumer management) throw a `RequestFailureException` in
+  place of the generic `IOException("Timeout or no response waiting for NATS JetStream server")`.
+- **Core** `Connection.request(...)` returns a `RequestFailureMessage` (which *is* a `Message`) instead
+  of `null`, which you can inspect for the same detail.
+
+The option is off by default; existing behavior is unchanged unless you enable in the connection options.
+
+```java
+Options options = Options.builder()
+    .server("nats://localhost:4222")
+    .advancedRequestBehavior()
+    .build();
+```
+
+For JetStream, catch the typed exception and branch on the reason:
+
+```java
+try {
+    js.publish("subject", data);
+}
+catch (RequestFailureException e) {
+    // e.getReason(), e.getConnectionStatus(), e.getWaited(), e.getLastError(), e.getCause()
+    log.warn("publish failed: {} (status={}, waited={})",
+        e.getReason(), e.getConnectionStatus(), e.getWaited());
+}
+```
+
+For a core request, the message will never be null. It will either be the response message or will be a RequestFailureMessage. You must inspect the returned message:
+
+```java
+Message m = nc.request("subject", data, Duration.ofSeconds(2));
+if (m instanceof RequestFailureMessage) {
+    RequestFailureMessage rfm = (RequestFailureMessage)m;
+    log.warn("request failed: {} (status={})", rfm.getReason(), rfm.getConnectionStatus());
+}
+```
+
+The two paths are distinct: a JetStream request **throws** `RequestFailureException` (which extends
+`IOException`, so existing `catch (IOException)` blocks keep working), while a core `request(...)`
+**returns** the `RequestFailureMessage` — it does not throw.
+
 ### Version 2.21.2
 
 Starting with 2.21.2 snapshots, the project has been migrated to Sonatype's Maven Central Repository. 
@@ -543,6 +594,7 @@ assertEquals(8000, o.getMaxMessagesInOutgoingQueue());
 | credential.path                   | Property used to set the path to a credentials file to be used in a FileAuthHandler  |
 | tls.first                         | Property used to set TLS Handshake First behavior                                    |
 | use.timeout.exception             | Instruct the client to throw TimeoutException instead of CancellationException       |
+| advanced.request.behavior         | Surface a specific RequestFailureException (reason, status, last error) on no reply |
 | use.dispatcher.with.executor      | Instruct dispatchers to dispatch all messages as a task                              |
 | force.flush.on.request            | When makeing a core request, send the message as soon as it's first in the queue     |
 | executor.service.class            | Property used to set class name for the main executor                                |

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id("signing")
 }
 
-def jarVersion = "2.25.4"
+def jarVersion = "2.60.0"
 group = 'io.nats'
 
 def isRelease = System.getenv("BUILD_EVENT") == "release"

--- a/src/main/java/io/nats/client/Connection.java
+++ b/src/main/java/io/nats/client/Connection.java
@@ -309,7 +309,10 @@ public interface Connection extends AutoCloseable {
      * @param subject the subject for the service that will handle the request
      * @param body the content of the message
      * @param timeout the time to wait for a response
-     * @return the reply message or null if the timeout is reached
+     * @return the reply message; or {@code null} if no response is received before the timeout. When
+     *         {@link Options.Builder#advancedRequestBehavior() advancedRequestBehavior} is enabled a
+     *         no-response instead returns a {@link RequestFailureMessage} (which is a {@code Message})
+     *         describing why the request failed, rather than {@code null}.
      * @throws InterruptedException if one is thrown while waiting, in order to propagate it up
      */
     @Nullable
@@ -324,7 +327,10 @@ public interface Connection extends AutoCloseable {
      * @param headers Optional headers to publish with the message.
      * @param body the content of the message
      * @param timeout the time to wait for a response
-     * @return the reply message or null if the timeout is reached
+     * @return the reply message; or {@code null} if no response is received before the timeout. When
+     *         {@link Options.Builder#advancedRequestBehavior() advancedRequestBehavior} is enabled a
+     *         no-response instead returns a {@link RequestFailureMessage} (which is a {@code Message})
+     *         describing why the request failed, rather than {@code null}.
      * @throws InterruptedException if one is thrown while waiting, in order to propagate it up
      */
     @Nullable
@@ -341,7 +347,10 @@ public interface Connection extends AutoCloseable {
      *
      * @param message the message
      * @param timeout the time to wait for a response
-     * @return the reply message or null if the timeout is reached
+     * @return the reply message; or {@code null} if no response is received before the timeout. When
+     *         {@link Options.Builder#advancedRequestBehavior() advancedRequestBehavior} is enabled a
+     *         no-response instead returns a {@link RequestFailureMessage} (which is a {@code Message})
+     *         describing why the request failed, rather than {@code null}.
      * @throws InterruptedException if one is thrown while waiting, in order to propagate it up
      */
     @Nullable

--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -718,6 +718,10 @@ public class Options {
      */
     public static final String PROP_USE_TIMEOUT_EXCEPTION = PFX + "use.timeout.exception";
     /**
+     * Property used to enable advanced request behavior, see {@link Builder#advancedRequestBehavior()}.
+     */
+    public static final String PROP_ADVANCED_REQUEST_BEHAVIOR = PFX + "advanced.request.behavior";
+    /**
      * Property used to a dispatcher that dispatches messages via the executor service instead of with a blocking call.
      * {@link Builder#useDispatcherWithExecutor()}.
      */
@@ -897,6 +901,7 @@ public class Options {
     private final boolean ignoreDiscoveredServers;
     private final boolean tlsFirst;
     private final boolean useTimeoutException;
+    private final boolean advancedRequestBehavior;
     private final boolean useDispatcherWithExecutor;
     private final boolean forceFlushOnRequest;
 
@@ -1062,6 +1067,7 @@ public class Options {
         private boolean ignoreDiscoveredServers = false;
         private boolean tlsFirst = false;
         private boolean useTimeoutException = false;
+        private boolean advancedRequestBehavior = false;
         private boolean useDispatcherWithExecutor = false;
         private boolean forceFlushOnRequest = true; // true since it's the original b/w compatible way
         private ServerPool serverPool = null;
@@ -1217,6 +1223,7 @@ public class Options {
             booleanProperty(props, PROP_IGNORE_DISCOVERED_SERVERS, b -> this.ignoreDiscoveredServers = b);
             booleanProperty(props, PROP_TLS_FIRST, b -> this.tlsFirst = b);
             booleanProperty(props, PROP_USE_TIMEOUT_EXCEPTION, b -> this.useTimeoutException = b);
+            booleanProperty(props, PROP_ADVANCED_REQUEST_BEHAVIOR, b -> this.advancedRequestBehavior = b);
             booleanProperty(props, PROP_USE_DISPATCHER_WITH_EXECUTOR, b -> this.useDispatcherWithExecutor = b);
             booleanProperty(props, PROP_FORCE_FLUSH_ON_REQUEST, b -> this.forceFlushOnRequest = b);
 
@@ -1701,7 +1708,7 @@ public class Options {
          * @return the Builder for chaining
          */
         public Builder connectionTimeout(Duration connectionTimeout) {
-            this.connectionTimeout = connectionTimeout;
+            this.connectionTimeout = connectionTimeout == null ? DEFAULT_CONNECTION_TIMEOUT : connectionTimeout;
             return this;
         }
 
@@ -1713,7 +1720,7 @@ public class Options {
          * @return the Builder for chaining
          */
         public Builder connectionTimeout(long connectionTimeoutMillis) {
-            this.connectionTimeout = Duration.ofMillis(connectionTimeoutMillis);
+            this.connectionTimeout = connectionTimeoutMillis < 1 ? DEFAULT_CONNECTION_TIMEOUT : Duration.ofMillis(connectionTimeoutMillis);
             return this;
         }
 
@@ -2208,6 +2215,19 @@ public class Options {
         }
 
         /**
+         * Enable advanced request behavior. When enabled, JetStream requests that return no response
+         * throw a {@link RequestFailureException} carrying a specific
+         * {@link RequestFailureReason} (timeout, connection closing, no-responders,
+         * protocol error, ...) plus the connection status and last protocol error, instead of the
+         * generic "Timeout or no response" IOException.
+         * @return the Builder for chaining
+         */
+        public Builder advancedRequestBehavior() {
+            this.advancedRequestBehavior = true;
+            return this;
+        }
+
+        /**
          * Instruct dispatchers to dispatch all messages as a task, instead of directly from dispatcher thread
          * @return the Builder for chaining
          */
@@ -2475,6 +2495,7 @@ public class Options {
             this.ignoreDiscoveredServers = o.ignoreDiscoveredServers;
             this.tlsFirst = o.tlsFirst;
             this.useTimeoutException = o.useTimeoutException;
+            this.advancedRequestBehavior = o.advancedRequestBehavior;
             this.useDispatcherWithExecutor = o.useDispatcherWithExecutor;
             this.forceFlushOnRequest = o.forceFlushOnRequest;
 
@@ -2554,6 +2575,7 @@ public class Options {
         this.ignoreDiscoveredServers = b.ignoreDiscoveredServers;
         this.tlsFirst = b.tlsFirst;
         this.useTimeoutException = b.useTimeoutException;
+        this.advancedRequestBehavior = b.advancedRequestBehavior;
         this.useDispatcherWithExecutor = b.useDispatcherWithExecutor;
         this.forceFlushOnRequest = b.forceFlushOnRequest;
 
@@ -3300,6 +3322,14 @@ public class Options {
      */
     public boolean useTimeoutException() {
         return useTimeoutException;
+    }
+
+    /**
+     * Get whether advanced request behavior is enabled.
+     * @return the flag
+     */
+    public boolean advancedRequestBehavior() {
+        return advancedRequestBehavior;
     }
 
     /**

--- a/src/main/java/io/nats/client/RequestFailureException.java
+++ b/src/main/java/io/nats/client/RequestFailureException.java
@@ -1,0 +1,84 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client;
+
+import io.nats.client.impl.RequestFailureMessage;
+
+import java.io.IOException;
+import java.time.Duration;
+
+/**
+ * Carries the detail of a request that came back without a response, but only when
+ * {@link Options.Builder#advancedRequestBehavior()} is enabled. It wraps a
+ * {@link RequestFailureMessage} and exposes a specific {@link RequestFailureReason} plus the connection
+ * status and last protocol error captured at the moment the request failed, so the actual cause (timeout
+ * vs. reconnect vs. permissions vs. no-responders) can be told apart. The original caught exception is
+ * chained as the cause (an {@link java.util.concurrent.ExecutionException} is unwrapped to its cause;
+ * see {@link RequestFailureMessage#getCause()}). Extends {@link IOException} so existing catch blocks and
+ * signatures are unaffected.
+ *
+ * <p>JetStream requests (publish, stream/consumer management) throw this in place of the generic
+ * "Timeout or no response waiting for NATS JetStream server" IOException. Core
+ * {@link Connection#request(String, byte[], java.time.Duration) Connection.request(...)} calls instead
+ * return the {@link RequestFailureMessage} carrier directly (it is a {@link Message}), which callers can
+ * inspect or wrap in this exception.
+ */
+public class RequestFailureException extends IOException {
+
+    private final RequestFailureMessage rfm;
+
+    public RequestFailureException(RequestFailureMessage rfm) {
+        super(buildMessage(rfm), rfm.getCause());
+        this.rfm = rfm;
+    }
+
+    private static String buildMessage(RequestFailureMessage rfm) {
+        StringBuilder sb = new StringBuilder("Request failed [reason=").append(rfm.getReason())
+            .append(", connectionStatus=").append(rfm.getConnectionStatus())
+            .append(", waited=").append(rfm.getWaited());
+        String lastError = rfm.getLastError();
+        if (lastError != null && !lastError.isEmpty()) {
+            sb.append(", lastError=").append(lastError);
+        }
+        return sb.append(']').toString();
+    }
+
+    /**
+     * @return the classified reason the request returned no response
+     */
+    public RequestFailureReason getReason() {
+        return rfm.getReason();
+    }
+
+    /**
+     * @return the connection status at the moment the request failed
+     */
+    public Connection.Status getConnectionStatus() {
+        return rfm.getConnectionStatus();
+    }
+
+    /**
+     * @return the last protocol error reported by the server (may be null or empty)
+     */
+    public String getLastError() {
+        return rfm.getLastError();
+    }
+
+    /**
+     * @return how long the request waited before failing
+     */
+    public Duration getWaited() {
+        return rfm.getWaited();
+    }
+}

--- a/src/main/java/io/nats/client/RequestFailureException.java
+++ b/src/main/java/io/nats/client/RequestFailureException.java
@@ -13,10 +13,7 @@
 
 package io.nats.client;
 
-import io.nats.client.impl.RequestFailureMessage;
-
 import java.io.IOException;
-import java.time.Duration;
 
 /**
  * Carries the detail of a request that came back without a response, but only when
@@ -35,6 +32,7 @@ import java.time.Duration;
  * inspect or wrap in this exception.
  */
 public class RequestFailureException extends IOException {
+    private static final long serialVersionUID = 1L;
 
     private final RequestFailureMessage rfm;
 
@@ -45,8 +43,7 @@ public class RequestFailureException extends IOException {
 
     private static String buildMessage(RequestFailureMessage rfm) {
         StringBuilder sb = new StringBuilder("Request failed [reason=").append(rfm.getReason())
-            .append(", connectionStatus=").append(rfm.getConnectionStatus())
-            .append(", waited=").append(rfm.getWaited());
+            .append(", connectionStatus=").append(rfm.getConnectionStatus());
         String lastError = rfm.getLastError();
         if (lastError != null && !lastError.isEmpty()) {
             sb.append(", lastError=").append(lastError);
@@ -73,12 +70,5 @@ public class RequestFailureException extends IOException {
      */
     public String getLastError() {
         return rfm.getLastError();
-    }
-
-    /**
-     * @return how long the request waited before failing
-     */
-    public Duration getWaited() {
-        return rfm.getWaited();
     }
 }

--- a/src/main/java/io/nats/client/RequestFailureMessage.java
+++ b/src/main/java/io/nats/client/RequestFailureMessage.java
@@ -11,41 +11,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io.nats.client.impl;
+package io.nats.client;
 
-import io.nats.client.Connection;
-import io.nats.client.RequestFailureException;
-import io.nats.client.RequestFailureReason;
+import io.nats.client.impl.NatsMessage;
 import io.nats.client.support.NatsRequestCompletableFuture;
 
-import java.time.Duration;
 import java.util.concurrent.CancellationException;
 
 /**
- * Internal carrier returned by {@link NatsConnection#requestInternal} in place of a null when a
- * request comes back without a response and {@link io.nats.client.Options#advancedRequestBehavior()}
- * is enabled. Construction classifies why the request came back empty (the {@link RequestFailureReason})
- * from the state captured at failure time, and carries enough detail for the JetStream layer to throw a
- * specific {@link RequestFailureException}. It is never published and never travels over the wire; the
- * public {@code Connection.request(...)} methods strip it back to null to preserve their null-on-timeout
- * contract.
+ * Carrier returned by the connection in place of a null when a request comes back without a response and
+ * {@link Options.Builder#advancedRequestBehavior()} is enabled. Construction classifies why the request
+ * came back empty (the {@link RequestFailureReason}) from the state captured at failure time, and carries
+ * enough detail for the JetStream layer to throw a specific {@link RequestFailureException}. It is never
+ * published and never travels over the wire. With the flag off it is never produced
+ * ({@code Connection.request(...)} returns null on no-response as before); with it on, core
+ * {@code request(...)} returns this carrier and JetStream wraps it in a {@link RequestFailureException}.
  */
 public class RequestFailureMessage extends NatsMessage {
 
     private final RequestFailureReason reason;
     private final Connection.Status connectionStatus;
     private final String lastError;
-    private final Duration waited;
     private final Throwable cause;
 
-    RequestFailureMessage(NatsRequestCompletableFuture future,
-                                    Throwable cause,
-                                    Duration waited,
-                                    Connection.Status connectionStatus,
-                                    String lastError) {
+    public RequestFailureMessage(NatsRequestCompletableFuture future,
+                                 Throwable cause,
+                                 Connection.Status connectionStatus,
+                                 String lastError) {
         super();
         this.cause = cause;
-        this.waited = waited;
         this.connectionStatus = connectionStatus;
         this.lastError = lastError;
         this.reason = classify(future, cause, connectionStatus, lastError);
@@ -60,13 +54,15 @@ public class RequestFailureMessage extends NatsMessage {
                 || connectionStatus == Connection.Status.DISCONNECTED) {
             return RequestFailureReason.CONNECTION_CLOSING;
         }
-        if (lastError != null && !lastError.isEmpty()) {
-            return RequestFailureReason.PROTOCOL_ERROR;
+        if (lastError != null) {
+            return RequestFailureReason.SERVER_ERROR;
         }
-        if (cause instanceof CancellationException
-                && !future.wasCancelledTimedOut()
-                && future.getCancelAction() == NatsRequestCompletableFuture.CancelAction.CANCEL) {
-            return RequestFailureReason.NO_RESPONDERS;
+        // a cancellation that is not a cleanup-timeout: NO_RESPONDERS for the 503 CANCEL path, otherwise a
+        // genuine (unmodeled) cancellation. A cleanup-timeout (wasCancelledTimedOut) falls through to TIMEOUT.
+        if (cause instanceof CancellationException && !future.wasCancelledTimedOut()) {
+            return future.getCancelAction() == NatsRequestCompletableFuture.CancelAction.CANCEL
+                ? RequestFailureReason.NO_RESPONDERS
+                : RequestFailureReason.CANCELLED;
         }
         return RequestFailureReason.TIMEOUT;
     }
@@ -81,10 +77,6 @@ public class RequestFailureMessage extends NatsMessage {
 
     public String getLastError() {
         return lastError;
-    }
-
-    public Duration getWaited() {
-        return waited;
     }
 
     /**

--- a/src/main/java/io/nats/client/RequestFailureReason.java
+++ b/src/main/java/io/nats/client/RequestFailureReason.java
@@ -15,8 +15,8 @@ package io.nats.client;
 
 /**
  * The classified reason a request returned no response, surfaced on a {@link RequestFailureException}
- * (JetStream requests) or carried by a {@link io.nats.client.impl.RequestFailureMessage} (core
- * requests) when {@link Options.Builder#advancedRequestBehavior()} is enabled.
+ * (JetStream requests) or carried by a {@link RequestFailureMessage} (core requests) when
+ * {@link Options.Builder#advancedRequestBehavior()} is enabled.
  */
 public enum RequestFailureReason {
     /** The request deadline elapsed with no reply (real server slowness or a short timeout). */
@@ -25,8 +25,8 @@ public enum RequestFailureReason {
     CONNECTION_CLOSING,
     /** A 503 No Responders - nothing was subscribed to the subject (e.g. no stream covers it). */
     NO_RESPONDERS,
-    /** The server sent a protocol -ERR (permissions violation, max payload, ...); see lastError. */
-    PROTOCOL_ERROR,
+    /** The server reported an error via -ERR (permissions violation, max payload, ...); see lastError. */
+    SERVER_ERROR,
     /** The request was cancelled for an unclassified reason. */
     CANCELLED
 }

--- a/src/main/java/io/nats/client/RequestFailureReason.java
+++ b/src/main/java/io/nats/client/RequestFailureReason.java
@@ -1,0 +1,32 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client;
+
+/**
+ * The classified reason a request returned no response, surfaced on a {@link RequestFailureException}
+ * (JetStream requests) or carried by a {@link io.nats.client.impl.RequestFailureMessage} (core
+ * requests) when {@link Options.Builder#advancedRequestBehavior()} is enabled.
+ */
+public enum RequestFailureReason {
+    /** The request deadline elapsed with no reply (real server slowness or a short timeout). */
+    TIMEOUT,
+    /** The in-flight request was cancelled by a disconnect, reconnect, or connection close. */
+    CONNECTION_CLOSING,
+    /** A 503 No Responders - nothing was subscribed to the subject (e.g. no stream covers it). */
+    NO_RESPONDERS,
+    /** The server sent a protocol -ERR (permissions violation, max payload, ...); see lastError. */
+    PROTOCOL_ERROR,
+    /** The request was cancelled for an unclassified reason. */
+    CANCELLED
+}

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -39,6 +39,7 @@ import java.util.function.Predicate;
 
 import static io.nats.client.support.NatsConstants.*;
 import static io.nats.client.support.NatsRequestCompletableFuture.CancelAction;
+import static io.nats.client.support.Validator.emptyAsNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 class NatsConnection implements Connection {
@@ -235,7 +236,7 @@ class NatsConnection implements Connection {
         boolean trace = options.isTraceConnection();
         long start = NatsSystemClock.nanoTime();
 
-        this.lastError.set("");
+        this.lastError.set(null);
 
         timeTraceLogger.trace("starting connect loop");
 
@@ -259,7 +260,7 @@ class NatsConnection implements Connection {
                     keepGoing = false;
                     break;
                 }
-                connectError.set(""); // new on each attempt
+                connectError.set(null); // new on each attempt
 
                 timeTraceLogger.trace("setting status to connecting");
                 updateStatus(Status.CONNECTING, resolved, cur);
@@ -462,7 +463,7 @@ class NatsConnection implements Connection {
                 if (isClosed()) {
                     return;
                 }
-                connectError.set(""); // reset on each loop
+                connectError.set(null); // reset on each loop
                 if (isDisconnectingOrClosed() || this.isClosing()) {
                     return;
                 }
@@ -1318,20 +1319,24 @@ class NatsConnection implements Connection {
         long timeoutNanos = timeout == null ? getOptions().getConnectionTimeout().toNanos() : timeout.toNanos();
 
         if (options.advancedRequestBehavior()) {
+            // getLastError() is connection-level and persists; capture it before the request and attribute
+            // a server error to this failure only if it changed (a new -ERR arrived during the request).
+            String lastErrorBefore = getLastError();
             Throwable cause;
             try {
                 return incoming.get(timeoutNanos, TimeUnit.NANOSECONDS);
             }
             catch (TimeoutException | CancellationException e) {
-                // RequestFailureMessage classifies the failure (reason) from the state passed in
                 cause = e;
             }
             catch (ExecutionException e) {
                 // unwrap: carry the underlying cause, not the ExecutionException wrapper, so it is consistent
                 // with the TimeoutException/CancellationException caught directly above (see RequestFailureMessage.getCause)
-                cause = e;
+                cause = e.getCause();
             }
-            return new RequestFailureMessage(incoming, cause, timeout, getStatus(), getLastError());
+            String lastErrorNow = getLastError();
+            String serverError = lastErrorNow != null && !lastErrorNow.equals(lastErrorBefore) ? lastErrorNow : null;
+            return new RequestFailureMessage(incoming, cause, getStatus(), serverError);
         }
 
         try {
@@ -1920,8 +1925,9 @@ class NatsConnection implements Connection {
     protected void processError(String errorText) {
         this.statistics.incrementErrCount();
 
-        this.lastError.set(errorText);
-        this.connectError.set(errorText); // even if this isn't during connection, save it just in case
+        String err = emptyAsNull(errorText);
+        this.lastError.set(err);
+        this.connectError.set(err); // even if this isn't during connection, save it just in case
 
         // If we get an authentication error, save it
         if (this.isAuthenticationError(errorText) && currentServer != null) {

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -1313,12 +1313,29 @@ class NatsConnection implements Connection {
                             @NonNull CancelAction cancelAction,
                             boolean flushImmediatelyAfterPublish) throws InterruptedException
     {
-        CompletableFuture<Message> incoming = requestFutureInternal(subject, headers, data, timeout, cancelAction, flushImmediatelyAfterPublish);
-        try {
-            if (timeout == null) {
-                timeout = getOptions().getConnectionTimeout();
+        NatsRequestCompletableFuture incoming = requestFutureInternal(subject, headers, data, timeout, cancelAction, flushImmediatelyAfterPublish);
+
+        long timeoutNanos = timeout == null ? getOptions().getConnectionTimeout().toNanos() : timeout.toNanos();
+
+        if (options.advancedRequestBehavior()) {
+            Throwable cause;
+            try {
+                return incoming.get(timeoutNanos, TimeUnit.NANOSECONDS);
             }
-            return incoming.get(timeout.toNanos(), TimeUnit.NANOSECONDS);
+            catch (TimeoutException | CancellationException e) {
+                // RequestFailureMessage classifies the failure (reason) from the state passed in
+                cause = e;
+            }
+            catch (ExecutionException e) {
+                // unwrap: carry the underlying cause, not the ExecutionException wrapper, so it is consistent
+                // with the TimeoutException/CancellationException caught directly above (see RequestFailureMessage.getCause)
+                cause = e;
+            }
+            return new RequestFailureMessage(incoming, cause, timeout, getStatus(), getLastError());
+        }
+
+        try {
+            return incoming.get(timeoutNanos, TimeUnit.NANOSECONDS);
         }
         catch (TimeoutException | ExecutionException | CancellationException e) {
             return null;
@@ -1382,7 +1399,7 @@ class NatsConnection implements Connection {
     }
 
     @NonNull
-    protected CompletableFuture<Message> requestFutureInternal(@NonNull String subject,
+    protected NatsRequestCompletableFuture requestFutureInternal(@NonNull String subject,
                                                      @Nullable Headers headers,
                                                      byte @Nullable [] body,
                                                      @Nullable Duration futureTimeout,

--- a/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
@@ -16,6 +16,7 @@ package io.nats.client.impl;
 import io.nats.client.JetStreamApiException;
 import io.nats.client.JetStreamOptions;
 import io.nats.client.Message;
+import io.nats.client.RequestFailureException;
 import io.nats.client.api.*;
 import io.nats.client.support.NatsJetStreamConstants;
 
@@ -238,7 +239,8 @@ class NatsJetStreamImpl implements NatsJetStreamConstants {
     Message makeRequestResponseRequired(String subject, byte[] bytes, Duration timeout) throws IOException {
         try {
             return responseRequired(conn.request(prependPrefix(subject), bytes, timeout));
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
         }
@@ -247,7 +249,8 @@ class NatsJetStreamImpl implements NatsJetStreamConstants {
     Message makeInternalRequestResponseRequired(String subject, Headers headers, byte[] data, Duration timeout, CancelAction cancelAction, boolean flushImmediatelyAfterPublish) throws IOException {
         try {
             return responseRequired(conn.requestInternal(subject, headers, data, timeout, cancelAction, flushImmediatelyAfterPublish));
-        } catch (InterruptedException e) {
+        }
+        catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException(e);
         }
@@ -256,6 +259,9 @@ class NatsJetStreamImpl implements NatsJetStreamConstants {
     Message responseRequired(Message respMessage) throws IOException {
         if (respMessage == null) {
             throw new IOException("Timeout or no response waiting for NATS JetStream server");
+        }
+        if (respMessage instanceof RequestFailureMessage) {
+            throw new RequestFailureException((RequestFailureMessage)respMessage);
         }
         return respMessage;
     }

--- a/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamImpl.java
@@ -13,10 +13,7 @@
 
 package io.nats.client.impl;
 
-import io.nats.client.JetStreamApiException;
-import io.nats.client.JetStreamOptions;
-import io.nats.client.Message;
-import io.nats.client.RequestFailureException;
+import io.nats.client.*;
 import io.nats.client.api.*;
 import io.nats.client.support.NatsJetStreamConstants;
 

--- a/src/main/java/io/nats/client/impl/NatsJetStreamMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamMessage.java
@@ -15,6 +15,7 @@ package io.nats.client.impl;
 
 import io.nats.client.Connection;
 import io.nats.client.Message;
+import io.nats.client.RequestFailureMessage;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;

--- a/src/main/java/io/nats/client/impl/NatsJetStreamMessage.java
+++ b/src/main/java/io/nats/client/impl/NatsJetStreamMessage.java
@@ -14,6 +14,7 @@
 package io.nats.client.impl;
 
 import io.nats.client.Connection;
+import io.nats.client.Message;
 
 import java.time.Duration;
 import java.util.concurrent.TimeoutException;
@@ -46,7 +47,9 @@ class NatsJetStreamMessage extends IncomingMessage {
         if (ackHasntBeenTermed()) {
             validateDurationRequired(d);
             Connection nc = getJetStreamValidatedConnection();
-            if (nc.request(replyTo, AckAck.bytes, d) == null) {
+            Message ackResp = nc.request(replyTo, AckAck.bytes, d);
+            // with advancedRequestBehavior a no-response comes back as a RequestFailureMessage instead of null
+            if (ackResp == null || ackResp instanceof RequestFailureMessage) {
                 throw new TimeoutException("Ack response timed out.");
             }
             lastAck = AckAck;

--- a/src/main/java/io/nats/client/impl/RequestFailureMessage.java
+++ b/src/main/java/io/nats/client/impl/RequestFailureMessage.java
@@ -1,0 +1,102 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.impl;
+
+import io.nats.client.Connection;
+import io.nats.client.RequestFailureException;
+import io.nats.client.RequestFailureReason;
+import io.nats.client.support.NatsRequestCompletableFuture;
+
+import java.time.Duration;
+import java.util.concurrent.CancellationException;
+
+/**
+ * Internal carrier returned by {@link NatsConnection#requestInternal} in place of a null when a
+ * request comes back without a response and {@link io.nats.client.Options#advancedRequestBehavior()}
+ * is enabled. Construction classifies why the request came back empty (the {@link RequestFailureReason})
+ * from the state captured at failure time, and carries enough detail for the JetStream layer to throw a
+ * specific {@link RequestFailureException}. It is never published and never travels over the wire; the
+ * public {@code Connection.request(...)} methods strip it back to null to preserve their null-on-timeout
+ * contract.
+ */
+public class RequestFailureMessage extends NatsMessage {
+
+    private final RequestFailureReason reason;
+    private final Connection.Status connectionStatus;
+    private final String lastError;
+    private final Duration waited;
+    private final Throwable cause;
+
+    RequestFailureMessage(NatsRequestCompletableFuture future,
+                                    Throwable cause,
+                                    Duration waited,
+                                    Connection.Status connectionStatus,
+                                    String lastError) {
+        super();
+        this.cause = cause;
+        this.waited = waited;
+        this.connectionStatus = connectionStatus;
+        this.lastError = lastError;
+        this.reason = classify(future, cause, connectionStatus, lastError);
+    }
+
+    private static RequestFailureReason classify(NatsRequestCompletableFuture future,
+                                                 Throwable cause,
+                                                 Connection.Status connectionStatus,
+                                                 String lastError) {
+        if (future.wasCancelledClosing()
+                || connectionStatus == Connection.Status.RECONNECTING
+                || connectionStatus == Connection.Status.DISCONNECTED) {
+            return RequestFailureReason.CONNECTION_CLOSING;
+        }
+        if (lastError != null && !lastError.isEmpty()) {
+            return RequestFailureReason.PROTOCOL_ERROR;
+        }
+        if (cause instanceof CancellationException
+                && !future.wasCancelledTimedOut()
+                && future.getCancelAction() == NatsRequestCompletableFuture.CancelAction.CANCEL) {
+            return RequestFailureReason.NO_RESPONDERS;
+        }
+        return RequestFailureReason.TIMEOUT;
+    }
+
+    public RequestFailureReason getReason() {
+        return reason;
+    }
+
+    public Connection.Status getConnectionStatus() {
+        return connectionStatus;
+    }
+
+    public String getLastError() {
+        return lastError;
+    }
+
+    public Duration getWaited() {
+        return waited;
+    }
+
+    /**
+     * The exception caught while waiting for the response, kept so the underlying detail is never lost.
+     * It is the {@link java.util.concurrent.TimeoutException} or
+     * {@link java.util.concurrent.CancellationException} as caught; for a failure delivered as an
+     * {@link java.util.concurrent.ExecutionException} it is that exception's
+     * {@linkplain Throwable#getCause() cause} (the wrapper is unwrapped, so a timeout from the internal
+     * cleanup task surfaces the same {@code TimeoutException} as a timeout from the request deadline).
+     * @return the underlying cause of the failure (may be null)
+     */
+    public Throwable getCause() {
+        return cause;
+    }
+}

--- a/src/main/java/io/nats/service/Discovery.java
+++ b/src/main/java/io/nats/service/Discovery.java
@@ -13,11 +13,7 @@
 
 package io.nats.service;
 
-import io.nats.client.Connection;
-import io.nats.client.Message;
-import io.nats.client.NatsSystemClock;
-import io.nats.client.Subscription;
-import io.nats.client.impl.RequestFailureMessage;
+import io.nats.client.*;
 
 import java.time.Duration;
 import java.util.ArrayList;

--- a/src/main/java/io/nats/service/Discovery.java
+++ b/src/main/java/io/nats/service/Discovery.java
@@ -17,6 +17,7 @@ import io.nats.client.Connection;
 import io.nats.client.Message;
 import io.nats.client.NatsSystemClock;
 import io.nats.client.Subscription;
+import io.nats.client.impl.RequestFailureMessage;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -185,7 +186,8 @@ public class Discovery {
         String subject = Service.toDiscoverySubject(action, serviceName, serviceId);
         try {
             Message m = conn.request(subject, null, Duration.ofNanos(maxTimeNanos));
-            if (m != null) {
+            // with advancedRequestBehavior a no-response comes back as a RequestFailureMessage instead of null
+            if (m != null && !(m instanceof RequestFailureMessage)) {
                 return m.getData();
             }
         }

--- a/src/test/java/io/nats/client/OptionsTests.java
+++ b/src/test/java/io/nats/client/OptionsTests.java
@@ -145,6 +145,22 @@ public class OptionsTests {
     }
 
     @Test
+    public void testAdvancedRequestBehavior() {
+        // default
+        assertFalse(new Options.Builder().build().advancedRequestBehavior(), "default advancedRequestBehavior");
+
+        // builder method + copy constructor
+        Options o = new Options.Builder().advancedRequestBehavior().build();
+        assertTrue(o.advancedRequestBehavior(), "chained advancedRequestBehavior");
+        assertTrue(new Options.Builder(o).build().advancedRequestBehavior(), "copied advancedRequestBehavior");
+
+        // environment property
+        Properties props = new Properties();
+        props.setProperty(Options.PROP_ADVANCED_REQUEST_BEHAVIOR, "true");
+        assertTrue(new Options.Builder(props).build().advancedRequestBehavior(), "property advancedRequestBehavior");
+    }
+
+    @Test
     public void testChainedStringOptions() {
         Options o = new Options.Builder().userInfo("hello".toCharArray(), "world".toCharArray()).connectionName("name").build();
         _testChainedStringOptions(o);

--- a/src/test/java/io/nats/client/impl/AdvancedRequestBehaviorTests.java
+++ b/src/test/java/io/nats/client/impl/AdvancedRequestBehaviorTests.java
@@ -53,7 +53,6 @@ public class AdvancedRequestBehaviorTests extends TestBase {
 
             assertEquals(RequestFailureReason.NO_RESPONDERS, e.getReason());
             assertEquals(Connection.Status.CONNECTED, e.getConnectionStatus());
-            assertNotNull(e.getWaited());
             // no protocol -ERR was involved
             assertTrue(e.getLastError() == null || e.getLastError().isEmpty());
         });
@@ -101,7 +100,6 @@ public class AdvancedRequestBehaviorTests extends TestBase {
 
             assertEquals(RequestFailureReason.TIMEOUT, e.getReason());
             assertEquals(Connection.Status.CONNECTED, e.getConnectionStatus());
-            assertNotNull(e.getWaited());
             assertTrue(e.getLastError() == null || e.getLastError().isEmpty());
         });
     }
@@ -119,7 +117,6 @@ public class AdvancedRequestBehaviorTests extends TestBase {
             RequestFailureMessage rfm = (RequestFailureMessage) m;
             assertEquals(RequestFailureReason.NO_RESPONDERS, rfm.getReason());
             assertEquals(Connection.Status.CONNECTED, rfm.getConnectionStatus());
-            assertNotNull(rfm.getWaited());
         });
     }
 
@@ -182,7 +179,6 @@ public class AdvancedRequestBehaviorTests extends TestBase {
             RequestFailureException e = (RequestFailureException) t;
             assertEquals(RequestFailureReason.CONNECTION_CLOSING, e.getReason(),
                 "expected CONNECTION_CLOSING, message was: " + e.getMessage());
-            assertNotNull(e.getWaited());
         }
         finally {
             ts.close(); // idempotent; ensure cleanup even if assertions above threw
@@ -190,7 +186,7 @@ public class AdvancedRequestBehaviorTests extends TestBase {
     }
 
     // ----------------------------------------------------------------------------------------------------
-    // PROTOCOL_ERROR is NOT covered here. To deterministically populate the connection's lastError with a
+    // SERVER_ERROR is NOT covered here. To deterministically populate the connection's lastError with a
     // server -ERR at the exact moment a JetStream request fails, you need a server configured with
     // restricted permissions (e.g. a user without subscribe permission on its own inbox) so the inbox
     // subscription draws a permissions violation, and then time a JetStream request to observe a non-empty
@@ -198,8 +194,8 @@ public class AdvancedRequestBehaviorTests extends TestBase {
     // when the -ERR lands relative to the request future completing. It is too involved / timing-sensitive
     // to make reliable at this integration level, so it is intentionally omitted rather than flaky.
     //
-    // CANCELLED is a fallback bucket in the classifier that is not reachable through any deterministic
-    // server scenario (cancellations route to NO_RESPONDERS or CONNECTION_CLOSING first), so it is also
-    // not covered here.
+    // CANCELLED has a dedicated branch (a cancellation that is not a 503 no-responders, not connection
+    // closing, and not a cleanup-timeout), but it represents a genuine/unmodeled cancel that no normal
+    // server scenario produces deterministically, so it is not covered here.
     // ----------------------------------------------------------------------------------------------------
 }

--- a/src/test/java/io/nats/client/impl/AdvancedRequestBehaviorTests.java
+++ b/src/test/java/io/nats/client/impl/AdvancedRequestBehaviorTests.java
@@ -1,0 +1,205 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.impl;
+
+import io.nats.client.*;
+import io.nats.client.utils.TestBase;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests (real test server) proving the opt-in {@code advancedRequestBehavior} flag.
+ * When the flag is ON, a JetStream request that comes back without a response throws a typed
+ * {@link RequestFailureException} carrying a classified {@link RequestFailureReason}.
+ * When the flag is OFF, behavior is byte-for-byte unchanged (the legacy generic IOException).
+ *
+ * The companion unit test {@code OptionsTests.testAdvancedRequestBehavior} already covers the
+ * option plumbing (default/builder/copy/property); these tests cover the end-to-end runtime behavior.
+ */
+public class AdvancedRequestBehaviorTests extends TestBase {
+
+    // legacy message thrown by NatsJetStreamImpl.responseRequired when the flag is OFF
+    private static final String LEGACY_NO_RESPONSE_MSG = "Timeout or no response waiting for NATS JetStream server";
+
+    // ----------------------------------------------------------------------------------------------------
+    // NO_RESPONDERS - a JetStream management request against a server with no JetStream responder.
+    // The connection's cancelAction defaults to CANCEL (reportNoResponders not set), so a 503
+    // no-responders cancels the in-flight future -> CancellationException, not timed out -> NO_RESPONDERS.
+    // ----------------------------------------------------------------------------------------------------
+    @Test
+    public void testNoRespondersReasonWhenFlagOn() throws Exception {
+        // runInServer starts a plain (non JetStream) server, so the $JS.API.* subjects have no responder at all.
+        runInServer(Options.builder().advancedRequestBehavior(), nc -> {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            RequestFailureException e = assertThrows(RequestFailureException.class,
+                () -> jsm.getStreamInfo("no-such-stream-anywhere"));
+
+            assertEquals(RequestFailureReason.NO_RESPONDERS, e.getReason());
+            assertEquals(Connection.Status.CONNECTED, e.getConnectionStatus());
+            assertNotNull(e.getWaited());
+            // no protocol -ERR was involved
+            assertTrue(e.getLastError() == null || e.getLastError().isEmpty());
+        });
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // Regression guard: SAME scenario with the flag OFF must still throw the plain legacy IOException
+    // (and must NOT be the typed subclass).
+    // ----------------------------------------------------------------------------------------------------
+    @Test
+    public void testLegacyIOExceptionWhenFlagOff() throws Exception {
+        // default options: advancedRequestBehavior intentionally NOT set
+        runInServer(nc -> {
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            IOException e = assertThrows(IOException.class,
+                () -> jsm.getStreamInfo("no-such-stream-anywhere"));
+
+            assertFalse(e instanceof RequestFailureException,
+                "With the flag OFF the typed exception must not be thrown");
+            assertEquals(LEGACY_NO_RESPONSE_MSG, e.getMessage());
+        });
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // TIMEOUT - a responder IS subscribed to the JetStream API subject (so it is not a 503 no-responders),
+    // but it never replies. With a short JetStream request timeout the future times out
+    // (TimeoutException, not cancelled-closing, no -ERR) -> TIMEOUT.
+    // ----------------------------------------------------------------------------------------------------
+    @Test
+    public void testTimeoutReasonWhenFlagOn() throws Exception {
+        runInServer(Options.builder().advancedRequestBehavior(), nc -> {
+            // A silent responder on the whole JetStream API space: it receives the request but
+            // never publishes a reply, so there is no 503 and the request must time out.
+            Dispatcher d = nc.createDispatcher(msg -> { /* deliberately never reply */ });
+            d.subscribe("$JS.API.>");
+
+            JetStreamOptions jso = JetStreamOptions.builder()
+                .requestTimeout(Duration.ofMillis(300))
+                .build();
+            JetStreamManagement jsm = nc.jetStreamManagement(jso);
+
+            RequestFailureException e = assertThrows(RequestFailureException.class,
+                () -> jsm.getStreamInfo("no-such-stream-anywhere"));
+
+            assertEquals(RequestFailureReason.TIMEOUT, e.getReason());
+            assertEquals(Connection.Status.CONNECTED, e.getConnectionStatus());
+            assertNotNull(e.getWaited());
+            assertTrue(e.getLastError() == null || e.getLastError().isEmpty());
+        });
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // The feature also applies to core (non JetStream) requests: with the flag ON, a request that comes
+    // back without a response returns a RequestFailureMessage carrier (which is a Message) instead of
+    // null, and the carrier exposes the classified reason. With the flag OFF the legacy null is returned.
+    // ----------------------------------------------------------------------------------------------------
+    @Test
+    public void testCoreRequestReturnsCarrierWhenFlagOn() throws Exception {
+        runInServer(Options.builder().advancedRequestBehavior(), nc -> {
+            Message m = nc.request("no.responder.subject", null, Duration.ofMillis(300));
+            assertInstanceOf(RequestFailureMessage.class, m);
+            RequestFailureMessage rfm = (RequestFailureMessage) m;
+            assertEquals(RequestFailureReason.NO_RESPONDERS, rfm.getReason());
+            assertEquals(Connection.Status.CONNECTED, rfm.getConnectionStatus());
+            assertNotNull(rfm.getWaited());
+        });
+    }
+
+    @Test
+    public void testCoreRequestNullContractPreservedWhenFlagOff() throws Exception {
+        // flag OFF (default): no responder -> the public request still returns null (legacy contract)
+        runInServer(nc -> {
+            Message m = nc.request("no.responder.subject", null, Duration.ofMillis(300));
+            assertNull(m);
+        });
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // CONNECTION_CLOSING - start a JetStream request whose responder never replies, then stop the server
+    // out from under the in-flight request so the future is cancelled-closing (or the status drops to
+    // RECONNECTING/DISCONNECTED). Both signals classify to CONNECTION_CLOSING.
+    // This is inherently a bit racy; we use a generous request timeout and a separate thread to trigger
+    // the request, then close the server, and assert on the resulting reason.
+    // ----------------------------------------------------------------------------------------------------
+    @Test
+    public void testConnectionClosingReasonWhenFlagOn() throws Exception {
+        NatsTestServer ts = new NatsTestServer(false);
+        Options options = Options.builder()
+            .server(ts.getURI())
+            .advancedRequestBehavior()
+            .maxReconnects(0) // do not try to reconnect; let the request fail fast on close
+            .build();
+
+        try (Connection nc = standardConnection(options)) {
+            // silent responder so the request would otherwise sit waiting (no 503, no reply)
+            Dispatcher d = nc.createDispatcher(msg -> { /* never reply */ });
+            d.subscribe("$JS.API.>");
+
+            JetStreamOptions jso = JetStreamOptions.builder()
+                .requestTimeout(Duration.ofSeconds(10)) // long, so the close (not a timeout) ends it
+                .build();
+            JetStreamManagement jsm = nc.jetStreamManagement(jso);
+
+            AtomicReference<Throwable> thrown = new AtomicReference<>();
+            Thread requester = new Thread(() -> {
+                try {
+                    jsm.getStreamInfo("no-such-stream-anywhere");
+                }
+                catch (Throwable t) {
+                    thrown.set(t);
+                }
+            });
+            requester.start();
+
+            // give the request a moment to be in-flight, then yank the server
+            sleep(500);
+            ts.close();
+
+            requester.join(15000);
+
+            Throwable t = thrown.get();
+            assertNotNull(t, "the in-flight JetStream request should have failed when the server stopped");
+            assertTrue(t instanceof RequestFailureException,
+                "expected RequestFailureException but got " + t);
+            RequestFailureException e = (RequestFailureException) t;
+            assertEquals(RequestFailureReason.CONNECTION_CLOSING, e.getReason(),
+                "expected CONNECTION_CLOSING, message was: " + e.getMessage());
+            assertNotNull(e.getWaited());
+        }
+        finally {
+            ts.close(); // idempotent; ensure cleanup even if assertions above threw
+        }
+    }
+
+    // ----------------------------------------------------------------------------------------------------
+    // PROTOCOL_ERROR is NOT covered here. To deterministically populate the connection's lastError with a
+    // server -ERR at the exact moment a JetStream request fails, you need a server configured with
+    // restricted permissions (e.g. a user without subscribe permission on its own inbox) so the inbox
+    // subscription draws a permissions violation, and then time a JetStream request to observe a non-empty
+    // getLastError(). That requires a custom server .conf with authorization blocks plus careful timing of
+    // when the -ERR lands relative to the request future completing. It is too involved / timing-sensitive
+    // to make reliable at this integration level, so it is intentionally omitted rather than flaky.
+    //
+    // CANCELLED is a fallback bucket in the classifier that is not reachable through any deterministic
+    // server scenario (cancellations route to NO_RESPONDERS or CONNECTION_CLOSING first), so it is also
+    // not covered here.
+    // ----------------------------------------------------------------------------------------------------
+}


### PR DESCRIPTION
Address #1581 

This adds an opt-in connection option, `advancedRequestBehavior`, that surfaces *why* a request came back without a response instead of the generic timeout. The detail is a classified `RequestFailureReason` — one of `TIMEOUT`, `CONNECTION_CLOSING`, `NO_RESPONDERS`, `PROTOCOL_ERROR`, or `CANCELLED` — plus the connection status, the last protocol error, how long the request waited, and the original exception chained as the cause, so you can tell a real timeout apart from a reconnect, a permissions error, or no stream on the subject.

It applies to both request styles:
- **JetStream** requests (publish, stream/consumer management) throw a `RequestFailureException` in place of the generic `IOException("Timeout or no response waiting for NATS JetStream server")`.
- **Core** `Connection.request(...)` returns a `RequestFailureMessage` (which *is* a `Message`) instead of `null`, which you can inspect for the same detail.

The option is off by default; existing behavior is unchanged unless you enable in the connection options.

```java
try {
    js.publish("subject", data);
}
catch (RequestFailureException e) {
    // e.getReason(), e.getConnectionStatus(), e.getLastError(), e.getCause()
    log.warn("publish failed: {} (status={})", e.getReason(), e.getConnectionStatus());
}
```

For a core request, the message will never be null. It will either be the response message or will be a RequestFailureMessage. You must inspect the returned message:

```java
Message m = nc.request("subject", data, Duration.ofSeconds(2));
if (m instanceof RequestFailureMessage) {
    RequestFailureMessage rfm = (RequestFailureMessage)m;
    log.warn("request failed: {} (status={})", rfm.getReason(), rfm.getConnectionStatus());
}
```

The two paths are distinct: a JetStream request **throws** `RequestFailureException` (which extends `IOException`, so existing `catch (IOException)` blocks keep working), while a core `request(...)` **returns** the `RequestFailureMessage` — it does not throw.