### PR TITLE
Consumer Source Field Nullability

### DIFF
--- a/src/main/java/io/nats/client/api/ConsumerSource.java
+++ b/src/main/java/io/nats/client/api/ConsumerSource.java
@@ -48,16 +48,16 @@ public class ConsumerSource implements JsonSerializable {
      * @param name the consumer name
      * @param deliverSubject the deliver subject
      */
-    public ConsumerSource(String name, String deliverSubject) {
-        this.name = name;
-        this.deliverSubject = deliverSubject;
+    public ConsumerSource(@NonNull String name, @NonNull String deliverSubject) {
+        this.name = validateConsumerName(name, true);
+        this.deliverSubject = validateSubject(deliverSubject, true);
     }
 
     /**
      * Construct a ConsumerSource configuration copying the information from another ConsumerSource
      * @param consumerSource the source configuration
      */
-    public ConsumerSource(ConsumerSource consumerSource) {
+    public ConsumerSource(@NonNull ConsumerSource consumerSource) {
         this.name = consumerSource.name;
         this.deliverSubject = consumerSource.deliverSubject;
     }
@@ -157,8 +157,6 @@ public class ConsumerSource implements JsonSerializable {
          * @return the ConsumerSource object
          */
         public ConsumerSource build() {
-            validateConsumerName(name, true);
-            validateSubject(deliverSubject, true);
             return new ConsumerSource(name, deliverSubject);
         }
     }


### PR DESCRIPTION
Making sure nullability matches schema

```json
"stream_consumer_source": {
  "type": "object",
  "description": "Consumer information for durable sourcing",
  "required": ["name", "deliver_subject"],
  "properties": {
    "name": {
      "description": "Consumer name",
      "$ref": "#/definitions/basic_name"
    },
    "deliver_subject": {
      "description": "The subject to deliver messages to",
      "type": "string"
    }
  }
},
```