### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsPublishSubscribePublish.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsPublishSubscribePublish.java
@@ -1,0 +1,34 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LearnCoreNatsPublishSubscribePublish {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            nc.createDispatcher(msg ->
+                System.out.println("warehouse received: " + new String(msg.getData(), StandardCharsets.UTF_8))
+            ).subscribe("orders.created");
+            Thread.sleep(200);
+
+            // NATS-DOC-START
+            // Publish one order to the orders.created subject. Publishing is
+            // fire-and-forget: the call hands the message to the server and returns.
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            nc.publish("orders.created", order);
+            // NATS-DOC-END
+
+            Thread.sleep(300);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsPublishSubscribeSubscribe.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsPublishSubscribeSubscribe.java
@@ -1,0 +1,33 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LearnCoreNatsPublishSubscribeSubscribe {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // NATS-DOC-START
+            // Subscribe as the warehouse service to orders.created. Each matching
+            // message is delivered to this dispatcher as it is published.
+            nc.createDispatcher(msg ->
+                System.out.println("warehouse received: " + new String(msg.getData(), StandardCharsets.UTF_8))
+            ).subscribe("orders.created");
+            // NATS-DOC-END
+
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            Thread.sleep(200);
+            nc.publish("orders.created", order);
+            Thread.sleep(300);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsQueueGroupsQueueSubscribe.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsQueueGroupsQueueSubscribe.java
@@ -1,0 +1,34 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LearnCoreNatsQueueGroupsQueueSubscribe {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // NATS-DOC-START
+            // Join the "packers" queue group on orders.created. Every subscriber that
+            // names the same group shares the load: each order is delivered to exactly
+            // one member. Run this in several processes to watch the load balance.
+            nc.createDispatcher(msg ->
+                System.out.println("packer handling: " + new String(msg.getData(), StandardCharsets.UTF_8))
+            ).subscribe("orders.created", "packers");
+            // NATS-DOC-END
+
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            Thread.sleep(200);
+            nc.publish("orders.created", order);
+            Thread.sleep(300);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyReplies.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyReplies.java
@@ -1,0 +1,55 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import io.nats.client.Subscription;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LearnCoreNatsRequestReplyReplies {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // Two inventory instances that both answer.
+            for (int i = 0; i < 2; i++) {
+                nc.createDispatcher(msg -> {
+                    if (msg.getReplyTo() != null) {
+                        nc.publish(msg.getReplyTo(),
+                            "{\"in_stock\":true,\"warehouse\":\"us-east\"}".getBytes(StandardCharsets.UTF_8));
+                    }
+                }).subscribe("orders.inventory.check");
+            }
+            Thread.sleep(200);
+
+            // NATS-DOC-START
+            // Gather more than one reply to a single request. A plain request returns
+            // only the first reply, so when several services may answer, subscribe to
+            // your own inbox, publish the request with that inbox as the reply subject,
+            // and collect replies until they stop arriving.
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            String inbox = nc.createInbox();
+            Subscription sub = nc.subscribe(inbox);
+            nc.publish("orders.inventory.check", inbox, order);
+
+            List<String> replies = new ArrayList<>();
+            Message m = sub.nextMessage(Duration.ofMillis(300));
+            while (m != null) {
+                replies.add(new String(m.getData(), StandardCharsets.UTF_8));
+                m = sub.nextMessage(Duration.ofMillis(300));
+            }
+            System.out.println("gathered " + replies.size() + " replies");
+            // NATS-DOC-END
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyRequest.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyRequest.java
@@ -33,7 +33,7 @@ public class LearnCoreNatsRequestReplyRequest {
 
             // NATS-DOC-START
             // Ask the inventory service whether an order's item is in stock. A missing
-            // service surfaces immediately as a cancelled request; a slow one as a
+            // service surfaces immediately as a canceled request; a slow one as a
             // timeout.
             byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
                 + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyRequest.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyRequest.java
@@ -1,0 +1,66 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.JetStreamStatusException;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class LearnCoreNatsRequestReplyRequest {
+    public static void main(String[] args) {
+        // reportNoResponders() makes a request to an unserved subject fail fast
+        // instead of waiting out the timeout.
+        Options options = Options.builder()
+            .server("nats://localhost:4222")
+            .reportNoResponders()
+            .build();
+        try (Connection nc = Nats.connect(options)) {
+            // A running inventory service so the request gets an answer.
+            nc.createDispatcher(msg -> {
+                if (msg.getReplyTo() != null) {
+                    nc.publish(msg.getReplyTo(),
+                        "{\"in_stock\":true,\"warehouse\":\"us-east\"}".getBytes(StandardCharsets.UTF_8));
+                }
+            }).subscribe("orders.inventory.check");
+            Thread.sleep(200);
+
+            // NATS-DOC-START
+            // Ask the inventory service whether an order's item is in stock. A missing
+            // service surfaces immediately as a cancelled request; a slow one as a
+            // timeout.
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            CompletableFuture<Message> future = nc.request("orders.inventory.check", order);
+            try {
+                Message reply = future.get(2, TimeUnit.SECONDS);
+                System.out.println("inventory replied: " + new String(reply.getData(), StandardCharsets.UTF_8));
+            }
+            catch (TimeoutException e) {
+                System.out.println("inventory service did not answer in time");
+            }
+            catch (ExecutionException e) {
+                // reportNoResponders() surfaces a missing service as a 503 status
+                if (e.getCause() instanceof JetStreamStatusException) {
+                    System.out.println("no inventory service is running");
+                }
+                else {
+                    System.out.println("request failed: " + e.getMessage());
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyRespond.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsRequestReplyRespond.java
@@ -1,0 +1,38 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnCoreNatsRequestReplyRespond {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // NATS-DOC-START
+            // The inventory service: subscribe to orders.inventory.check and answer
+            // every request by publishing back to the reply subject it carries.
+            nc.createDispatcher(msg -> {
+                if (msg.getReplyTo() != null) {
+                    nc.publish(msg.getReplyTo(),
+                        "{\"in_stock\":true,\"warehouse\":\"us-east\"}".getBytes(StandardCharsets.UTF_8));
+                }
+            }).subscribe("orders.inventory.check");
+            // NATS-DOC-END
+
+            Thread.sleep(200);
+            Message reply = nc.request("orders.inventory.check", null, Duration.ofSeconds(2));
+            if (reply != null) {
+                System.out.println("inventory replied: " + new String(reply.getData(), StandardCharsets.UTF_8));
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsScatterGatherGather.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsScatterGatherGather.java
@@ -1,0 +1,55 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+import io.nats.client.Subscription;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LearnCoreNatsScatterGatherGather {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // Three shipping-quote providers, each answering on shipping.quote.
+            for (int i = 0; i < 3; i++) {
+                nc.createDispatcher(msg -> {
+                    if (msg.getReplyTo() != null) {
+                        nc.publish(msg.getReplyTo(),
+                            "{\"carrier\":\"carrier-a\",\"quote_cents\":1500}".getBytes(StandardCharsets.UTF_8));
+                    }
+                }).subscribe("shipping.quote");
+            }
+            Thread.sleep(200);
+
+            // NATS-DOC-START
+            // Scatter one request to every shipping-quote provider and gather the
+            // replies. Subscribe to a private inbox, publish the request with that
+            // inbox as the reply subject, then collect quotes until they stop arriving
+            // and pick the cheapest.
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            String inbox = nc.createInbox();
+            Subscription sub = nc.subscribe(inbox);
+            nc.publish("shipping.quote", inbox, order);
+
+            List<String> quotes = new ArrayList<>();
+            Message m = sub.nextMessage(Duration.ofMillis(300));
+            while (m != null) {
+                quotes.add(new String(m.getData(), StandardCharsets.UTF_8));
+                m = sub.nextMessage(Duration.ofMillis(300));
+            }
+            System.out.println("gathered " + quotes.size() + " quotes");
+            // NATS-DOC-END
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsScatterGatherProvider.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsScatterGatherProvider.java
@@ -1,0 +1,39 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnCoreNatsScatterGatherProvider {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // NATS-DOC-START
+            // A shipping-quote provider. Subscribe plainly to shipping.quote (NOT in a
+            // queue group, so every provider sees each request) and reply with a price.
+            // Run several copies, each quoting a different number.
+            nc.createDispatcher(msg -> {
+                if (msg.getReplyTo() != null) {
+                    nc.publish(msg.getReplyTo(),
+                        "{\"carrier\":\"carrier-a\",\"quote_cents\":1500}".getBytes(StandardCharsets.UTF_8));
+                }
+            }).subscribe("shipping.quote");
+            // NATS-DOC-END
+
+            Thread.sleep(200);
+            Message reply = nc.request("shipping.quote", null, Duration.ofSeconds(2));
+            if (reply != null) {
+                System.out.println("quote: " + new String(reply.getData(), StandardCharsets.UTF_8));
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsSubjectsAndWildcardsWildcardMulti.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsSubjectsAndWildcardsWildcardMulti.java
@@ -1,0 +1,36 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LearnCoreNatsSubjectsAndWildcardsWildcardMulti {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // NATS-DOC-START
+            // Audit service: catch every order message at any depth. The multi-token
+            // wildcard > matches one or more tokens and must be the last token, so
+            // orders.> matches orders.created, orders.us.created, and
+            // orders.us.west.created alike.
+            nc.createDispatcher(msg ->
+                System.out.println("audit: " + msg.getSubject())
+            ).subscribe("orders.>");
+            // NATS-DOC-END
+
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            Thread.sleep(200);
+            nc.publish("orders.created", order);
+            nc.publish("orders.shipped", order);
+            Thread.sleep(300);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsSubjectsAndWildcardsWildcardSingle.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnCoreNatsSubjectsAndWildcardsWildcardSingle.java
@@ -1,0 +1,36 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class LearnCoreNatsSubjectsAndWildcardsWildcardSingle {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+            // NATS-DOC-START
+            // Regional analytics: one subscription catches created orders from every
+            // region. The single-token wildcard * matches exactly one token, so both
+            // orders.us.created and orders.eu.created match, while orders.created and
+            // orders.us.west.created do not.
+            nc.createDispatcher(msg ->
+                System.out.println("analytics: new order on " + msg.getSubject())
+            ).subscribe("orders.*.created");
+            // NATS-DOC-END
+
+            byte[] order = ("{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\","
+                + "\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}").getBytes(StandardCharsets.UTF_8);
+            Thread.sleep(200);
+            nc.publish("orders.us.created", order);
+            nc.publish("orders.created", order);
+            Thread.sleep(300);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        catch (IOException e) {
+            // can be thrown by connect
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAcknowledgmentNakWithDelay.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAcknowledgmentNakWithDelay.java
@@ -1,0 +1,37 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnJetStreamAcknowledgmentNakWithDelay {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Pull one message and negatively acknowledge it with a delay.
+            // The server holds the message and redelivers it after 10 seconds,
+            // which backs off retries instead of looping immediately.
+            Message m = cc.next(Duration.ofSeconds(5));
+            if (m == null) {
+                System.out.println("Nothing to read.");
+                return;
+            }
+
+            System.out.printf("subject=%s data=%s%n",
+                m.getSubject(),
+                new String(m.getData(), StandardCharsets.UTF_8));
+
+            m.nakWithDelay(Duration.ofSeconds(10));
+            System.out.println("Nak sent; redelivery delayed 10s.");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAcknowledgmentTermPoison.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAcknowledgmentTermPoison.java
@@ -1,0 +1,37 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnJetStreamAcknowledgmentTermPoison {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Pull one message that can never be processed (a poison message)
+            // and terminate it. The server stops redelivering without marking
+            // it as successfully processed.
+            Message m = cc.next(Duration.ofSeconds(5));
+            if (m == null) {
+                System.out.println("Nothing to read.");
+                return;
+            }
+
+            System.out.printf("subject=%s data=%s%n",
+                m.getSubject(),
+                new String(m.getData(), StandardCharsets.UTF_8));
+
+            m.term();
+            System.out.println("Message terminated; no more redeliveries.");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAcknowledgmentWatchMaxDeliveries.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAcknowledgmentWatchMaxDeliveries.java
@@ -1,0 +1,33 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamAcknowledgmentWatchMaxDeliveries {
+    public static void main(String[] args) throws InterruptedException {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            // NATS-DOC-START
+            // Watch the max-deliveries advisory for this consumer. The server
+            // publishes one of these whenever a message hits MaxDeliver and is
+            // dropped, which is your signal to route it to a dead-letter flow.
+            String advisory = "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.ORDERS.shipping";
+
+            Dispatcher d = nc.createDispatcher(msg ->
+                System.out.println("max-deliveries advisory: " +
+                    new String(msg.getData(), StandardCharsets.UTF_8)));
+            d.subscribe(advisory);
+
+            // Keep the subscription open so advisories can arrive.
+            Thread.sleep(60_000);
+            // NATS-DOC-END
+        }
+        catch (InterruptedException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAdvancedPublishingAsync.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamAdvancedPublishingAsync.java
@@ -1,0 +1,49 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class LearnJetStreamAdvancedPublishingAsync {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Async publish: publishAsync returns a CompletableFuture immediately,
+            // before the server replies, so the round trips overlap. Collect the
+            // futures, then read each ack -- a future that completes exceptionally
+            // is a failed publish you must re-send.
+            String[] orders = {
+                "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\",\"total_cents\":4200}",
+                "{\"order_id\":\"ord_2zr9\",\"customer\":\"globex\",\"total_cents\":7800}",
+                "{\"order_id\":\"ord_5t1m\",\"customer\":\"initech\",\"total_cents\":1500}",
+                "{\"order_id\":\"ord_9p3x\",\"customer\":\"hooli\",\"total_cents\":9900}"
+            };
+
+            List<CompletableFuture<PublishAck>> futures = new ArrayList<>();
+            for (String order : orders) {
+                futures.add(js.publishAsync("orders.created",
+                    order.getBytes(StandardCharsets.UTF_8)));
+            }
+
+            for (int i = 0; i < futures.size(); i++) {
+                try {
+                    PublishAck ack = futures.get(i).get();
+                    System.out.printf("order %d stored at sequence %d%n", i + 1, ack.getSeqno());
+                } catch (Exception e) {
+                    System.out.printf("order %d failed, re-publish it: %s%n", i + 1, e.getMessage());
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamFilteringCreateFiltered.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamFilteringCreateFiltered.java
@@ -1,0 +1,40 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamFilteringCreateFiltered {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Create a durable pull consumer that only sees orders.shipped.
+            // The filter subject narrows the stream's subjects down to one.
+            ConsumerContext cc = sc.createOrUpdateConsumer(
+                ConsumerConfiguration.builder()
+                    .durable("analytics")
+                    .filterSubject("orders.shipped")
+                    .ackPolicy(AckPolicy.Explicit)
+                    .build());
+
+            System.out.println("Created filtered consumer: " + cc.getConsumerName());
+
+            // Fetch a small batch. Only orders.shipped messages come back;
+            // orders.created is filtered out before it reaches this consumer.
+            try (FetchConsumer fc = cc.fetch(
+                    FetchConsumeOptions.builder().maxMessages(5).expiresIn(2000).build())) {
+                Message m;
+                while ((m = fc.nextMessage()) != null) {
+                    System.out.println("subject=" + m.getSubject());
+                    m.ack();
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamFilteringFilterMatchesNothing.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamFilteringFilterMatchesNothing.java
@@ -1,0 +1,37 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamFilteringFilterMatchesNothing {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // The filter subject has a typo: "orders.shiped" matches no stored
+            // subject. The consumer is still created without error.
+            ConsumerContext cc = sc.createOrUpdateConsumer(
+                ConsumerConfiguration.builder()
+                    .durable("analytics-typo")
+                    .filterSubject("orders.shiped")
+                    .ackPolicy(AckPolicy.Explicit)
+                    .build());
+
+            // The fetch blocks until the expiry, then returns nothing. A wrong
+            // filter fails silently: no messages, no error.
+            try (FetchConsumer fc = cc.fetch(
+                    FetchConsumeOptions.builder().maxMessages(5).expiresIn(2000).build())) {
+                Message m = fc.nextMessage();
+                if (m == null) {
+                    System.out.println("Pull returned nothing: filter matched no stored subject.");
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectBySequence.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectBySequence.java
@@ -1,0 +1,27 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamGetDirectBySequence {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Read the message stored at stream sequence 2. Without Direct Get
+            // enabled this is a regular get, served by the stream leader.
+            MessageInfo mi = sc.getMessage(2);
+
+            System.out.println("Subject: " + mi.getSubject());
+            System.out.println("Payload: " + new String(mi.getData(), StandardCharsets.UTF_8));
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectDirectRead.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectDirectRead.java
@@ -1,0 +1,28 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamGetDirectDirectRead {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Read the message at stream sequence 1. Because ORDERS has
+            // AllowDirect enabled, the client sends this over the Direct Get
+            // API, so any replica or mirror can answer instead of the leader.
+            MessageInfo mi = sc.getMessage(1);
+
+            System.out.println("Subject: " + mi.getSubject());
+            System.out.println("Payload: " + new String(mi.getData(), StandardCharsets.UTF_8));
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectEnable.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectEnable.java
@@ -1,0 +1,30 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamGetDirectEnable {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // Read the current configuration so the update keeps every other setting.
+            StreamConfiguration current = jsm.getStreamInfo("ORDERS").getConfiguration();
+
+            // NATS-DOC-START
+            // Turn on Direct Get for ORDERS. Reads can then be served by any
+            // replica or mirror instead of only the stream leader.
+            StreamConfiguration updated = StreamConfiguration.builder(current)
+                    .allowDirect(true)
+                    .build();
+            StreamInfo info = jsm.updateStream(updated);
+
+            System.out.println("AllowDirect: " + info.getConfiguration().getAllowDirect());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectLastForSubject.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamGetDirectLastForSubject.java
@@ -1,0 +1,27 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamGetDirectLastForSubject {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Read the most recent message on a subject. Without Direct Get
+            // enabled this is a regular get, served by the stream leader.
+            MessageInfo mi = sc.getLastMessage("orders.shipped");
+
+            System.out.println("Subject: " + mi.getSubject());
+            System.out.println("Payload: " + new String(mi.getData(), StandardCharsets.UTF_8));
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlPublishWithTtl.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlPublishWithTtl.java
@@ -29,8 +29,8 @@ public class LearnJetStreamMessageTtlPublishWithTtl {
             Headers headers = new Headers();
             headers.add("Nats-TTL", "60s");
 
-            PublishAck ack = js.publish("orders.cancelled", headers,
-                    "order 4242 cancelled".getBytes(StandardCharsets.UTF_8));
+            PublishAck ack = js.publish("orders.canceled", headers,
+                    "order 4242 canceled".getBytes(StandardCharsets.UTF_8));
 
             System.out.println("Stored in stream: " + ack.getStream());
             System.out.println("At sequence: " + ack.getSeqno());

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlPublishWithTtl.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlPublishWithTtl.java
@@ -1,0 +1,43 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+import io.nats.client.impl.Headers;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamMessageTtlPublishWithTtl {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // The stream must allow per-message TTLs before any Nats-TTL header is
+            // honored. AllowMsgTTL is set once, when the stream is created.
+            StreamConfiguration sc = StreamConfiguration.builder()
+                    .name("ORDERS")
+                    .subjects("orders.>")
+                    .allowMessageTtl()
+                    .build();
+            jsm.addStream(sc);
+
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Attach a per-message TTL with the Nats-TTL header. The server keeps
+            // this message for 60 seconds after it is stored, then deletes it.
+            Headers headers = new Headers();
+            headers.add("Nats-TTL", "60s");
+
+            PublishAck ack = js.publish("orders.cancelled", headers,
+                    "order 4242 cancelled".getBytes(StandardCharsets.UTF_8));
+
+            System.out.println("Stored in stream: " + ack.getStream());
+            System.out.println("At sequence: " + ack.getSeqno());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlTtlOnDisabledStream.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlTtlOnDisabledStream.java
@@ -1,0 +1,47 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+import io.nats.client.impl.Headers;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamMessageTtlTtlOnDisabledStream {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // This throwaway stream never enabled AllowMsgTTL, so it rejects any
+            // per-message TTL header.
+            StreamConfiguration sc = StreamConfiguration.builder()
+                    .name("ORDERS_NO_TTL")
+                    .subjects("no-ttl.>")
+                    .build();
+            jsm.addStream(sc);
+
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Publishing a Nats-TTL header to a stream without AllowMsgTTL is
+            // rejected by the server, and nothing is stored.
+            Headers headers = new Headers();
+            headers.add("Nats-TTL", "60s");
+
+            try {
+                js.publish("no-ttl.cancelled", headers,
+                        "order 4242 cancelled".getBytes(StandardCharsets.UTF_8));
+            }
+            catch (JetStreamApiException e) {
+                // Error 10166: "per-message TTL is disabled". Enabling
+                // AllowMsgTTL on the stream is the fix.
+                System.out.println("Publish rejected [" + e.getApiErrorCode() + "]: "
+                        + e.getErrorDescription());
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlTtlOnDisabledStream.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMessageTtlTtlOnDisabledStream.java
@@ -29,8 +29,8 @@ public class LearnJetStreamMessageTtlTtlOnDisabledStream {
             headers.add("Nats-TTL", "60s");
 
             try {
-                js.publish("no-ttl.cancelled", headers,
-                        "order 4242 cancelled".getBytes(StandardCharsets.UTF_8));
+                js.publish("no-ttl.canceled", headers,
+                        "order 4242 canceled".getBytes(StandardCharsets.UTF_8));
             }
             catch (JetStreamApiException e) {
                 // Error 10166: "per-message TTL is disabled". Enabling

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMirrorsAndSourcesCreateMirror.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMirrorsAndSourcesCreateMirror.java
@@ -1,0 +1,30 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamMirrorsAndSourcesCreateMirror {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            // NATS-DOC-START
+            // Create ORDERS-ARCHIVE as a read-only mirror of ORDERS. A mirror
+            // takes no subjects of its own; it follows the upstream stream.
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            StreamInfo streamInfo = jsm.addStream(StreamConfiguration.builder()
+                    .name("ORDERS-ARCHIVE")
+                    .mirror(Mirror.builder().sourceName("ORDERS").build())
+                    .storageType(StorageType.File)
+                .build());
+
+            // Confirm: the new stream mirrors ORDERS
+            StreamConfiguration config = streamInfo.getConfiguration();
+            System.out.println("Created mirror " + config.getName()
+                    + " of " + config.getMirror().getSourceName());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMirrorsAndSourcesCreateSource.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMirrorsAndSourcesCreateSource.java
@@ -1,0 +1,39 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamMirrorsAndSourcesCreateSource {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // Setup: the three regional streams ALL-ORDERS aggregates.
+            jsm.addStream(StreamConfiguration.builder().name("ORDERS-US").subjects("us.orders.>").storageType(StorageType.File).build());
+            jsm.addStream(StreamConfiguration.builder().name("ORDERS-EU").subjects("eu.orders.>").storageType(StorageType.File).build());
+            jsm.addStream(StreamConfiguration.builder().name("ORDERS-APAC").subjects("apac.orders.>").storageType(StorageType.File).build());
+
+            // NATS-DOC-START
+            // Create ALL-ORDERS as an aggregate that sources the three regional
+            // streams into one. Unlike a mirror, a stream can list several sources.
+            StreamInfo streamInfo = jsm.addStream(StreamConfiguration.builder()
+                    .name("ALL-ORDERS")
+                    .sources(
+                        Source.builder().sourceName("ORDERS-US").build(),
+                        Source.builder().sourceName("ORDERS-EU").build(),
+                        Source.builder().sourceName("ORDERS-APAC").build())
+                    .storageType(StorageType.File)
+                .build());
+
+            // Confirm: the aggregate lists three sources
+            StreamConfiguration config = streamInfo.getConfiguration();
+            System.out.println("Created " + config.getName()
+                    + " sourcing " + config.getSources().size() + " streams");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMirrorsAndSourcesMirrorLag.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamMirrorsAndSourcesMirrorLag.java
@@ -1,0 +1,27 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamMirrorsAndSourcesMirrorLag {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // NATS-DOC-START
+            // A mirror is eventually consistent. Read its lag before trusting
+            // it to hold what the upstream just received: 0 means caught up.
+            StreamInfo streamInfo = jsm.getStreamInfo("ORDERS-ARCHIVE");
+            MirrorInfo mirror = streamInfo.getMirrorInfo();
+
+            System.out.println("Upstream:  " + mirror.getName());
+            System.out.println("Lag:       " + mirror.getLag());
+            System.out.println("Last seen: " + mirror.getActive());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamOrderedConsumerRead.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamOrderedConsumerRead.java
@@ -1,0 +1,37 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnJetStreamOrderedConsumerRead {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Ask for an ordered consumer over the stream. There's no ack to
+            // send: the library runs the consumer for you and recreates it if it
+            // ever misses a message, so you read every order in stream order.
+            // DeliverPolicy.All starts from the first order.
+            OrderedConsumerContext occ = sc.createOrderedConsumer(
+                new OrderedConsumerConfiguration().deliverPolicy(DeliverPolicy.All));
+
+            // Read the whole log once, in order, stopping when caught up.
+            Message m;
+            while ((m = occ.next(Duration.ofSeconds(5))) != null) {
+                System.out.println("order " + new String(m.getData(), StandardCharsets.UTF_8));
+                if (m.metaData().pendingCount() == 0) {
+                    break;
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingConfirmStored.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingConfirmStored.java
@@ -1,0 +1,27 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPublishingConfirmStored {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Publish one order; the returned ack confirms it was stored
+            PublishAck ack = js.publish("orders.created",
+                "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\",\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}".getBytes(StandardCharsets.UTF_8));
+
+            // A non-null ack means the server persisted the message
+            System.out.printf("Confirmed stored in %s at sequence %d%n", ack.getStream(), ack.getSeqno());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingDedup.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingDedup.java
@@ -1,0 +1,35 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPublishingDedup {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStream js = nc.jetStream();
+
+            byte[] body = "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\",\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}".getBytes(StandardCharsets.UTF_8);
+
+            // NATS-DOC-START
+            // Tag the message with a stable id so a retry is deduplicated
+            PublishOptions options = PublishOptions.builder()
+                .messageId("ord_8w2k-created")
+                .build();
+
+            // First publish stores the message
+            PublishAck first = js.publish("orders.created", body, options);
+            System.out.printf("First:  seq=%d duplicate=%b%n", first.getSeqno(), first.isDuplicate());
+
+            // Re-publishing the same id returns the original sequence, marked duplicate
+            PublishAck second = js.publish("orders.created", body, options);
+            System.out.printf("Second: seq=%d duplicate=%b%n", second.getSeqno(), second.isDuplicate());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingPubAck.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingPubAck.java
@@ -1,0 +1,28 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPublishingPubAck {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Publish one order and print every field of the ack
+            PublishAck ack = js.publish("orders.created",
+                "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\",\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}".getBytes(StandardCharsets.UTF_8));
+
+            System.out.println("Stream:    " + ack.getStream());
+            System.out.println("Sequence:  " + ack.getSeqno());
+            System.out.println("Duplicate: " + ack.isDuplicate());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingSync.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPublishingSync.java
@@ -1,0 +1,33 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPublishingSync {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Publish three orders to the "ORDERS" stream and read each ack
+            PublishAck ack1 = js.publish("orders.created",
+                "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\",\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:22Z\"}".getBytes(StandardCharsets.UTF_8));
+            System.out.printf("Stored in %s at sequence %d%n", ack1.getStream(), ack1.getSeqno());
+
+            PublishAck ack2 = js.publish("orders.created",
+                "{\"order_id\":\"ord_2zr9\",\"customer\":\"globex\",\"total_cents\":7800,\"ts\":\"2026-05-22T10:14:25Z\"}".getBytes(StandardCharsets.UTF_8));
+            System.out.printf("Stored in %s at sequence %d%n", ack2.getStream(), ack2.getSeqno());
+
+            PublishAck ack3 = js.publish("orders.shipped",
+                "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\",\"total_cents\":4200,\"ts\":\"2026-05-22T10:14:31Z\"}".getBytes(StandardCharsets.UTF_8));
+            System.out.printf("Stored in %s at sequence %d%n", ack3.getStream(), ack3.getSeqno());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPullConsumersConsumeContinuous.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPullConsumersConsumeContinuous.java
@@ -1,0 +1,32 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPullConsumersConsumeContinuous {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // consume() sets up a continuous flow: the library keeps pull
+            // requests open and runs the handler for each order as soon as it
+            // lands in the stream. It runs until you stop it.
+            try (MessageConsumer mc = cc.consume(msg -> {
+                System.out.println("shipping " + new String(msg.getData(), StandardCharsets.UTF_8));
+                msg.ack();
+            })) {
+                // Keep consuming until the process is stopped.
+                Thread.sleep(Long.MAX_VALUE);
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPullConsumersEmptyFetch.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPullConsumersEmptyFetch.java
@@ -1,0 +1,38 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPullConsumersEmptyFetch {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // On a drained consumer the fetch ends with no messages once the
+            // expiry passes, and nextMessage() returns null right away. Treat
+            // that as "nothing right now," not a failure: note it and fetch
+            // again instead of erroring.
+            try (FetchConsumer fc = cc.fetch(
+                    FetchConsumeOptions.builder().maxMessages(10).expiresIn(2000).build())) {
+                Message m = fc.nextMessage();
+                if (m == null) {
+                    System.out.println("no orders waiting, will retry");
+                }
+                while (m != null) {
+                    System.out.println("shipping " + new String(m.getData(), StandardCharsets.UTF_8));
+                    m.ack();
+                    m = fc.nextMessage();
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPullConsumersFetchBatch.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamPullConsumersFetchBatch.java
@@ -1,0 +1,33 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamPullConsumersFetchBatch {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Fetch a batch of up to 10 orders, waiting up to 2 seconds for
+            // them. The fetch ends when the batch is full or the wait elapses,
+            // whichever comes first. Process and ack each, then fetch again.
+            try (FetchConsumer fc = cc.fetch(
+                    FetchConsumeOptions.builder().maxMessages(10).expiresIn(2000).build())) {
+                Message m;
+                while ((m = fc.nextMessage()) != null) {
+                    System.out.println("shipping " + new String(m.getData(), StandardCharsets.UTF_8));
+                    m.ack();
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamReadingBackCreate.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamReadingBackCreate.java
@@ -1,0 +1,29 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamReadingBackCreate {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Create a durable consumer that delivers every stored message.
+            // AckPolicy.Explicit means each message must be acknowledged.
+            ConsumerContext cc = sc.createOrUpdateConsumer(
+                ConsumerConfiguration.builder()
+                    .durable("billing")
+                    .deliverPolicy(DeliverPolicy.All)
+                    .ackPolicy(AckPolicy.Explicit)
+                    .build());
+
+            System.out.println("Created durable consumer: " + cc.getConsumerName());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamReadingBackRead.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamReadingBackRead.java
@@ -1,0 +1,42 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamReadingBackRead {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("billing");
+
+            // NATS-DOC-START
+            // Ask the consumer how many messages are still waiting, then fetch
+            // exactly that many so the loop ends without guessing a count.
+            long pending = cc.getConsumerInfo().getNumPending();
+            if (pending == 0) {
+                System.out.println("Nothing to read.");
+                return;
+            }
+
+            try (FetchConsumer fc = cc.fetch(
+                    FetchConsumeOptions.builder().maxMessages((int) pending).build())) {
+                Message m;
+                while ((m = fc.nextMessage()) != null) {
+                    System.out.printf("stream_seq=%d consumer_seq=%d data=%s%n",
+                        m.metaData().streamSequence(),
+                        m.metaData().consumerSequence(),
+                        new String(m.getData(), StandardCharsets.UTF_8));
+                    // Acknowledge each message so the server advances the consumer.
+                    m.ack();
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamRetentionPoliciesRetentionSwitchRejected.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamRetentionPoliciesRetentionSwitchRejected.java
@@ -1,0 +1,45 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamRetentionPoliciesRetentionSwitchRejected {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // Make sure the FULFILLMENT WorkQueue stream exists.
+            try {
+                jsm.getStreamInfo("FULFILLMENT");
+            }
+            catch (JetStreamApiException notFound) {
+                jsm.addStream(StreamConfiguration.builder()
+                    .name("FULFILLMENT")
+                    .subjects("fulfill.>")
+                    .retentionPolicy(RetentionPolicy.WorkQueue)
+                    .build());
+            }
+
+            // NATS-DOC-START
+            // You can't change a stream's retention policy after it's created.
+            // Switching FULFILLMENT from WorkQueue to Limits is rejected; to change
+            // retention you would delete the stream and recreate it.
+            try {
+                jsm.updateStream(StreamConfiguration.builder()
+                    .name("FULFILLMENT")
+                    .subjects("fulfill.>")
+                    .retentionPolicy(RetentionPolicy.Limits)
+                    .build());
+            }
+            catch (JetStreamApiException e) {
+                System.out.println("Rejected: " + e.getMessage());
+                // stream configuration update can not change retention policy to/from workqueue [10052]
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamRetentionPoliciesWorkQueueCreate.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamRetentionPoliciesWorkQueueCreate.java
@@ -1,0 +1,56 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamRetentionPoliciesWorkQueueCreate {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStream js = nc.jetStream();
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // NATS-DOC-START
+            // FULFILLMENT is the queue of paid orders awaiting shipment, separate
+            // from the ORDERS record stream. WorkQueue retention delivers each task
+            // to one consumer; the first ack removes it, so the stream drains to empty.
+            StreamInfo info = jsm.addStream(StreamConfiguration.builder()
+                .name("FULFILLMENT")
+                .subjects("fulfill.>")
+                .retentionPolicy(RetentionPolicy.WorkQueue)
+                .build());
+
+            System.out.println("Retention policy: " + info.getConfiguration().getRetentionPolicy());
+
+            // Queue one paid order for a US shipper to pick up.
+            js.publish("fulfill.us",
+                "{\"order_id\":\"ord_8w2k\",\"customer\":\"acme-co\"}".getBytes(StandardCharsets.UTF_8));
+
+            // A durable pull consumer with explicit ack: a shipping worker must
+            // acknowledge each task once it has handled the order.
+            jsm.addOrUpdateConsumer("FULFILLMENT", ConsumerConfiguration.builder()
+                .durable("shippers")
+                .ackPolicy(AckPolicy.Explicit)
+                .build());
+
+            // Fetch one task and ack it, as a shipping worker would.
+            ConsumerContext shippers = js.getConsumerContext("FULFILLMENT", "shippers");
+            try (FetchConsumer fc = shippers.fetchMessages(1)) {
+                Message task = fc.nextMessage();
+                System.out.println("Shipping: " + new String(task.getData(), StandardCharsets.UTF_8));
+                task.ack();
+            }
+
+            // The ack removed the task, so the WorkQueue stream is now empty.
+            // A Limits stream like ORDERS would still hold the message.
+            long count = jsm.getStreamInfo("FULFILLMENT").getStreamState().getMsgCount();
+            System.out.println("Messages remaining in FULFILLMENT: " + count);
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamRetentionPoliciesWorkqueueOverlap.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamRetentionPoliciesWorkqueueOverlap.java
@@ -1,0 +1,68 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamRetentionPoliciesWorkqueueOverlap {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // Make sure the FULFILLMENT WorkQueue stream exists.
+            try {
+                jsm.getStreamInfo("FULFILLMENT");
+            }
+            catch (JetStreamApiException notFound) {
+                jsm.addStream(StreamConfiguration.builder()
+                    .name("FULFILLMENT")
+                    .subjects("fulfill.>")
+                    .retentionPolicy(RetentionPolicy.WorkQueue)
+                    .build());
+            }
+
+            // NATS-DOC-START
+            // One unfiltered consumer on a WorkQueue stream is fine: it owns every
+            // subject, so each task still has exactly one owner.
+            jsm.addOrUpdateConsumer("FULFILLMENT", ConsumerConfiguration.builder()
+                .durable("shippers")
+                .ackPolicy(AckPolicy.Explicit)
+                .build());
+            System.out.println("Added consumer: shippers");
+
+            // A second unfiltered consumer would let two workers claim the same
+            // task, so the WorkQueue stream rejects it.
+            try {
+                jsm.addOrUpdateConsumer("FULFILLMENT", ConsumerConfiguration.builder()
+                    .durable("eu-shippers")
+                    .ackPolicy(AckPolicy.Explicit)
+                    .build());
+            }
+            catch (JetStreamApiException e) {
+                System.out.println("Rejected: " + e.getMessage());
+                // multiple non-filtered consumers not allowed on workqueue stream [10099]
+            }
+
+            // To split the work, drop the catch-all consumer...
+            jsm.deleteConsumer("FULFILLMENT", "shippers");
+
+            // ...and give each region its own subject filter. The filters don't
+            // overlap, so every task still maps to exactly one consumer.
+            jsm.addOrUpdateConsumer("FULFILLMENT", ConsumerConfiguration.builder()
+                .durable("us-shippers")
+                .filterSubject("fulfill.us")
+                .ackPolicy(AckPolicy.Explicit)
+                .build());
+            jsm.addOrUpdateConsumer("FULFILLMENT", ConsumerConfiguration.builder()
+                .durable("eu-shippers")
+                .filterSubject("fulfill.eu")
+                .ackPolicy(AckPolicy.Explicit)
+                .build());
+            System.out.println("Added filtered consumers: us-shippers (fulfill.us), eu-shippers (fulfill.eu)");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamShapingTheStreamDiscardNew.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamShapingTheStreamDiscardNew.java
@@ -1,0 +1,45 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamShapingTheStreamDiscardNew {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            JetStream js = nc.jetStream();
+
+            // NATS-DOC-START
+            // Switch ORDERS to Discard New. Discard New never drops stored
+            // messages, so capping it at one message leaves the existing orders
+            // in place and puts the stream instantly over its limit; the next
+            // publish is rejected.
+            StreamInfo si = jsm.getStreamInfo("ORDERS");
+            jsm.updateStream(StreamConfiguration.builder(si.getConfiguration())
+                .discardPolicy(DiscardPolicy.New)
+                .maxMessages(1)
+                .build());
+
+            // This publish hits the full stream and is rejected instead of
+            // succeeding silently. Handle it in the publisher.
+            try {
+                js.publish("orders.created", "{\"order_id\":\"ord_8w2k\"}".getBytes());
+            }
+            catch (JetStreamApiException e) {
+                System.out.println("publish rejected: " + e.getMessage());
+            }
+
+            // Put ORDERS back: Discard Old, no message cap (age and byte limits
+            // stay).
+            jsm.updateStream(StreamConfiguration.builder(si.getConfiguration())
+                .discardPolicy(DiscardPolicy.Old)
+                .maxMessages(-1)
+                .build());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamShapingTheStreamPerSubjectLimit.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamShapingTheStreamPerSubjectLimit.java
@@ -1,0 +1,29 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamShapingTheStreamPerSubjectLimit {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // NATS-DOC-START
+            // Add a per-subject ceiling so one noisy subject can't evict
+            // another's messages. maxMessagesPerSubject keeps the most recent N
+            // messages for every subject independently, alongside the
+            // whole-stream limits.
+            StreamInfo si = jsm.getStreamInfo("ORDERS");
+            StreamConfiguration cfg = StreamConfiguration.builder(si.getConfiguration())
+                .maxMessagesPerSubject(100000)
+                .build();
+            jsm.updateStream(cfg);
+            System.out.println("ORDERS now keeps 100000 messages per subject");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamShapingTheStreamSetLimits.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamShapingTheStreamSetLimits.java
@@ -1,0 +1,31 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.time.Duration;
+
+public class LearnJetStreamShapingTheStreamSetLimits {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // NATS-DOC-START
+            // Cap ORDERS with a seven-day age limit and a 1 GiB byte ceiling.
+            // Build from the current config so other fields, and the stored
+            // messages, are left in place, then update the stream.
+            StreamInfo si = jsm.getStreamInfo("ORDERS");
+            StreamConfiguration cfg = StreamConfiguration.builder(si.getConfiguration())
+                .maxAge(Duration.ofDays(7))
+                .maxBytes(1L << 30) // 1 GiB
+                .build();
+            jsm.updateStream(cfg);
+            System.out.println("ORDERS capped at 7d age and 1 GiB");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamSubjectMappingRepublish.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamSubjectMappingRepublish.java
@@ -1,0 +1,36 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamSubjectMappingRepublish {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // Read the current configuration so the update keeps every other setting.
+            StreamConfiguration current = jsm.getStreamInfo("ORDERS").getConfiguration();
+
+            // NATS-DOC-START
+            // Republish every message ORDERS stores onto a parallel subject that
+            // ordinary core subscribers can watch, without them touching the stream.
+            Republish rp = Republish.builder()
+                    .source("orders.>")
+                    .destination("dash.orders.>")
+                    // .headersOnly(true) // republish only the headers, not the body
+                    .build();
+
+            StreamConfiguration updated = StreamConfiguration.builder(current)
+                    .republish(rp)
+                    .build();
+            StreamInfo info = jsm.updateStream(updated);
+
+            System.out.println("Republish destination: " + info.getConfiguration().getRepublish().getDestination());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamSubjectMappingTransform.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamSubjectMappingTransform.java
@@ -1,0 +1,35 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamSubjectMappingTransform {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // NATS-DOC-START
+            // Rewrite each ingested subject as it lands in the stream. The template
+            // shards each customer into one of three buckets: partition(3,1) hashes
+            // the first wildcard token into 0, 1 or 2, and wildcard(1) keeps that
+            // same token as the trailing part of the stored subject.
+            SubjectTransform st = new SubjectTransform(
+                    "ingest.*",
+                    "orders.{{partition(3,1)}}.{{wildcard(1)}}");
+
+            StreamConfiguration sc = StreamConfiguration.builder()
+                    .name("ORDERS-SHARDED")
+                    .subjects("ingest.*")
+                    .subjectTransform(st)
+                    .build();
+            StreamInfo info = jsm.addStream(sc);
+
+            System.out.println("Created stream: " + info.getConfiguration().getName());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamWorkerPoolMaxPending.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamWorkerPoolMaxPending.java
@@ -1,0 +1,32 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamWorkerPoolMaxPending {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Raise MaxAckPending so a larger pool can hold more orders in
+            // progress at once. The cap is shared across the whole "shipping"
+            // consumer, not per worker, so size it to at least your worker count.
+            // createOrUpdateConsumer updates the existing consumer in place.
+            sc.createOrUpdateConsumer(
+                ConsumerConfiguration.builder()
+                    .durable("shipping")
+                    .deliverPolicy(DeliverPolicy.All)
+                    .ackPolicy(AckPolicy.Explicit)
+                    .maxAckPending(5000)
+                    .build());
+
+            System.out.println("shipping MaxAckPending set to 5000");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamWorkerPoolRedeliveryCount.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamWorkerPoolRedeliveryCount.java
@@ -1,0 +1,42 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamWorkerPoolRedeliveryCount {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Each message reports how many times it has been delivered. A count
+            // above one means a redelivery: the server handed this order out
+            // before, but a worker crashed or ran past AckWait before acking.
+            // Key your side effects by order_id so handling the same order twice
+            // is harmless.
+            try (FetchConsumer fc = cc.fetch(
+                    FetchConsumeOptions.builder().maxMessages(10).build())) {
+                Message m;
+                while ((m = fc.nextMessage()) != null) {
+                    long delivered = m.metaData().deliveredCount();
+                    String data = new String(m.getData(), StandardCharsets.UTF_8);
+                    if (delivered > 1) {
+                        System.out.printf("redelivery #%d of %s%n", delivered, data);
+                    } else {
+                        System.out.printf("first delivery of %s%n", data);
+                    }
+                    // Acknowledge so the server advances the consumer.
+                    m.ack();
+                }
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamWorkerPoolWorker.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamWorkerPoolWorker.java
@@ -1,0 +1,33 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+import java.nio.charset.StandardCharsets;
+
+public class LearnJetStreamWorkerPoolWorker {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // consume() runs the handler for every order the server hands this
+            // worker. Run this same program in several processes: they all share
+            // the one "shipping" consumer, and the server splits the stored
+            // orders across them, one order to one worker.
+            try (MessageConsumer mc = cc.consume(msg -> {
+                System.out.println("shipping " + new String(msg.getData(), StandardCharsets.UTF_8));
+                msg.ack();
+            })) {
+                // Keep this worker running until the process is stopped.
+                Thread.sleep(Long.MAX_VALUE);
+            }
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerCreate.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerCreate.java
@@ -1,0 +1,29 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamYourFirstConsumerCreate {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+
+            // NATS-DOC-START
+            // Create a durable pull consumer that delivers every stored message.
+            // AckPolicy.Explicit means each message must be acknowledged.
+            ConsumerContext cc = sc.createOrUpdateConsumer(
+                ConsumerConfiguration.builder()
+                    .durable("shipping")
+                    .deliverPolicy(DeliverPolicy.All)
+                    .ackPolicy(AckPolicy.Explicit)
+                    .build());
+
+            System.out.println("Created durable consumer: " + cc.getConsumerName());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerDoubleAck.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerDoubleAck.java
@@ -1,0 +1,37 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnJetStreamYourFirstConsumerDoubleAck {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Pull one message and acknowledge it with a confirmed ack.
+            // ackSync waits for the server to confirm the ack was stored, so
+            // you know the consumer advanced before moving on.
+            Message m = cc.next(Duration.ofSeconds(5));
+            if (m == null) {
+                System.out.println("Nothing to read.");
+                return;
+            }
+
+            System.out.printf("subject=%s data=%s%n",
+                m.getSubject(),
+                new String(m.getData(), StandardCharsets.UTF_8));
+
+            m.ackSync(Duration.ofSeconds(1));
+            System.out.println("Ack confirmed by server.");
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerNext.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerNext.java
@@ -1,0 +1,35 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnJetStreamYourFirstConsumerNext {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Pull one message but do not acknowledge it. Because there is no
+            // ack, the message stays in flight and the server redelivers it
+            // after the consumer's Ack Wait window expires.
+            Message m = cc.next(Duration.ofSeconds(5));
+            if (m == null) {
+                System.out.println("Nothing to read.");
+                return;
+            }
+
+            System.out.printf("subject=%s data=%s%n",
+                m.getSubject(),
+                new String(m.getData(), StandardCharsets.UTF_8));
+            // No m.ack() — the message is redelivered after Ack Wait.
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerPullAndAck.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstConsumerPullAndAck.java
@@ -1,0 +1,35 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+public class LearnJetStreamYourFirstConsumerPullAndAck {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            StreamContext sc = nc.getStreamContext("ORDERS");
+            ConsumerContext cc = sc.getConsumerContext("shipping");
+
+            // NATS-DOC-START
+            // Pull one message, process it, then acknowledge so the server
+            // advances the consumer and never redelivers this message.
+            Message m = cc.next(Duration.ofSeconds(5));
+            if (m == null) {
+                System.out.println("Nothing to read.");
+                return;
+            }
+
+            System.out.printf("subject=%s data=%s%n",
+                m.getSubject(),
+                new String(m.getData(), StandardCharsets.UTF_8));
+
+            m.ack();
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstStreamCreate.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstStreamCreate.java
@@ -1,0 +1,27 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamYourFirstStreamCreate {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            // NATS-DOC-START
+            // Create a stream named "ORDERS" that captures any subject under `orders.`
+            JetStreamManagement jsm = nc.jetStreamManagement();
+            StreamInfo streamInfo = jsm.addStream(StreamConfiguration.builder()
+                    .name("ORDERS")
+                    .subjects("orders.>")
+                    .storageType(StorageType.File)
+                .build());
+
+            // Confirm the stream was created
+            System.out.println("Created stream: " + streamInfo.getConfiguration().getName());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstStreamInfo.java
+++ b/examples/src/main/java/io/nats/examples/natsIoDoc/LearnJetStreamYourFirstStreamInfo.java
@@ -1,0 +1,28 @@
+package io.nats.examples.natsIoDoc;
+
+import io.nats.client.*;
+import io.nats.client.api.*;
+
+public class LearnJetStreamYourFirstStreamInfo {
+    public static void main(String[] args) {
+        try (Connection nc = Nats.connect("nats://localhost:4222")) {
+
+            JetStreamManagement jsm = nc.jetStreamManagement();
+
+            // NATS-DOC-START
+            // Fetch info for the "ORDERS" stream and print key fields
+            StreamInfo streamInfo = jsm.getStreamInfo("ORDERS");
+
+            StreamConfiguration config = streamInfo.getConfiguration();
+            StreamState state = streamInfo.getStreamState();
+
+            System.out.println("Name:     " + config.getName());
+            System.out.println("Subjects: " + config.getSubjects());
+            System.out.println("Messages: " + state.getMsgCount());
+            // NATS-DOC-END
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Moves the documentation examples from the `core-docs` and `jetstream-docs` branches into `examples/src/main/java/io/nats/examples/natsIoDoc/` on main (52 new `Learn*.java` files joining the 19 already here; additive only).

Why: the new docs.nats.io build fetches these snippets at build time. On side branches they get zero CI (no workflow triggers on them); on main the `examples` subproject's `compileJava` covers them on every PR/push automatically — no gradle or workflow changes needed.

Note: please keep the docs branches until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)