### PR TITLE
Count connect failure once per server, not once per resolved IP

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -281,14 +281,16 @@ class NatsConnection implements Connection {
                 timeTraceLogger.trace("setting status to disconnected");
                 updateStatus(Status.DISCONNECTED, resolved, cur);
 
-                failList.add(cur);
-                serverPool.connectFailed(cur);
-
                 String err = connectError.get();
 
                 if (this.isAuthenticationError(err)) {
                     this.serverAuthErrors.put(resolved, err);
                 }
+            }
+
+            if (!isConnected() && !isClosed()) {
+                failList.add(cur);
+                serverPool.connectFailed(cur);
             }
         }
 
@@ -482,7 +484,6 @@ class NatsConnection implements Connection {
                     return;
                 }
 
-                serverPool.connectFailed(cur);
                 String err = connectError.get();
                 if (this.isAuthenticationError(err)) {
                     if (err.equals(this.serverAuthErrors.get(resolved))) {
@@ -490,6 +491,10 @@ class NatsConnection implements Connection {
                     }
                     serverAuthErrors.put(resolved, err);
                 }
+            }
+
+            if (!isConnected() && !isClosed()) {
+                serverPool.connectFailed(cur);
             }
         }
     }

--- a/src/test/java/io/nats/client/impl/MaxReconnectResolvedIpsTest.java
+++ b/src/test/java/io/nats/client/impl/MaxReconnectResolvedIpsTest.java
@@ -1,0 +1,132 @@
+// Copyright 2026 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.nats.client.impl;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import io.nats.client.utils.TestBase;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Proves that the maxReconnect budget is honored per logical server, independent of how many
+ * IP addresses that server's hostname resolves to.
+ *
+ * <p>Before the fix, {@code connectFailed} was invoked once per resolved IP address, so a hostname
+ * resolving to N addresses exhausted the maxReconnect budget roughly N times faster than a
+ * single-address server. With maxReconnects = M and a hostname resolving to N addresses, the client
+ * should make exactly N * (M + 1) connection attempts before giving up (the "+1" is the initial
+ * connect round, which shares the same budget). The bug made it give up after far fewer.
+ */
+public class MaxReconnectResolvedIpsTest extends TestBase {
+
+    private static final AtomicInteger CONNECT_ATTEMPTS = new AtomicInteger(0);
+
+    // A DataPort that never connects and simply counts how many connect attempts were made.
+    // Must be public: Options.buildDataPort() instantiates it reflectively from another package.
+    public static class CountingFailDataPort implements DataPort {
+        @Override
+        @SuppressWarnings("ClassEscapesDefinedScope")
+        public void connect(@NonNull String serverURI, @NonNull NatsConnection conn, long timeoutNanos) throws IOException {
+            CONNECT_ATTEMPTS.incrementAndGet();
+            throw new IOException("test data port refuses to connect");
+        }
+
+        @Override public void upgradeToSecure() {}
+        @Override public int read(byte[] dst, int off, int len) { return -1; }
+        @Override public void write(byte[] src, int toWrite) {}
+        @Override public void shutdownInput() {}
+        @Override public void close() {}
+        @Override public void flush() {}
+    }
+
+    // A server pool that resolves the single configured hostname to a fixed set of IP addresses.
+    public static class MultiIpServerPool extends NatsServerPool {
+        private final List<String> ips;
+        MultiIpServerPool(List<String> ips) {
+            this.ips = ips;
+        }
+        @Override
+        public List<String> resolveHostToIps(@NonNull String host, boolean maxOneResult, boolean includeIPV6) {
+            return ips;
+        }
+    }
+
+    @Test
+    public void testMaxReconnectNotDividedByResolvedIpCount() throws Exception {
+        int maxReconnects = 4;
+        List<String> resolvedIps = Arrays.asList("192.0.2.1", "192.0.2.2", "192.0.2.3"); // TEST-NET-1, never routable
+        int numIps = resolvedIps.size();
+
+        CONNECT_ATTEMPTS.set(0);
+
+        Options options = new Options.Builder()
+            .server("nats://fakehost.invalid:4222") // a hostname (not an IP) so resolveHost is exercised
+            .serverPool(new MultiIpServerPool(resolvedIps))
+            .dataPortType(CountingFailDataPort.class.getName())
+            .maxReconnects(maxReconnects)
+            .reconnectWait(Duration.ofMillis(1))
+            .reconnectJitter(Duration.ofMillis(1))
+            .connectionTimeout(Duration.ofMillis(200))
+            .noRandomize()
+            .build();
+
+        // reconnectOnConnect makes the initial connect share the same reconnect budget, so the
+        // whole budget is exhausted synchronously before this call returns a closed connection.
+        try (Connection conn = Nats.connectReconnectOnConnect(options)) {
+            assertEquals(Connection.Status.CLOSED, conn.getStatus());
+
+            // Initial round + maxReconnects rounds, each trying every resolved IP once.
+            int expected = numIps * (maxReconnects + 1);
+            assertEquals(expected, CONNECT_ATTEMPTS.get(),
+                    "maxReconnect budget must be per-server, not per-resolved-IP");
+        }
+    }
+
+    @Test
+    public void testSingleIpBaselineUnchanged() throws Exception {
+        // Same scenario with a single resolved IP: the attempt count must match the multi-IP case
+        // scaled by IP count, confirming the budget itself is unchanged (numIps * (maxReconnects + 1)).
+        int maxReconnects = 4;
+        List<String> resolvedIps = Collections.singletonList("192.0.2.1");
+
+        CONNECT_ATTEMPTS.set(0);
+
+        final Options options = new Options.Builder()
+            .server("nats://fakehost.invalid:4222")
+            .serverPool(new MultiIpServerPool(resolvedIps))
+            .dataPortType(CountingFailDataPort.class.getName())
+            .maxReconnects(maxReconnects)
+            .reconnectWait(Duration.ofMillis(1))
+            .reconnectJitter(Duration.ofMillis(1))
+            .connectionTimeout(Duration.ofMillis(200))
+            .noRandomize()
+            .build();
+
+        try (Connection conn = Nats.connectReconnectOnConnect(options)) {
+            assertEquals(Connection.Status.CLOSED, conn.getStatus());
+            assertEquals(maxReconnects + 1, CONNECT_ATTEMPTS.get());
+        }
+    }
+}

