### PR TITLE
Reset Reader Connection

### DIFF
--- a/src/main/java/io/nats/client/Options.java
+++ b/src/main/java/io/nats/client/Options.java
@@ -501,7 +501,7 @@ public class Options {
      */
     public static final String PROP_RECONNECT_DELAY_HANDLER_CLASS = PFX + "reconnect.delay.handler.class";
     /**
-     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#reconnectDelayBehavior(ReconnectDelayBehavior)
+     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#reconnectDelayBehavior(Options.ReconnectDelayBehavior)
      * reconnectDelayBehavior}. Value is the name of a {@link ReconnectDelayBehavior} constant (e.g. {@code BeforeSubsequentRounds}, {@code BeforeAllRounds}).
      */
     public static final String PROP_RECONNECT_DELAY_BEHAVIOR = PFX + "reconnect.delay.behavior";
@@ -548,7 +548,7 @@ public class Options {
     @Deprecated
     public static final String PROP_FAST_FALLBACK = PFX + "fast.fallback";
     /**
-     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#hostnameResolveMode(HostnameResolveMode) hostnameResolveMode}.
+     * Property used to configure a builder from a Properties object. {@value}, see {@link Builder#hostnameResolveMode(Options.HostnameResolveMode) hostnameResolveMode}.
      * Takes precedence over PROP_NO_RESOLVE_HOSTNAMES and PROP_FAST_FALLBACK
      */
     public static final String PROP_HOSTNAME_RESOLVE_MODE = PFX + "hostnameResolveMode";
@@ -1390,7 +1390,7 @@ public class Options {
          * Fastest validation, but use with caution
          * If you know your subjects are always valid.
          * @return the Builder for chaining
-         * @deprecated use {@link #subjectValidationType(SubjectValidationType)} with {@link SubjectValidationType#None} instead
+         * @deprecated use {@link #subjectValidationType(Options.SubjectValidationType)} with {@link SubjectValidationType#None} instead
          */
         @Deprecated
         public Builder noSubjectValidation() {
@@ -1404,7 +1404,7 @@ public class Options {
          * Slower validation, but may be useful when exposing the ability
          * of an application user to set a subject.
          * @return the Builder for chaining
-         * @deprecated use {@link #subjectValidationType(SubjectValidationType)} with {@link SubjectValidationType#Strict} instead
+         * @deprecated use {@link #subjectValidationType(Options.SubjectValidationType)} with {@link SubjectValidationType#Strict} instead
          */
         @Deprecated
         public Builder strictSubjectValidation() {
@@ -3052,7 +3052,7 @@ public class Options {
     }
 
     /**
-     * the reconnect delay behavior, see {@link Builder#reconnectDelayBehavior(ReconnectDelayBehavior) reconnectDelayBehavior()} in the builder doc
+     * the reconnect delay behavior, see {@link Builder#reconnectDelayBehavior(Options.ReconnectDelayBehavior) reconnectDelayBehavior()} in the builder doc
      * @return the behavior, never null (defaults to {@link ReconnectDelayBehavior#BeforeSubsequentRounds})
      */
     public ReconnectDelayBehavior reconnectDelayBehavior() {

--- a/src/main/java/io/nats/client/api/PriorityPolicy.java
+++ b/src/main/java/io/nats/client/api/PriorityPolicy.java
@@ -19,12 +19,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Represents the Priority Policy of a consumer
- * @see <a href="https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-42.md">nats-io ADR-42</a>
+ * Represents the Priority Policy of a consumer.
  * Setting a priority policy will also require setting a Priority group. <BR>
  * When a priority policy and priority group are set, client instances making pull request need to specify the priority group
  * and optionally other ConsumerOptions See {@link io.nats.client.BaseConsumeOptions}
  *
+ * @see <a href="https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-42.md">nats-io ADR-42</a>
  */
 public enum PriorityPolicy {
     /** Standard consumer. All client instances are load balance fairly. */

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -937,6 +937,11 @@ class NatsConnection implements Connection {
     protected boolean writerExecutorIsClosed() { return writerExecutor == null; }
     protected boolean scheduledExecutorIsClosed() { return scheduledExecutor == null; }
 
+    // Repoint this connection's reader at the given connection
+    protected void setReaderConnection(NatsConnection connection) {
+        reader.setConnection(connection);
+    }
+
     // Should only be called from closeSocket or close
     protected void closeSocketImpl(boolean forceClose) {
         clearCurrentServer();

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -937,7 +937,10 @@ class NatsConnection implements Connection {
     protected boolean writerExecutorIsClosed() { return writerExecutor == null; }
     protected boolean scheduledExecutorIsClosed() { return scheduledExecutor == null; }
 
-    // Repoint this connection's reader at the given connection
+    // Repoint this connection's reader at the given connection, without exposing the reader's private
+    // connection field. Pass 'this' to (re)bind the reader to this connection. The repoint is a single
+    // volatile write - visible to the reader thread but not atomic with respect to an in-flight message
+    // parse; see NatsConnectionReader.setConnection for the invariant.
     protected void setReaderConnection(NatsConnection connection) {
         reader.setConnection(connection);
     }

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -74,7 +74,14 @@ class NatsConnectionReader implements Runnable {
     private final AtomicBoolean running;
 
     private final boolean utf8Mode;
-    private final ReadListener readListener;
+    // The listener the reader thread invokes: either a no-op (no ReadListener configured) or a wrapper
+    // that dispatches on the CURRENT connection (read from the volatile connection field at call time).
+    // volatile because the reader thread reads it and the setConnection caller thread may replace it.
+    private volatile ReadListener readListener;
+    // The raw ReadListener (from Options) the current wrapper was built from - null when the no-op is in
+    // place. Used by refreshReadListener to skip a needless rebuild when a repoint doesn't change it.
+    // Only touched by the constructing / repointing thread, never the reader thread.
+    private ReadListener currentUserRl;
 
     NatsConnectionReader(NatsConnection connection) {
         this.connection = connection;
@@ -91,29 +98,69 @@ class NatsConnectionReader implements Runnable {
 
         this.utf8Mode = connection.getOptions().supportUTF8Subjects();
 
-        final ReadListener rl = connection.getOptions().getReadListener();
-        if (rl == null) {
+        refreshReadListener(connection);
+    }
+
+    // (Re)derive the readListener from the connection's Options, but replace it ONLY when the configured
+    // ReadListener actually changed - so a repoint that doesn't change it costs nothing. The wrapper reads
+    // the current connection from the volatile field at dispatch time (not a captured reference), so when
+    // the source listener is unchanged the existing wrapper (or no-op) is already correct for the new
+    // connection and is kept as-is.
+    //   - first call (construction): readListener is still null, so we always build.
+    //   - repoint, old null + new null: same (no-op already installed) - keep it.
+    //   - repoint, old == new (same instance): the wrapper is fine - keep it.
+    //   - otherwise: build the matching wrapper (or no-op) and remember the new source.
+    private void refreshReadListener(NatsConnection connection) {
+        final ReadListener newSuppliedUserRl = connection.getOptions().getReadListener();
+        if (readListener != null && newSuppliedUserRl == currentUserRl) {
+            return;
+        }
+        currentUserRl = newSuppliedUserRl;
+        if (newSuppliedUserRl == null) {
             readListener = new ReadListener() {};
         }
         else {
             readListener = new ReadListener() {
                 @Override
                 public void protocol(String op, String text) {
-                    connection.makeCallback(() -> rl.protocol(op, text));
+                    NatsConnectionReader.this.connection.makeCallback(() -> newSuppliedUserRl.protocol(op, text));
                 }
 
                 @Override
                 public void message(String op, Message message) {
-                    connection.makeCallback(() -> rl.message(op, message));
+                    NatsConnectionReader.this.connection.makeCallback(() -> newSuppliedUserRl.message(op, message));
                 }
             };
         }
     }
 
-    // Repoint this reader at a different connection. The field is volatile so the reader thread
-    // picks up the change on its next delivery.
+    // test access only - the listener the reader thread would invoke (no-op or wrapper)
+    ReadListener readListenerForTesting() {
+        return readListener;
+    }
+
+    // Repoint this reader at a different connection. The connection field is volatile, so the reader
+    // thread sees the new target the next time it reads it, and the ReadListener is re-derived from the
+    // new connection's Options only when it actually changed (see refreshReadListener).
+    //
+    // What follows the repoint: everything read from the connection field on use - message delivery,
+    // statistics, protocol handling (OK/ERR/PONG/INFO), and the re-derived ReadListener. What does NOT
+    // follow: the wire-parse parameters fixed at construction - the read buffer size, the max-control-line
+    // buffers (msgLineChars / protocolBuffer), and utf8 subject mode. Those hold in-flight parse state and
+    // are used in tight loops by the reader thread; swapping them from another thread mid-parse would
+    // corrupt the message being decoded, so they are intentionally left as constructed. A repoint is
+    // therefore only fully safe across connections whose parse-affecting Options (buffer size, max control
+    // line, utf8 subjects) match; otherwise the reader keeps parsing per its original Options.
+    //
+    // INVARIANT: volatile gives visibility, NOT atomicity across a multi-step message parse. This method
+    // does NOT require the reader to be stopped first - a caller may repoint a running reader - so if a
+    // repoint lands mid-message it can straddle both connections (e.g. read stats registered on the
+    // previous connection, delivery on the new one). A caller needing a clean handoff must ensure the
+    // reader is between messages, or accept the split. When the two connections share the same underlying
+    // socket, delivering to the new connection is correct and only a read-byte stat is split.
     protected void setConnection(NatsConnection connection) {
         this.connection = connection;
+        refreshReadListener(connection);
     }
 
     // Should only be called if the current thread has exited.

--- a/src/main/java/io/nats/client/impl/NatsConnectionReader.java
+++ b/src/main/java/io/nats/client/impl/NatsConnectionReader.java
@@ -40,7 +40,11 @@ class NatsConnectionReader implements Runnable {
         GATHER_DATA
     }
 
-    private final NatsConnection connection;
+    // volatile (was final) so a live reader can be repointed at a different connection - the reader
+    // thread reads this on every delivered message and must see the new target. Repointing is done
+    // through setConnection(...) rather than direct field access, so the field stays private; see
+    // NatsConnection.setReaderConnection(...) for the entry point
+    private volatile NatsConnection connection;
 
     private ByteBuffer protocolBuffer; // use a byte buffer to assist character decoding
 
@@ -104,6 +108,12 @@ class NatsConnectionReader implements Runnable {
                 }
             };
         }
+    }
+
+    // Repoint this reader at a different connection. The field is volatile so the reader thread
+    // picks up the change on its next delivery.
+    protected void setConnection(NatsConnection connection) {
+        this.connection = connection;
     }
 
     // Should only be called if the current thread has exited.


### PR DESCRIPTION
Allows a `NatsConnectionReader` to be repointed to a different `NatsConnection` without exposing internals.

- `NatsConnectionReader.connection`: `final` → `private volatile`, set via a new `setConnection(...)` so the reader thread sees the new target on its next read.
- New `protected NatsConnection.setReaderConnection(NatsConnection)` is the entry point; the reader's field stays private.
- The `ReadListener` is re-derived from the new connection's `Options`, rebuilt only when it actually changed.

The repoint is a single volatile write — visible to the reader thread but not atomic with respect to an in-flight message parse; the threading contract is documented on `setConnection`.
