### PR TITLE
Address forceReconnectImpl reader/writer stop race

### DIFF
--- a/src/main/java/io/nats/client/impl/NatsConnection.java
+++ b/src/main/java/io/nats/client/impl/NatsConnection.java
@@ -350,6 +350,13 @@ class NatsConnection implements Connection {
         try {
             updateStatus(Status.DISCONNECTED);
 
+            // Stop the reader and writer BEFORE the port is closed below. stop(false) sets running=false
+            // without shutdownInput, so when the close unblocks a socket-blocked read the reader treats
+            // the resulting IOException as an expected shutdown rather than a communication issue that
+            // would spawn another reconnect. Capture the stopped-futures so we can join them below.
+            Future<Boolean> readerStopped = reader.isRunning() ? reader.stop(false) : null;
+            Future<Boolean> writerStopped = writer.isRunning() ? writer.stop() : null;
+
             // Close and reset the current data port and future
             if (dataPortFuture != null) {
                 dataPortFuture.cancel(true);
@@ -375,15 +382,29 @@ class NatsConnection implements Connection {
                 });
             }
 
-            // stop i/o
+            // Join the reader and writer with the full connection timeout, NOT a fixed 100ms. The port
+            // close above is what actually unblocks a socket-blocked reader, and it runs asynchronously,
+            // so a 100ms budget can expire before the reader thread has terminated. That matters because
+            // stop(false) has already cleared running, so the downstream reconnect (tryToConnect) re-joins
+            // the reader only when reader.isRunning() - now false - and will NOT wait for it. A reader
+            // still alive at that point can later throw, see running flipped back true by the new reader's
+            // start(), call handleCommunicationIssue on the now-healthy connection, and stomp the shared
+            // running flag. Waiting the real budget here guarantees the old threads are dead before their
+            // reader/writer instances are reused. In the common case the close lands in well under a
+            // millisecond and these joins return immediately, so no latency is added to a normal failover.
+            long timeoutNanos = options.getConnectionTimeout().toNanos();
             try {
-                this.reader.stop(false).get(100, TimeUnit.MILLISECONDS);
+                if (readerStopped != null) {
+                    readerStopped.get(timeoutNanos, TimeUnit.NANOSECONDS);
+                }
             }
             catch (Exception ex) {
                 processException(ex);
             }
             try {
-                this.writer.stop().get(100, TimeUnit.MILLISECONDS);
+                if (writerStopped != null) {
+                    writerStopped.get(timeoutNanos, TimeUnit.NANOSECONDS);
+                }
             }
             catch (Exception ex) {
                 processException(ex);


### PR DESCRIPTION
forceReconnectImpl tears the socket down with reader.stop(false) + an async port close + a 100 ms join, then proceeds to reconnectImpl() regardless of whether that join succeeded. Three facts combine into a race:

reader.stop(false) sets running=false but does NOT shutdownInput() — the reader thread stays blocked in dataPort.read(...); only the port close wakes it, and that runs on another thread.
The stopped future completes only when run() actually returns, so the .get(100ms) is really "wait up to 100 ms for the reader thread to die" — and on a busy executor / TLS socket it can miss.
tryToConnect re-joins the reader only if (reader.isRunning()) (V3: core/.../NatsConnection.java:516), which is now false — so it does NOT wait for a still-alive reader before calling reader.start(...) on the same instance.
A reader that outlives the 100 ms window can then, once the async close finally unblocks it: throw IOException, see running flipped back true by the new start(), call handleCommunicationIssue on the now-healthy connection (spurious full reconnect), and — via its finally { running.set(false) } — stomp the shared flag the freshly started reader loops on. Timing-dependent, worse under executor pressure and TLS. See the audit for the full trace.