### PR TITLE
ScheduledTask: survive tick exceptions and report them to ErrorListener

### DIFF
--- a/src/main/java/io/nats/client/impl/MessageManager.java
+++ b/src/main/java/io/nats/client/impl/MessageManager.java
@@ -155,7 +155,8 @@ abstract class MessageManager {
                         if (sinceLast > alarmPeriodSettingNanos.get()) {
                             handleHeartbeatError();
                         }
-                    })
+                    },
+                    conn::reportScheduledTaskException)
             );
 
             // since we just scheduled, reset this otherwise it may alarm too soon

--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -648,13 +648,14 @@ class NatsConnection implements Connection {
                                 // it's running in a thread, there is no point throwing here
                             }
                         }
-                    });
+                    }, this::reportScheduledTaskException);
                 }
 
                 long cleanMillis = this.options.getRequestCleanupInterval().toMillis();
 
                 if (cleanMillis > 0) {
-                    cleanupTask = new ScheduledTask(scheduledExecutor, cleanMillis, () -> cleanResponses(false));
+                    cleanupTask = new ScheduledTask(scheduledExecutor, cleanMillis,
+                        () -> cleanResponses(false), this::reportScheduledTaskException);
                 }
             }
 
@@ -1928,6 +1929,10 @@ class NatsConnection implements Connection {
     protected void processException(Exception exp) {
         this.statistics.incrementExceptionCount();
         makeCallback(() -> options.getErrorListener().exceptionOccurred(this, exp));
+    }
+
+    void reportScheduledTaskException(Throwable t) {
+        processException(t instanceof Exception ? (Exception) t : new RuntimeException(t));
     }
 
     protected void processError(String errorText) {

--- a/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
+++ b/src/main/java/io/nats/client/impl/SocketDataPortWithWriteTimeout.java
@@ -68,7 +68,8 @@ public class SocketDataPortWithWriteTimeout extends SocketDataPort {
                         // This task is going to re-run anyway, so no point in throwing
                     }
                 }
-            });
+            },
+            conn::reportScheduledTaskException);
     }
 
     public void write(byte[] src, int toWrite) throws IOException {

--- a/src/main/java/io/nats/client/support/ScheduledTask.java
+++ b/src/main/java/io/nats/client/support/ScheduledTask.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 
 /**
@@ -32,6 +33,7 @@ public class ScheduledTask implements Runnable {
 
     private final String id;
     private final Runnable runnable;
+    private final Consumer<Throwable> reporter;
     protected final AtomicReference<ScheduledFuture<?>> scheduledFutureRef;
 
     protected final AtomicBoolean notShutdown;
@@ -40,28 +42,41 @@ public class ScheduledTask implements Runnable {
     protected final long periodNanos;
 
     public ScheduledTask(ScheduledExecutorService ses, long initialAndPeriodMillis, Runnable runnable) {
-        this(null, ses, initialAndPeriodMillis, initialAndPeriodMillis, TimeUnit.MILLISECONDS, runnable);
+        this(null, ses, initialAndPeriodMillis, initialAndPeriodMillis, TimeUnit.MILLISECONDS, runnable, null);
+    }
+
+    public ScheduledTask(ScheduledExecutorService ses, long initialAndPeriodMillis, Runnable runnable, Consumer<Throwable> reporter) {
+        this(null, ses, initialAndPeriodMillis, initialAndPeriodMillis, TimeUnit.MILLISECONDS, runnable, reporter);
     }
 
     public ScheduledTask(String id, ScheduledExecutorService ses, long initialAndPeriodMillis, Runnable runnable) {
-        this(id, ses, initialAndPeriodMillis, initialAndPeriodMillis, TimeUnit.MILLISECONDS, runnable);
+        this(id, ses, initialAndPeriodMillis, initialAndPeriodMillis, TimeUnit.MILLISECONDS, runnable, null);
     }
 
     public ScheduledTask(ScheduledExecutorService ses, long initialAndPeriod, TimeUnit unit, Runnable runnable) {
-        this(null, ses, initialAndPeriod, initialAndPeriod, unit, runnable);
+        this(null, ses, initialAndPeriod, initialAndPeriod, unit, runnable, null);
+    }
+
+    public ScheduledTask(ScheduledExecutorService ses, long initialAndPeriod, TimeUnit unit, Runnable runnable, Consumer<Throwable> reporter) {
+        this(null, ses, initialAndPeriod, initialAndPeriod, unit, runnable, reporter);
     }
 
     public ScheduledTask(String id, ScheduledExecutorService ses, long initialAndPeriod, TimeUnit unit, Runnable runnable) {
-        this(id, ses, initialAndPeriod, initialAndPeriod, unit, runnable);
+        this(id, ses, initialAndPeriod, initialAndPeriod, unit, runnable, null);
     }
 
     public ScheduledTask(ScheduledExecutorService ses, long initialDelay, long period, TimeUnit unit, Runnable runnable) {
-        this(null, ses, initialDelay, period, unit, runnable);
+        this(null, ses, initialDelay, period, unit, runnable, null);
     }
 
     public ScheduledTask(String id, ScheduledExecutorService ses, long initialDelay, long period, TimeUnit unit, Runnable runnable) {
+        this(id, ses, initialDelay, period, unit, runnable, null);
+    }
+
+    public ScheduledTask(String id, ScheduledExecutorService ses, long initialDelay, long period, TimeUnit unit, Runnable runnable, Consumer<Throwable> reporter) {
         this.id = id == null || id.isEmpty() ? "st-" + ID_GENERATOR.getAndIncrement() : id;
         this.runnable = runnable;
+        this.reporter = reporter;
         notShutdown = new AtomicBoolean(true);
         executing = new AtomicBoolean(false);
         this.initialDelayNanos = unit.toNanos(initialDelay);
@@ -78,6 +93,11 @@ public class ScheduledTask implements Runnable {
         return periodNanos;
     }
 
+    // A throw that escapes run() permanently cancels the fixed-rate schedule
+    // (see ScheduledExecutorService.scheduleAtFixedRate), so recoverable problems
+    // are caught and reported, keeping the schedule alive. VirtualMachineError
+    // (OutOfMemoryError, StackOverflowError, ...) is reported then rethrown,
+    // deliberately letting the schedule die.
     @Override
     public void run() {
         try {
@@ -86,8 +106,25 @@ public class ScheduledTask implements Runnable {
                 runnable.run();
             }
         }
+        catch (Throwable t) {
+            report(t);
+            if (t instanceof VirtualMachineError) {
+                throw (VirtualMachineError) t;
+            }
+        }
         finally {
             executing.set(false);
+        }
+    }
+
+    private void report(Throwable t) {
+        if (reporter != null) {
+            try {
+                reporter.accept(t);
+            }
+            catch (Throwable ignore) {
+                // a throwing reporter must not affect the schedule
+            }
         }
     }
 

--- a/src/test/java/io/nats/client/support/ScheduledTaskTests.java
+++ b/src/test/java/io/nats/client/support/ScheduledTaskTests.java
@@ -2,12 +2,16 @@ package io.nats.client.support;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.nats.client.utils.TestBase.variant;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScheduledTaskTests {
@@ -71,6 +75,96 @@ public class ScheduledTaskTests {
         assertEquals(count, sttr400.counter.get());
         assertTrue(task400.toString().contains("shutdown"));
         assertTrue(task400.toString().contains("/done"));
+    }
+
+    @Test
+    public void testThrowingTickIsReportedAndScheduleSurvives() throws InterruptedException {
+        ScheduledThreadPoolExecutor stpe = testExecutor();
+        try {
+            AtomicInteger ticks = new AtomicInteger();
+            List<Throwable> reported = new CopyOnWriteArrayList<>();
+            ScheduledTask task = new ScheduledTask(stpe, 50, TimeUnit.MILLISECONDS,
+                () -> { throw new RuntimeException("tick " + ticks.incrementAndGet()); },
+                reported::add);
+
+            Thread.sleep(500);
+            assertFalse(task.isDone());
+            task.shutdown();
+            assertTrue(task.isDone());
+            Thread.sleep(100); // let any in-flight tick finish reporting
+
+            assertTrue(ticks.get() >= 3, "ticks must keep firing after a tick throws, saw " + ticks.get());
+            assertEquals(ticks.get(), reported.size());
+            assertInstanceOf(RuntimeException.class, reported.get(0));
+        }
+        finally {
+            stpe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testThrowingTickWithoutReporterScheduleStillSurvives() throws InterruptedException {
+        ScheduledThreadPoolExecutor stpe = testExecutor();
+        try {
+            AtomicInteger ticks = new AtomicInteger();
+            ScheduledTask task = new ScheduledTask(stpe, 50, TimeUnit.MILLISECONDS,
+                () -> { throw new RuntimeException("tick " + ticks.incrementAndGet()); });
+
+            Thread.sleep(500);
+            assertTrue(ticks.get() >= 3, "ticks must keep firing without a reporter, saw " + ticks.get());
+            assertFalse(task.isDone());
+            task.shutdown();
+        }
+        finally {
+            stpe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testThrowingReporterDoesNotKillSchedule() throws InterruptedException {
+        ScheduledThreadPoolExecutor stpe = testExecutor();
+        try {
+            AtomicInteger ticks = new AtomicInteger();
+            ScheduledTask task = new ScheduledTask(stpe, 50, TimeUnit.MILLISECONDS,
+                () -> { throw new RuntimeException("tick " + ticks.incrementAndGet()); },
+                t -> { throw new IllegalStateException("reporter is broken too"); });
+
+            Thread.sleep(500);
+            assertTrue(ticks.get() >= 3, "ticks must keep firing when the reporter throws, saw " + ticks.get());
+            assertFalse(task.isDone());
+            task.shutdown();
+        }
+        finally {
+            stpe.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testFatalErrorIsReportedAndScheduleDies() throws InterruptedException {
+        ScheduledThreadPoolExecutor stpe = testExecutor();
+        try {
+            AtomicInteger ticks = new AtomicInteger();
+            List<Throwable> reported = new CopyOnWriteArrayList<>();
+            ScheduledTask task = new ScheduledTask(stpe, 50, TimeUnit.MILLISECONDS,
+                () -> { ticks.incrementAndGet(); throw new OutOfMemoryError("simulated"); },
+                reported::add);
+
+            Thread.sleep(500);
+            assertEquals(1, ticks.get(), "a fatal error must end the schedule after the first tick");
+            assertEquals(1, reported.size());
+            assertInstanceOf(OutOfMemoryError.class, reported.get(0));
+            assertTrue(task.isDone());
+        }
+        finally {
+            stpe.shutdownNow();
+        }
+    }
+
+    private static ScheduledThreadPoolExecutor testExecutor() {
+        ScheduledThreadPoolExecutor stpe = new ScheduledThreadPoolExecutor(1);
+        stpe.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+        stpe.setRemoveOnCancelPolicy(true);
+        return stpe;
     }
 
     @SuppressWarnings("SameParameterValue")


### PR DESCRIPTION
## Problem

When any exception is generated inside `io.nats.client.support.ScheduledTask#run`, it stays invisible — without any logging imprints — and it stops the scheduled task from being rescheduled afterward, silently losing all upcoming schedules.

## Expected behaviour

1. Log the error.
2. Keep the scheduled trigger for next tasks if the exception is recoverable.

## Proof that it won't be rescheduled

`ScheduledFutureTask.run()` calls `runAndReset()`:

```java
protected boolean runAndReset() {
    if (state != NEW || !RUNNER.compareAndSet(this, null, Thread.currentThread()))
        return false;
    boolean ran = false;
    int s = state;
    try {
        Callable<V> c = callable;
        if (c != null && s == NEW) {
            try {
                c.call();           // note: result is NOT recorded
                ran = true;
            } catch (Throwable ex) {
                setException(ex);   // state: NEW -> COMPLETING -> EXCEPTIONAL
            }
        }
    } finally { ... }
    return ran && s == NEW;
}
```

- On success, `c.call()` returns, `ran = true`, and — unlike plain `run()` — the result is never stored, so the state stays `NEW`. That's the "reset": a `FutureTask` is reusable only while its state is `NEW`, and `runAndReset` deliberately avoids consuming it. Returns `true`.
- On exception, the `catch (Throwable ex)` calls `setException(ex)`, which irreversibly transitions the state to `EXCEPTIONAL` (`FutureTask` states are one-way; there's no path back to `NEW`). `ran` stays `false`, so it returns `false`. The exception is now stored in the future — retrievable via `get()`, never rethrown to the worker thread.

Then `ScheduledFutureTask.run()` consumes that boolean:

```java
else if (super.runAndReset()) {
    setNextRunTime();
    reExecutePeriodic(outerTask);   // only on true!
}
```

So the suppress-forever behavior is just: exception → `runAndReset()` returns `false` → the task is silently not re-enqueued, and since its state is now `EXCEPTIONAL` it couldn't run again even if it were (the `state != NEW` guard at the top would bail). Nothing is logged, no thread dies — the throwable sits in the future waiting for a `get()` that, in the fixed-rate pattern, nobody ever calls.