--- a/src/test/java/io/nats/client/impl/MaxReconnectResolvedIpsTest.java
+++ b/src/test/java/io/nats/client/impl/MaxReconnectResolvedIpsTest.java
@@ -19,6 +19,7 @@ import io.nats.client.Options;
 import io.nats.client.utils.TestBase;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MaxReconnectResolvedIpsTest extends TestBase {
 
     private static final AtomicInteger CONNECT_ATTEMPTS = new AtomicInteger(0);
+    private static final String CONNECT_ATTEMPTS_LOCK = "MaxReconnectResolvedIpsTest.CONNECT_ATTEMPTS";
 
     // A DataPort that never connects and simply counts how many connect attempts were made.
     // Must be public: Options.buildDataPort() instantiates it reflectively from another package.
@@ -74,6 +76,7 @@ public class MaxReconnectResolvedIpsTest extends TestBase {
     }
 
     @Test
+    @ResourceLock(CONNECT_ATTEMPTS_LOCK)
     public void testMaxReconnectNotDividedByResolvedIpCount() throws Exception {
         int maxReconnects = 4;
         List<String> resolvedIps = Arrays.asList("192.0.2.1", "192.0.2.2", "192.0.2.3"); // TEST-NET-1, never routable
@@ -105,6 +108,7 @@ public class MaxReconnectResolvedIpsTest extends TestBase {
     }
 
     @Test
+    @ResourceLock(CONNECT_ATTEMPTS_LOCK)
     public void testSingleIpBaselineUnchanged() throws Exception {
         // Same scenario with a single resolved IP: the attempt count must match the multi-IP case
         // scaled by IP count, confirming the budget itself is unchanged (numIps * (maxReconnects + 1)).


### PR DESCRIPTION
## Problem

The `maxReconnects` budget is consumed per **resolved IP address** instead of per **logical server**. `serverPool.connectFailed(cur)` is called inside the loop over the addresses that a server's hostname resolves to — in both the initial connect loop (`tryToConnect` callers in `connectImpl`) and `reconnectImplConnect`. Since `NatsServerPool.connectFailed` increments `failedAttempts` and drops the server from the pool once it reaches `maxConnectAttempts`, a hostname resolving to N addresses exhausts the budget roughly N times faster than a single-address server.

## How to reproduce

1. Configure a client with `maxReconnects(M)` pointing at a single unreachable server whose hostname resolves to N > 1 IP addresses (common with round-robin DNS, Kubernetes headless services, or dual-stack A + AAAA records).
2. Let the connection fail and observe the number of connection attempts before the client gives up.

## Current behavior

Each failed attempt against each resolved address counts against the server's `maxReconnects` budget. With N resolved addresses the pool removes the server after only about `M / N` failed rounds — e.g. `maxReconnects(4)` against a hostname resolving to 3 addresses gives up after roughly one round of reconnect attempts instead of four.

## Expected behavior

One full round over all of a server's resolved addresses counts as **one** failed attempt against that server. With `maxReconnects(M)` the client performs M reconnect rounds regardless of how many addresses the hostname resolves to; the total number of socket-level attempts is `N × M` (plus the initial round).

## Fix

Move the `serverPool.connectFailed(cur)` call (and the `failList` bookkeeping in the connect path) out of the per-resolved-address loop, so it runs once after a whole round over the server's addresses has failed. It is guarded by `!isConnected() && !isClosed()` so a success or a close mid-round doesn't record a failure.

## Why the unit test proves the fix

`MaxReconnectResolvedIpsTest` removes both the network and DNS from the equation so the attempt count is fully deterministic:

* A custom `NatsServerPool` overrides `resolveHostToIps` to return a fixed list of addresses for the configured hostname — simulating multi-address DNS without any actual resolution.
* A custom `DataPort` counts every `connect` invocation and always throws `IOException` — every attempt fails, so the client must walk through its entire reconnect budget.
* `Nats.connectReconnectOnConnect` makes the initial connect share the reconnect budget and exhaust it synchronously, so by the time the call returns a `CLOSED` connection all attempts have happened.

`testMaxReconnectNotDividedByResolvedIpCount` uses `maxReconnects = 4` with 3 resolved addresses and asserts **exactly** `3 × (4 + 1) = 15` connect attempts. Before the fix, `connectFailed` fired once per address per round (3× per round), so the budget of 4 was exhausted after about one round and the count came out far below 15 — the assertion fails on the old code and passes with the fix. The strict equality also proves the fix doesn't over-count: more than 15 would mean the budget stopped being honored.

`testSingleIpBaselineUnchanged` runs the same scenario with 1 resolved address and asserts `4 + 1 = 5` attempts, proving the single-address behavior (where per-address and per-server counting coincide) is unchanged by the fix.